### PR TITLE
feat: GitHub Pages 정적 배포 전환

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,49 @@
+name: GitHub Pages 배포
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/app/**"
+      - "src/lib/**"
+      - "trips/**"
+      - "package.json"
+      - "next.config.ts"
+      - "tailwind.config.ts"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+      - run: npm run build
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: out
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,11 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  output: "export",
+  images: {
+    unoptimized: true,
+  },
+  basePath: "/travel-planner",
+};
 
 export default nextConfig;


### PR DESCRIPTION
## 작업 내용
AppPaaS 컨테이너 빌드 실패로 GitHub Pages 정적 배포로 전환.
현재 모든 페이지가 SSG이므로 서버 불필요. BE 필요 시 AppPaaS로 재전환.

## 변경 사항
- `next.config.ts`: `output: "export"`, `basePath: "/travel-planner"`
- `deploy-pages.yml`: trips/ 또는 src/app/ 변경 시 자동 빌드+배포
- GitHub Pages `build_type`을 `workflow`로 변경 완료

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ✅ 통과 | `out/` 디렉토리에 14일 전체 HTML 생성 |
| 테스트 | ⬜ 해당없음 | 배포 설정 변경 |

Closes #49