### PR TITLE
feat: Phase 2 소셜 로그인 (Auth.js v5 + Google OAuth)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@auth/prisma-adapter": "^2.11.1",
         "@neondatabase/serverless": "^1.0.2",
         "@prisma/adapter-neon": "^7.7.0",
         "@prisma/client": "^7.7.0",
@@ -16,6 +17,7 @@
         "autoprefixer": "^10.4.27",
         "gray-matter": "^4.0.3",
         "next": "^15.5.14",
+        "next-auth": "^5.0.0-beta.30",
         "postcss": "^8.5.8",
         "prisma": "^7.7.0",
         "react": "^19.2.4",
@@ -44,6 +46,47 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@auth/core": {
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.1.tgz",
+      "integrity": "sha512-t9cJ2zNYAdWMacGRMT6+r4xr1uybIdmYa49calBPeTqwgAFPV/88ac9TEvCR85pvATiSPt8VaNf+Gt24JIT/uw==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^7.0.7"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@auth/prisma-adapter": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@auth/prisma-adapter/-/prisma-adapter-2.11.1.tgz",
+      "integrity": "sha512-Ke7DXP0Fy0Mlmjz/ZJLXwQash2UkA4621xCM0rMtEczr1kppLc/njCbUkHkIQ/PnmILjqSPEKeTjDPsYruvkug==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.1"
+      },
+      "peerDependencies": {
+        "@prisma/client": ">=2.26.0 || >=3 || >=4 || >=5 || >=6"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1294,6 +1337,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@prisma/adapter-neon": {
@@ -5371,6 +5423,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6594,6 +6655,62 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "5.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.30.tgz",
+      "integrity": "sha512-+c51gquM3F6nMVmoAusRJ7RIoY0K4Ts9HCCwyy/BRoe4mp3msZpOzYMyb5LAYc1wSo74PMQkGDcaghIO7W6Xjg==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.0"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
+        "nodemailer": "^7.0.7",
+        "react": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-auth/node_modules/@auth/core": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.0.tgz",
+      "integrity": "sha512-Wd7mHPQ/8zy6Qj7f4T46vg3aoor8fskJm6g2Zyj064oQ3+p0xNZXAV60ww0hY+MbTesfu29kK14Zk5d5JTazXQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^6.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -6684,6 +6801,15 @@
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
       "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
       "license": "MIT"
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.5.tgz",
+      "integrity": "sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -7276,6 +7402,25 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": ">=10"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@auth/prisma-adapter": "^2.11.1",
     "@neondatabase/serverless": "^1.0.2",
     "@prisma/adapter-neon": "^7.7.0",
     "@prisma/client": "^7.7.0",
@@ -17,6 +18,7 @@
     "autoprefixer": "^10.4.27",
     "gray-matter": "^4.0.3",
     "next": "^15.5.14",
+    "next-auth": "^5.0.0-beta.30",
     "postcss": "^8.5.8",
     "prisma": "^7.7.0",
     "react": "^19.2.4",

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from "@/auth";
+
+export const { GET, POST } = handlers;

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,0 +1,31 @@
+import { signIn } from "@/auth";
+
+export default function SignInPage() {
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <div className="w-full max-w-sm space-y-6 text-center">
+        <div className="space-y-2">
+          <h1 className="text-heading-lg font-bold text-surface-900">
+            우리의 여행
+          </h1>
+          <p className="text-body-md text-surface-500">
+            로그인하고 여행 일정을 관리하세요
+          </p>
+        </div>
+        <form
+          action={async () => {
+            "use server";
+            await signIn("google", { redirectTo: "/" });
+          }}
+        >
+          <button
+            type="submit"
+            className="w-full rounded-lg bg-surface-900 px-4 py-3 text-body-md font-medium text-white transition-colors hover:bg-surface-700"
+          >
+            Google 계정으로 로그인
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata, Viewport } from "next";
 import { Inter } from "next/font/google";
 import ScrollToTop from "@/components/ScrollToTop";
+import SessionProvider from "@/components/SessionProvider";
+import AuthButton from "@/components/AuthButton";
 import "./globals.css";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -24,10 +26,15 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className={`${inter.className} bg-white text-surface-900 min-h-screen`}>
-        <main className="max-w-content mx-auto w-full px-4 py-6 pb-16">
-          {children}
-        </main>
-        <ScrollToTop />
+        <SessionProvider>
+          <header className="max-w-content mx-auto w-full px-4 pt-4 flex justify-end">
+            <AuthButton />
+          </header>
+          <main className="max-w-content mx-auto w-full px-4 py-6 pb-16">
+            {children}
+          </main>
+          <ScrollToTop />
+        </SessionProvider>
       </body>
     </html>
   );

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -1,0 +1,9 @@
+import Google from "next-auth/providers/google";
+import type { NextAuthConfig } from "next-auth";
+
+export default {
+  providers: [Google],
+  pages: {
+    signIn: "/auth/signin",
+  },
+} satisfies NextAuthConfig;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,10 @@
+import NextAuth from "next-auth";
+import { PrismaAdapter } from "@auth/prisma-adapter";
+import { prisma } from "@/lib/prisma";
+import authConfig from "./auth.config";
+
+export const { handlers, auth, signIn, signOut } = NextAuth({
+  adapter: PrismaAdapter(prisma),
+  session: { strategy: "jwt" },
+  ...authConfig,
+});

--- a/src/components/AuthButton.tsx
+++ b/src/components/AuthButton.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useSession, signOut } from "next-auth/react";
+
+export default function AuthButton() {
+  const { data: session } = useSession();
+
+  if (!session?.user) return null;
+
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-body-sm text-surface-500">
+        {session.user.name}
+      </span>
+      <button
+        onClick={() => signOut()}
+        className="rounded-md px-3 py-1.5 text-body-sm text-surface-500 transition-colors hover:bg-surface-100 hover:text-surface-700"
+      >
+        로그아웃
+      </button>
+    </div>
+  );
+}

--- a/src/components/SessionProvider.tsx
+++ b/src/components/SessionProvider.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { SessionProvider as NextAuthSessionProvider } from "next-auth/react";
+
+export default function SessionProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <NextAuthSessionProvider>{children}</NextAuthSessionProvider>;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,25 @@
+import NextAuth from "next-auth";
+import authConfig from "./auth.config";
+
+const { auth } = NextAuth(authConfig);
+
+export default auth((req) => {
+  const isLoggedIn = !!req.auth;
+  const isAuthRoute = req.nextUrl.pathname.startsWith("/auth");
+  const isApiAuthRoute = req.nextUrl.pathname.startsWith("/api/auth");
+
+  // Auth API 라우트는 항상 허용
+  if (isApiAuthRoute) return;
+
+  // 로그인 페이지는 항상 허용
+  if (isAuthRoute) return;
+
+  // 비로그인 사용자 → 로그인 페이지로 리다이렉트
+  if (!isLoggedIn) {
+    return Response.redirect(new URL("/auth/signin", req.nextUrl));
+  }
+});
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};


### PR DESCRIPTION
## Summary

- Auth.js v5 + Google OAuth2 소셜 로그인
- 비로그인 사용자 /auth/signin으로 리다이렉트 (보호 라우트)
- SessionProvider + AuthButton으로 세션 상태 표시

## Checklist (#76)

- [x] T011 Auth.js 의존성 설치
- [x] T012 auth.config.ts (Edge 호환)
- [x] T013 auth.ts (PrismaAdapter + JWT)
- [x] T014 API 핸들러
- [x] T015 middleware.ts 보호 라우트
- [x] T016 Google OAuth + Vercel 환경변수
- [x] T017 로그인 페이지
- [x] T018 AuthButton 컴포넌트
- [x] T019 세션 프로바이더 적용
- [ ] T020 QS1 검증 (프리뷰 배포에서)

## Test plan

- [ ] 프리뷰 URL 접속 → /auth/signin 리다이렉트 확인
- [ ] Google 로그인 → 메인 페이지 표시 확인
- [ ] 로그아웃 버튼 동작 확인

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)