### PR TITLE
fix: outputFileTracingRoot + lockfile 정리 — AppPaaS 컨테이너 호환

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  outputFileTracingRoot: path.join(__dirname, ".."),
 };
 
 export default nextConfig;


### PR DESCRIPTION
## 작업 내용
- `outputFileTracingRoot` 설정으로 Next.js workspace root 명시
- `.npmrc`로 루트 lockfile 생성 방지

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ✅ 통과 | multiple lockfile 경고 해소 |

Closes #49