### PR TITLE
fix: Agoda/Booking.com 링크 추가 및 API 성능 개선

### DIFF
--- a/mcp-servers/hotels_mcp_server/hotels_mcp/api_client.py
+++ b/mcp-servers/hotels_mcp_server/hotels_mcp/api_client.py
@@ -12,6 +12,17 @@ logger = logging.getLogger("travel-mcp-server")
 RAPIDAPI_KEY = os.getenv("RAPIDAPI_KEY")
 RAPIDAPI_HOST = os.getenv("RAPIDAPI_HOST", "booking-com15.p.rapidapi.com")
 
+# Shared client for connection reuse (connection pooling)
+_client: Optional[httpx.AsyncClient] = None
+
+
+def get_client() -> httpx.AsyncClient:
+    """Get or create a shared httpx client for connection reuse."""
+    global _client
+    if _client is None or _client.is_closed:
+        _client = httpx.AsyncClient(timeout=30.0)
+    return _client
+
 
 async def make_rapidapi_request(endpoint: str, params: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
     """Make a request to the RapidAPI with proper error handling."""
@@ -23,12 +34,12 @@ async def make_rapidapi_request(endpoint: str, params: Optional[Dict[str, str]] 
     }
 
     logger.info(f"Making API request to {endpoint} with params: {params}")
-    async with httpx.AsyncClient() as client:
-        try:
-            response = await client.get(url, headers=headers, params=params, timeout=30.0)
-            response.raise_for_status()
-            logger.info(f"API request to {endpoint} successful")
-            return response.json()
-        except Exception as e:
-            logger.error(f"API request to {endpoint} failed: {str(e)}")
-            return {"error": str(e)}
+    client = get_client()
+    try:
+        response = await client.get(url, headers=headers, params=params)
+        response.raise_for_status()
+        logger.info(f"API request to {endpoint} successful")
+        return response.json()
+    except Exception as e:
+        logger.error(f"API request to {endpoint} failed: {str(e)}")
+        return {"error": str(e)}

--- a/mcp-servers/hotels_mcp_server/hotels_mcp/hotels_server.py
+++ b/mcp-servers/hotels_mcp_server/hotels_mcp/hotels_server.py
@@ -5,9 +5,26 @@ import signal
 import sys
 import argparse
 from typing import Dict, List, Any, Optional
+from urllib.parse import quote_plus
 from mcp.server.fastmcp import FastMCP
 
 from hotels_mcp.api_client import make_rapidapi_request, RAPIDAPI_KEY, RAPIDAPI_HOST
+
+
+def _booking_links(hotel_name: str, checkin_date: str, checkout_date: str, adults: int = 2) -> str:
+    """Generate Booking.com and Agoda search links with dates."""
+    encoded_name = quote_plus(hotel_name)
+    booking_url = (
+        f"https://www.booking.com/searchresults.html"
+        f"?ss={encoded_name}&checkin={checkin_date}&checkout={checkout_date}"
+        f"&group_adults={adults}"
+    )
+    agoda_url = (
+        f"https://www.agoda.com/search"
+        f"?q={encoded_name}&checkIn={checkin_date}&checkOut={checkout_date}"
+        f"&adults={adults}"
+    )
+    return f"Booking.com: {booking_url}\nAgoda: {agoda_url}\n"
 
 # Configure logging
 logging.basicConfig(
@@ -162,7 +179,12 @@ async def get_hotels(destination_id: str, checkin_date: str, checkout_date: str,
                 if checkin and checkout:
                     hotel_info += f"Check-in: {checkin.get('fromTime', 'N/A')}-{checkin.get('untilTime', 'N/A')}\n"
                     hotel_info += f"Check-out: by {checkout.get('untilTime', 'N/A')}\n"
-                
+
+                # Add booking links with dates
+                hotel_name = property_data.get('name', '')
+                if hotel_name:
+                    hotel_info += _booking_links(hotel_name, checkin_date, checkout_date, adults)
+
                 formatted_results.append(hotel_info)
             else:
                 formatted_results.append("Hotel information not available in the expected format.")
@@ -246,6 +268,11 @@ async def get_hotel_details(hotel_id: str, checkin_date: str, checkout_date: str
     desc = data.get("description", "")
     if desc:
         info_parts.append(f"\nDescription: {desc[:500]}")
+
+    # Booking links with dates
+    hotel_name = data.get("hotel_name", "")
+    if hotel_name:
+        info_parts.append(_booking_links(hotel_name, checkin_date, checkout_date, adults))
 
     return "\n".join(info_parts)
 

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -15,7 +15,10 @@ def patch_api_credentials():
         patch.object(api_client_module, "RAPIDAPI_KEY", "test-key-123"),
         patch.object(api_client_module, "RAPIDAPI_HOST", "booking-com15.p.rapidapi.com"),
     ):
+        # Reset shared client before each test so httpx_mock can intercept
+        api_client_module._client = None
         yield
+        api_client_module._client = None
 
 
 class TestMakeRapidapiRequest:
@@ -76,3 +79,23 @@ class TestMakeRapidapiRequest:
         result = await make_rapidapi_request("/api/v1/hotels/searchDestination")
 
         assert "error" not in result
+
+
+class TestConnectionReuse:
+    """API client should reuse connections for performance."""
+
+    def test_module_exposes_shared_client(self):
+        """api_client should have a module-level shared client for connection pooling."""
+        assert hasattr(api_client_module, "get_client"), \
+            "api_client must expose get_client() for connection reuse"
+
+    async def test_consecutive_requests_reuse_client(self, httpx_mock: HTTPXMock):
+        """Two consecutive requests should reuse the same underlying client."""
+        httpx_mock.add_response(json={"status": True, "data": []})
+        httpx_mock.add_response(json={"status": True, "data": []})
+
+        await make_rapidapi_request("/api/v1/hotels/searchDestination", {"query": "a"})
+        await make_rapidapi_request("/api/v1/hotels/searchDestination", {"query": "b"})
+
+        # Both requests should have gone through (proves client works for multiple calls)
+        assert len(httpx_mock.get_requests()) == 2

--- a/tests/unit/test_hotels.py
+++ b/tests/unit/test_hotels.py
@@ -3,6 +3,7 @@ import json
 import re
 import pytest
 from pathlib import Path
+from urllib.parse import quote_plus
 
 FIXTURES = Path(__file__).parent.parent / "fixtures"
 
@@ -70,7 +71,7 @@ class TestSearchDestinationsParsing:
 class TestGetHotelsParsing:
     """Replicate the formatting logic from get_hotels()."""
 
-    def _format(self, data: dict) -> str:
+    def _format(self, data: dict, checkin_date: str = "", checkout_date: str = "", adults: int = 2) -> str:
         formatted_results = []
         if "data" in data and "hotels" in data["data"] and isinstance(data["data"]["hotels"], list):
             hotels = data["data"]["hotels"]
@@ -133,6 +134,19 @@ class TestGetHotelsParsing:
                     hotel_info += f"Check-in: {checkin.get('fromTime', 'N/A')}-{checkin.get('untilTime', 'N/A')}\n"
                     hotel_info += f"Check-out: by {checkout.get('untilTime', 'N/A')}\n"
 
+                # Booking links with dates
+                hotel_name = property_data.get('name', '')
+                if hotel_name and checkin_date and checkout_date:
+                    encoded = quote_plus(hotel_name)
+                    hotel_info += (
+                        f"Booking.com: https://www.booking.com/searchresults.html"
+                        f"?ss={encoded}&checkin={checkin_date}&checkout={checkout_date}"
+                        f"&group_adults={adults}\n"
+                        f"Agoda: https://www.agoda.com/search"
+                        f"?q={encoded}&checkIn={checkin_date}&checkOut={checkout_date}"
+                        f"&adults={adults}\n"
+                    )
+
                 formatted_results.append(hotel_info)
 
         return "\n---\n".join(formatted_results) if formatted_results else "No hotels found for this destination and dates."
@@ -185,6 +199,25 @@ class TestGetHotelsParsing:
         result = self._format(data)
         assert "---" in result
 
+    def test_booking_link_with_dates(self):
+        data = load_fixture("hotels_search_hotels.json")
+        result = self._format(data, checkin_date="2026-06-07", checkout_date="2026-06-09")
+        assert "booking.com" in result.lower()
+        assert "2026-06-07" in result
+        assert "2026-06-09" in result
+
+    def test_agoda_link_with_dates(self):
+        data = load_fixture("hotels_search_hotels.json")
+        result = self._format(data, checkin_date="2026-06-07", checkout_date="2026-06-09")
+        assert "agoda.com" in result.lower()
+        assert "2026-06-07" in result
+
+    def test_both_booking_and_agoda_links_present(self):
+        data = load_fixture("hotels_search_hotels.json")
+        result = self._format(data, checkin_date="2026-06-07", checkout_date="2026-06-09")
+        assert "Booking.com" in result
+        assert "Agoda" in result
+
 
 # ---------------------------------------------------------------------------
 # get_hotel_details parsing
@@ -193,7 +226,7 @@ class TestGetHotelsParsing:
 class TestGetHotelDetailsParsing:
     """Replicate the formatting logic from get_hotel_details()."""
 
-    def _format(self, result: dict) -> str:
+    def _format(self, result: dict, checkin_date: str = "", checkout_date: str = "", adults: int = 2) -> str:
         data = result.get("data", {})
         if not data:
             return "No hotel details found."
@@ -236,6 +269,19 @@ class TestGetHotelDetailsParsing:
         desc = data.get("description", "")
         if desc:
             info_parts.append(f"\nDescription: {desc[:500]}")
+
+        # Booking links with dates
+        hotel_name = data.get("hotel_name", "")
+        if hotel_name and checkin_date and checkout_date:
+            encoded = quote_plus(hotel_name)
+            info_parts.append(
+                f"Booking.com: https://www.booking.com/searchresults.html"
+                f"?ss={encoded}&checkin={checkin_date}&checkout={checkout_date}"
+                f"&group_adults={adults}\n"
+                f"Agoda: https://www.agoda.com/search"
+                f"?q={encoded}&checkIn={checkin_date}&checkOut={checkout_date}"
+                f"&adults={adults}\n"
+            )
 
         return "\n".join(info_parts)
 
@@ -296,3 +342,22 @@ class TestGetHotelDetailsParsing:
     def test_empty_data_returns_no_details_message(self):
         result = self._format({"data": {}})
         assert result == "No hotel details found."
+
+    def test_booking_link_with_dates(self):
+        data = load_fixture("hotels_get_details.json")
+        result = self._format(data, checkin_date="2026-06-07", checkout_date="2026-06-09")
+        assert "booking.com" in result.lower()
+        assert "2026-06-07" in result
+        assert "2026-06-09" in result
+
+    def test_agoda_link_with_dates(self):
+        data = load_fixture("hotels_get_details.json")
+        result = self._format(data, checkin_date="2026-06-07", checkout_date="2026-06-09")
+        assert "agoda.com" in result.lower()
+        assert "2026-06-07" in result
+
+    def test_both_booking_and_agoda_links_present(self):
+        data = load_fixture("hotels_get_details.json")
+        result = self._format(data, checkin_date="2026-06-07", checkout_date="2026-06-09")
+        assert "Booking.com" in result
+        assert "Agoda" in result


### PR DESCRIPTION
## Summary
- `get_hotels`, `get_hotel_details` 출력에 **Booking.com + Agoda** 검색 링크 생성
- URL에 checkin/checkout 날짜 및 adults 파라미터 포함 (링크 클릭 시 날짜 자동 반영)
- httpx AsyncClient를 모듈 레벨 공유 클라이언트로 변경하여 **커넥션 풀링** 적용 (속도 개선)

## Test plan
- [x] 기존 47개 테스트 통과 확인
- [x] 신규 8개 테스트 추가 (Booking.com/Agoda 링크 + 날짜 파라미터 + 커넥션 재사용)
- [x] 전체 55개 테스트 통과 (`pytest tests/ -v`)
- [ ] Claude Desktop에서 호텔 검색 후 Booking.com/Agoda 링크 클릭 → 날짜 포함 확인
- [ ] 연속 API 호출 시 응답 속도 개선 체감 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)