### PR TITLE
fix: Next.js standalone 모드 — AppPaaS 컨테이너 호환

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
 };
 
 export default nextConfig;


### PR DESCRIPTION
## 작업 내용
빌드 성공 후 컨테이너 이미지 생성 실패 문제 해결.
`output: "standalone"` 설정으로 self-contained 서버 번들 생성.

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ✅ 통과 | `npm run build` 정상 |

Closes #49