### PR TITLE
fix: AppPaaS Linux 빌드 호환 — platform-specific 패키지 제거

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,7 +14,6 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "gray-matter": "^4.0.3",
-        "lightningcss-darwin-arm64": "^1.32.0",
         "lucide-react": "^1.7.0",
         "next": "^15.5.14",
         "postcss": "^8.5.8",
@@ -6973,7 +6972,9 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
+      "optional": true,
       "os": [
         "darwin"
       ],

--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,6 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "gray-matter": "^4.0.3",
-    "lightningcss-darwin-arm64": "^1.32.0",
     "lucide-react": "^1.7.0",
     "next": "^15.5.14",
     "postcss": "^8.5.8",


### PR DESCRIPTION
## 작업 내용
`lightningcss-darwin-arm64`가 lockfile에 포함되어 AppPaaS(Linux x64) 빌드 실패. 제거 후 lockfile 재생성.

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ✅ 통과 | 로컬 `npm run build` 정상 |

Closes #49