### PR TITLE
fix: 달력 날짜 타임존 무관 표시 (Timestamptz(3) 유지)

### DIFF
--- a/scripts/migrate-markdown.ts
+++ b/scripts/migrate-markdown.ts
@@ -168,9 +168,9 @@ function parseOverview(content: string) {
     const endMonth = parseInt(periodMatch[4]) - 1;
     const endDay = parseInt(periodMatch[5]);
 
-    // KST 정오 → UTC 변환 (타임존 밀림 방지)
-    startDate = new Date(Date.UTC(year, startMonth, startDay, 3, 0, 0));
-    endDate = new Date(Date.UTC(year, endMonth, endDay, 3, 0, 0));
+    // UTC 자정으로 저장. 표시 시 UTC 기준 날짜 추출 → 타임존 무관
+    startDate = new Date(Date.UTC(year, startMonth, startDay, 0, 0, 0));
+    endDate = new Date(Date.UTC(year, endMonth, endDay, 0, 0, 0));
   }
 
   return { title, startDate, endDate };
@@ -201,8 +201,8 @@ function parseDayFile(filename: string, tripStartDate: Date | null) {
   // 연도는 tripStartDate에서 가져옴
   const year = tripStartDate ? tripStartDate.getFullYear() : new Date().getFullYear();
 
-  // KST 정오(12:00)를 UTC로 → 타임존 밀림 방지
-  const dateUtc = new Date(Date.UTC(year, month, day, 3, 0, 0)); // KST 12:00 = UTC 03:00
+  // UTC 자정으로 저장. 표시 시 UTC 기준 날짜 추출 → 타임존 무관
+  const dateUtc = new Date(Date.UTC(year, month, day, 0, 0, 0));
 
   return {
     date: dateUtc,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";
+import { formatCalendarDateFull } from "@/lib/date-utils";
 
 export default async function Home() {
   const session = await auth();
@@ -44,8 +45,8 @@ export default async function Home() {
           <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm text-surface-500">
             {trip.startDate && trip.endDate && (
               <span>
-                {trip.startDate.toLocaleDateString("ko-KR")} ~{" "}
-                {trip.endDate.toLocaleDateString("ko-KR")}
+                {formatCalendarDateFull(trip.startDate)} ~{" "}
+                {formatCalendarDateFull(trip.endDate)}
               </span>
             )}
             <span>{trip._count.days}일</span>

--- a/src/app/trips/[id]/day/[dayId]/page.tsx
+++ b/src/app/trips/[id]/day/[dayId]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
+import { formatCalendarDateLong } from "@/lib/date-utils";
 import { remark } from "remark";
 import remarkGfm from "remark-gfm";
 import html from "remark-html";
@@ -64,12 +65,7 @@ export default async function DayDetailPage({
           {day.title && ` — ${day.title}`}
         </h1>
         <p className="mt-1 text-body-md text-surface-500">
-          {day.date.toLocaleDateString("ko-KR", {
-            year: "numeric",
-            month: "long",
-            day: "numeric",
-            weekday: "long",
-          })}
+          {formatCalendarDateLong(day.date)}
         </p>
       </div>
 

--- a/src/app/trips/[id]/page.tsx
+++ b/src/app/trips/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
+import { formatCalendarDateFull, formatCalendarDate } from "@/lib/date-utils";
 import { remark } from "remark";
 import remarkGfm from "remark-gfm";
 import html from "remark-html";
@@ -58,8 +59,8 @@ export default async function TripDetailPage({
         <h1 className="text-heading-lg font-bold">{trip.title}</h1>
         {trip.startDate && trip.endDate && (
           <p className="mt-1 text-body-md text-surface-500">
-            {trip.startDate.toLocaleDateString("ko-KR")} ~{" "}
-            {trip.endDate.toLocaleDateString("ko-KR")}
+            {formatCalendarDateFull(trip.startDate)} ~{" "}
+            {formatCalendarDateFull(trip.endDate)}
           </p>
         )}
       </div>
@@ -96,11 +97,7 @@ export default async function TripDetailPage({
                 )}
               </div>
               <span className="text-body-sm text-surface-400">
-                {day.date.toLocaleDateString("ko-KR", {
-                  month: "numeric",
-                  day: "numeric",
-                  weekday: "short",
-                })}
+                {formatCalendarDate(day.date)}
               </span>
             </div>
           </Link>

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -1,0 +1,45 @@
+/**
+ * 달력 날짜 표시 유틸리티
+ *
+ * 여행 일정 날짜(Day.date, Trip.startDate/endDate)는 "6월 7일"이라는 달력 날짜이다.
+ * DB에 UTC 자정(00:00:00Z)으로 저장하고, 표시 시 UTC 기준으로 날짜를 추출한다.
+ * 이렇게 하면 한국에서든 포르투갈에서든 같은 날짜가 표시된다.
+ *
+ * 감사 필드(createdAt, updatedAt 등)는 시점이므로 이 유틸 사용 불필요.
+ */
+
+/**
+ * UTC 자정 기준으로 "M. D. (요일)" 형태를 반환한다.
+ * 예: 2026-06-07T00:00:00Z → "6. 7. (일)"
+ */
+export function formatCalendarDate(date: Date | string): string {
+  const d = typeof date === "string" ? new Date(date) : date;
+  const month = d.getUTCMonth() + 1;
+  const day = d.getUTCDate();
+  const weekday = ["일", "월", "화", "수", "목", "금", "토"][d.getUTCDay()];
+  return `${month}. ${day}. (${weekday})`;
+}
+
+/**
+ * UTC 자정 기준으로 "YYYY. M. D." 형태를 반환한다.
+ * 예: 2026-06-07T00:00:00Z → "2026. 6. 7."
+ */
+export function formatCalendarDateFull(date: Date | string): string {
+  const d = typeof date === "string" ? new Date(date) : date;
+  const year = d.getUTCFullYear();
+  const month = d.getUTCMonth() + 1;
+  const day = d.getUTCDate();
+  return `${year}. ${month}. ${day}.`;
+}
+
+/**
+ * UTC 자정 기준으로 "YYYY년 M월 D일 (요일)" 형태를 반환한다.
+ */
+export function formatCalendarDateLong(date: Date | string): string {
+  const d = typeof date === "string" ? new Date(date) : date;
+  const year = d.getUTCFullYear();
+  const month = d.getUTCMonth() + 1;
+  const day = d.getUTCDate();
+  const weekday = ["일", "월", "화", "수", "목", "금", "토"][d.getUTCDay()];
+  return `${year}년 ${month}월 ${day}일 ${weekday}요일`;
+}


### PR DESCRIPTION
## Summary

- Timestamptz(3) 스펙 유지
- 달력 날짜: UTC 자정 저장 + getUTC 추출 → 어디서든 동일 날짜 표시
- date-utils.ts 유틸리티 추가
- 한국어 제목 + 날짜 보정 재마이그레이션

🤖 Generated with [Claude Code](https://claude.com/claude-code)