### PR TITLE
fix: 루트 package.json 추가 — AppPaaS 빌드 호환

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "travel-planner",
+  "private": true,
+  "scripts": {
+    "postinstall": "cd web && npm install",
+    "build": "cd web && npm run build",
+    "start": "cd web && npm run start"
+  }
+}


### PR DESCRIPTION
## 작업 내용
AppPaaS가 루트 `package.json`을 요구하므로 추가.

## 변경 사항
- `postinstall`: `cd web && npm install` (web/ 의존성 자동 설치)
- `build`: `cd web && npm run build` (web/ 빌드 위임)

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ✅ 통과 | 로컬 `npm run build` 정상 |
| 테스트 | ⬜ 해당없음 | 설정 파일 추가 |

Closes #49