### PR TITLE
fix: GitHub Pages 불필요 파일 노출 차단

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,8 +9,15 @@ exclude:
   - mcp-servers
   - specs
   - .specify
+  - .claude
+  - .omc
   - tests
   - scripts
   - templates
+  - docs
+  - CLAUDE.md
+  - README.md
+  - "02_honeymoon_plan.md"
+  - pyproject.toml
   - "*.py"
   - Makefile


### PR DESCRIPTION
## Summary
- _config.yml exclude 목록에 CLAUDE.md, README.md, docs/, .claude/, .omc/ 등 추가
- trips/ 디렉토리만 GitHub Pages에 노출되도록 제한

## Test plan
- [ ] GitHub Pages 빌드 후 trips/ 외 파일이 사이트에 노출되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)