### PR TITLE
fix: GitHub Pages 네비게이션 정리

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@ title: "Travel Planner"
 description: "여행 일정 플래너 — AI 기반 검색·추천·생성"
 baseurl: "/travel-planner"
 url: "https://idean3885.github.io"
+header_pages: []
 include:
   - trips
 exclude:


### PR DESCRIPTION
## Summary
- header_pages: [] 로 네비게이션에 trips 파일 나열 차단
- 랜딩 페이지(index.md)만 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)