### PR TITLE
chore: CLAUDE.md Git 워크플로우 규칙 + 브랜치 보호 강화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,18 @@ travel-planner/
 └── docs/                           # GitHub Pages용 (추후)
 ```
 
+## Git 워크플로우 규칙
+
+### 필수: `/devex:flow` 사용
+- 모든 코드 변경은 반드시 `/devex:flow`를 통해 진행한다
+- main 브랜치에 직접 push 금지 (어드민 포함, `enforce_admins: true`)
+- feature 브랜치 → PR → 리뷰 → 머지 순서를 반드시 따른다
+
+### 브랜치 최신화
+- feature 브랜치 작업 전 반드시 `git pull origin main`으로 최신화
+- PR 생성 전 base 브랜치와 충돌 여부 확인
+- 충돌 발생 시 rebase로 해결 후 PR 생성
+
 ## 작업 규칙
 
 ### 데일리 파일 포맷


### PR DESCRIPTION
## Summary
- CLAUDE.md에 `/devex:flow` 필수 사용, main 직접 push 금지, 브랜치 최신화 규칙 추가
- `enforce_admins: true` 설정 완료 (어드민 바이패스 불가)

## Context
v1.0.2 작업 중 main에 직접 push하여 브랜치 보호 규칙 위반 발생.
재발 방지를 위해 규칙 문서화 + GitHub 설정 강화.

## Test plan
- [ ] main 직접 push 시 거부되는지 확인
- [ ] CLAUDE.md 규칙이 정상 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)