### PR TITLE
feat: Phase 4 팀 기능 (OWNER/HOST/GUEST 권한 + 초대/관리) (#78)

### DIFF
--- a/prisma/migrations/20260414053446_add_owner_role/migration.sql
+++ b/prisma/migrations/20260414053446_add_owner_role/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "TripRole" ADD VALUE 'OWNER';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -107,6 +107,7 @@ model Day {
 }
 
 enum TripRole {
+  OWNER
   HOST
   GUEST
 }

--- a/src/app/api/trips/[id]/days/[dayId]/route.ts
+++ b/src/app/api/trips/[id]/days/[dayId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getSession, getTripMember } from "@/lib/auth-helpers";
+import { getSession, canEdit } from "@/lib/auth-helpers";
 
 type Params = { params: Promise<{ id: string; dayId: string }> };
 
@@ -13,9 +13,8 @@ export async function PUT(request: Request, { params }: Params) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const member = await getTripMember(tripId, session.user.id);
-  if (!member) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  if (!(await canEdit(tripId, session.user.id))) {
+    return NextResponse.json({ error: "편집 권한이 없습니다" }, { status: 403 });
   }
 
   const body = await request.json();
@@ -43,9 +42,8 @@ export async function DELETE(request: Request, { params }: Params) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const member = await getTripMember(tripId, session.user.id);
-  if (!member) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  if (!(await canEdit(tripId, session.user.id))) {
+    return NextResponse.json({ error: "편집 권한이 없습니다" }, { status: 403 });
   }
 
   await prisma.day.delete({

--- a/src/app/api/trips/[id]/days/route.ts
+++ b/src/app/api/trips/[id]/days/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getSession, getTripMember } from "@/lib/auth-helpers";
+import { getSession, getTripMember, canEdit } from "@/lib/auth-helpers";
 
 type Params = { params: Promise<{ id: string }> };
 
@@ -35,9 +35,8 @@ export async function POST(request: Request, { params }: Params) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const member = await getTripMember(tripId, session.user.id);
-  if (!member) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  if (!(await canEdit(tripId, session.user.id))) {
+    return NextResponse.json({ error: "편집 권한이 없습니다" }, { status: 403 });
   }
 
   const body = await request.json();

--- a/src/app/api/trips/[id]/invitations/route.ts
+++ b/src/app/api/trips/[id]/invitations/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getSession, isHost } from "@/lib/auth-helpers";
+import crypto from "crypto";
+
+type Params = { params: Promise<{ id: string }> };
+
+// T041: 초대 목록 조회
+export async function GET(request: Request, { params }: Params) {
+  const { id } = await params;
+  const tripId = parseInt(id);
+  const session = await getSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!(await isHost(tripId, session.user.id))) {
+    return NextResponse.json({ error: "호스트만 초대를 관리할 수 있습니다" }, { status: 403 });
+  }
+
+  const invitations = await prisma.invitation.findMany({
+    where: { tripId },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return NextResponse.json(invitations);
+}
+
+// T038: 초대 링크 생성
+export async function POST(request: Request, { params }: Params) {
+  const { id } = await params;
+  const tripId = parseInt(id);
+  const session = await getSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!(await isHost(tripId, session.user.id))) {
+    return NextResponse.json({ error: "호스트만 초대할 수 있습니다" }, { status: 403 });
+  }
+
+  const body = await request.json();
+  const { email, role } = body;
+
+  if (!email) {
+    return NextResponse.json({ error: "이메일은 필수입니다" }, { status: 400 });
+  }
+
+  if (role && !["HOST", "GUEST"].includes(role)) {
+    return NextResponse.json({ error: "역할은 HOST 또는 GUEST만 가능합니다" }, { status: 400 });
+  }
+
+  // 기존 대기 중 초대 만료 처리
+  await prisma.invitation.updateMany({
+    where: { tripId, email, status: "PENDING" },
+    data: { status: "EXPIRED" },
+  });
+
+  const token = crypto.randomBytes(32).toString("hex");
+  const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // 7일
+
+  const invitation = await prisma.invitation.create({
+    data: {
+      tripId,
+      invitedById: session.user.id,
+      email,
+      token,
+      role: role || "GUEST",
+      expiresAt,
+    },
+  });
+
+  return NextResponse.json(
+    {
+      ...invitation,
+      inviteUrl: `${process.env.NEXTAUTH_URL || ""}/invite/${token}`,
+    },
+    { status: 201 }
+  );
+}

--- a/src/app/api/trips/[id]/leave/route.ts
+++ b/src/app/api/trips/[id]/leave/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getSession, getTripMember } from "@/lib/auth-helpers";
+
+type Params = { params: Promise<{ id: string }> };
+
+// T046: 자발적 탈퇴
+export async function POST(request: Request, { params }: Params) {
+  const { id } = await params;
+  const tripId = parseInt(id);
+  const session = await getSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const member = await getTripMember(tripId, session.user.id);
+  if (!member) {
+    return NextResponse.json({ error: "멤버가 아닙니다" }, { status: 400 });
+  }
+
+  // 주인은 양도 후 탈퇴
+  if (member.role === "OWNER") {
+    return NextResponse.json(
+      { error: "주인은 다른 호스트에게 양도한 후 탈퇴할 수 있습니다" },
+      { status: 400 }
+    );
+  }
+
+  await prisma.tripMember.delete({ where: { id: member.id } });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/trips/[id]/members/route.ts
+++ b/src/app/api/trips/[id]/members/route.ts
@@ -1,0 +1,113 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getSession, getTripMember, isHost, isOwner } from "@/lib/auth-helpers";
+
+type Params = { params: Promise<{ id: string }> };
+
+// T042: 멤버 목록
+export async function GET(request: Request, { params }: Params) {
+  const { id } = await params;
+  const tripId = parseInt(id);
+  const session = await getSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const member = await getTripMember(tripId, session.user.id);
+  if (!member) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const members = await prisma.tripMember.findMany({
+    where: { tripId },
+    include: { user: { select: { id: true, name: true, email: true, image: true } } },
+    orderBy: [{ role: "asc" }, { joinedAt: "asc" }],
+  });
+
+  return NextResponse.json({ members, myRole: member.role });
+}
+
+// T043~T044: 역할 변경 (승격/강등)
+export async function PATCH(request: Request, { params }: Params) {
+  const { id } = await params;
+  const tripId = parseInt(id);
+  const session = await getSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { memberId, action } = body; // action: "promote" | "demote"
+
+  if (!memberId || !["promote", "demote"].includes(action)) {
+    return NextResponse.json({ error: "잘못된 요청입니다" }, { status: 400 });
+  }
+
+  const target = await prisma.tripMember.findUnique({ where: { id: memberId } });
+  if (!target || target.tripId !== tripId) {
+    return NextResponse.json({ error: "멤버를 찾을 수 없습니다" }, { status: 404 });
+  }
+
+  if (action === "promote") {
+    // 게스트 → 호스트: 호스트면 가능
+    if (target.role !== "GUEST") {
+      return NextResponse.json({ error: "게스트만 승격할 수 있습니다" }, { status: 400 });
+    }
+    if (!(await isHost(tripId, session.user.id))) {
+      return NextResponse.json({ error: "호스트만 승격할 수 있습니다" }, { status: 403 });
+    }
+    await prisma.tripMember.update({ where: { id: memberId }, data: { role: "HOST" } });
+  } else {
+    // 호스트 → 게스트: 주인만 가능
+    if (target.role !== "HOST") {
+      return NextResponse.json({ error: "호스트만 강등할 수 있습니다" }, { status: 400 });
+    }
+    if (!(await isOwner(tripId, session.user.id))) {
+      return NextResponse.json({ error: "주인만 강등할 수 있습니다" }, { status: 403 });
+    }
+    await prisma.tripMember.update({ where: { id: memberId }, data: { role: "GUEST" } });
+  }
+
+  return NextResponse.json({ ok: true });
+}
+
+// T045: 멤버 제거
+export async function DELETE(request: Request, { params }: Params) {
+  const { id } = await params;
+  const tripId = parseInt(id);
+  const session = await getSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const memberId = parseInt(searchParams.get("memberId") || "");
+
+  if (isNaN(memberId)) {
+    return NextResponse.json({ error: "memberId가 필요합니다" }, { status: 400 });
+  }
+
+  const target = await prisma.tripMember.findUnique({ where: { id: memberId } });
+  if (!target || target.tripId !== tripId) {
+    return NextResponse.json({ error: "멤버를 찾을 수 없습니다" }, { status: 404 });
+  }
+
+  // 주인은 제거 불가 (양도 후 탈퇴)
+  if (target.role === "OWNER") {
+    return NextResponse.json({ error: "주인은 제거할 수 없습니다. 먼저 양도하세요" }, { status: 400 });
+  }
+
+  // 호스트 제거는 주인만
+  if (target.role === "HOST" && !(await isOwner(tripId, session.user.id))) {
+    return NextResponse.json({ error: "주인만 호스트를 제거할 수 있습니다" }, { status: 403 });
+  }
+
+  // 게스트 제거는 호스트면 가능
+  if (target.role === "GUEST" && !(await isHost(tripId, session.user.id))) {
+    return NextResponse.json({ error: "호스트만 게스트를 제거할 수 있습니다" }, { status: 403 });
+  }
+
+  await prisma.tripMember.delete({ where: { id: memberId } });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/trips/[id]/route.ts
+++ b/src/app/api/trips/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getSession, getTripMember, isHost } from "@/lib/auth-helpers";
+import { getSession, getTripMember, canEdit, isOwner } from "@/lib/auth-helpers";
 
 type Params = { params: Promise<{ id: string }> };
 
@@ -44,9 +44,8 @@ export async function PUT(request: Request, { params }: Params) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const member = await getTripMember(tripId, session.user.id);
-  if (!member) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  if (!(await canEdit(tripId, session.user.id))) {
+    return NextResponse.json({ error: "편집 권한이 없습니다" }, { status: 403 });
   }
 
   const body = await request.json();
@@ -75,8 +74,8 @@ export async function DELETE(request: Request, { params }: Params) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  if (!(await isHost(tripId, session.user.id))) {
-    return NextResponse.json({ error: "호스트만 삭제할 수 있습니다" }, { status: 403 });
+  if (!(await isOwner(tripId, session.user.id))) {
+    return NextResponse.json({ error: "주인만 삭제할 수 있습니다" }, { status: 403 });
   }
 
   await prisma.trip.delete({ where: { id: tripId } });

--- a/src/app/api/trips/[id]/transfer/route.ts
+++ b/src/app/api/trips/[id]/transfer/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getSession, isOwner } from "@/lib/auth-helpers";
+
+type Params = { params: Promise<{ id: string }> };
+
+// T047: 주인 양도
+export async function POST(request: Request, { params }: Params) {
+  const { id } = await params;
+  const tripId = parseInt(id);
+  const session = await getSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!(await isOwner(tripId, session.user.id))) {
+    return NextResponse.json({ error: "주인만 양도할 수 있습니다" }, { status: 403 });
+  }
+
+  const body = await request.json();
+  const { targetMemberId } = body;
+
+  const target = await prisma.tripMember.findUnique({ where: { id: targetMemberId } });
+  if (!target || target.tripId !== tripId) {
+    return NextResponse.json({ error: "멤버를 찾을 수 없습니다" }, { status: 404 });
+  }
+
+  if (target.role !== "HOST") {
+    return NextResponse.json({ error: "호스트에게만 양도할 수 있습니다" }, { status: 400 });
+  }
+
+  // 트랜잭션: 대상 → OWNER, 기존 주인 → HOST
+  const currentOwner = await prisma.tripMember.findFirst({
+    where: { tripId, userId: session.user.id, role: "OWNER" },
+  });
+
+  if (!currentOwner) {
+    return NextResponse.json({ error: "주인 정보를 찾을 수 없습니다" }, { status: 500 });
+  }
+
+  await prisma.$transaction([
+    prisma.tripMember.update({ where: { id: target.id }, data: { role: "OWNER" } }),
+    prisma.tripMember.update({ where: { id: currentOwner.id }, data: { role: "HOST" } }),
+  ]);
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -1,0 +1,88 @@
+import { redirect } from "next/navigation";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+
+export default async function InvitePage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+  const session = await auth();
+
+  // 비로그인 → 로그인 후 돌아오기
+  if (!session?.user?.id) {
+    redirect(`/auth/signin?callbackUrl=/invite/${token}`);
+  }
+
+  // 초대 조회
+  const invitation = await prisma.invitation.findUnique({
+    where: { token },
+    include: { trip: { select: { id: true, title: true } } },
+  });
+
+  if (!invitation) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center space-y-2">
+          <h1 className="text-heading-lg font-bold text-surface-900">초대를 찾을 수 없습니다</h1>
+          <p className="text-body-md text-surface-500">링크가 잘못되었거나 만료되었습니다.</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (invitation.status !== "PENDING") {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center space-y-2">
+          <h1 className="text-heading-lg font-bold text-surface-900">이미 처리된 초대입니다</h1>
+          <p className="text-body-md text-surface-500">
+            {invitation.status === "ACCEPTED" ? "이미 수락된 초대입니다." : "만료된 초대입니다."}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (new Date() > invitation.expiresAt) {
+    await prisma.invitation.update({
+      where: { id: invitation.id },
+      data: { status: "EXPIRED" },
+    });
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center space-y-2">
+          <h1 className="text-heading-lg font-bold text-surface-900">초대가 만료되었습니다</h1>
+          <p className="text-body-md text-surface-500">호스트에게 새 초대를 요청하세요.</p>
+        </div>
+      </div>
+    );
+  }
+
+  // 이미 멤버인지 확인
+  const existing = await prisma.tripMember.findUnique({
+    where: { tripId_userId: { tripId: invitation.tripId, userId: session.user.id } },
+  });
+
+  if (existing) {
+    redirect(`/trips/${invitation.tripId}`);
+  }
+
+  // 초대 수락: TripMember 생성 + Invitation 상태 변경
+  await prisma.$transaction([
+    prisma.tripMember.create({
+      data: {
+        tripId: invitation.tripId,
+        userId: session.user.id,
+        role: invitation.role,
+      },
+    }),
+    prisma.invitation.update({
+      where: { id: invitation.id },
+      data: { status: "ACCEPTED" },
+    }),
+  ]);
+
+  redirect(`/trips/${invitation.tripId}`);
+}

--- a/src/app/trips/[id]/day/[dayId]/page.tsx
+++ b/src/app/trips/[id]/day/[dayId]/page.tsx
@@ -74,6 +74,7 @@ export default async function DayDetailPage({
         dayId={day.id}
         initialContent={day.content ?? ""}
         initialHtml={contentHtml}
+        canEdit={member.role !== "GUEST"}
       />
     </div>
   );

--- a/src/components/DayEditor.tsx
+++ b/src/components/DayEditor.tsx
@@ -7,6 +7,7 @@ interface DayEditorProps {
   dayId: number;
   initialContent: string;
   initialHtml: string;
+  canEdit: boolean;
 }
 
 export default function DayEditor({
@@ -14,6 +15,7 @@ export default function DayEditor({
   dayId,
   initialContent,
   initialHtml,
+  canEdit: canEditProp,
 }: DayEditorProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [content, setContent] = useState(initialContent);
@@ -77,14 +79,16 @@ export default function DayEditor({
 
   return (
     <div className="space-y-3">
-      <div className="flex justify-end">
-        <button
-          onClick={() => setIsEditing(true)}
-          className="rounded-md px-3 py-1.5 text-body-sm text-surface-500 hover:bg-surface-100 hover:text-surface-700"
-        >
-          편집
-        </button>
-      </div>
+      {canEditProp && (
+        <div className="flex justify-end">
+          <button
+            onClick={() => setIsEditing(true)}
+            className="rounded-md px-3 py-1.5 text-body-sm text-surface-500 hover:bg-surface-100 hover:text-surface-700"
+          >
+            편집
+          </button>
+        </div>
+      )}
       <div
         className="prose prose-sm max-w-none"
         dangerouslySetInnerHTML={{ __html: html }}

--- a/src/lib/auth-helpers.ts
+++ b/src/lib/auth-helpers.ts
@@ -19,9 +19,24 @@ export async function getTripMember(tripId: number, userId: string) {
 }
 
 /**
- * 현재 사용자가 해당 여행의 HOST인지 확인한다.
+ * 현재 사용자가 해당 여행의 주인(OWNER)인지 확인한다.
+ */
+export async function isOwner(tripId: number, userId: string) {
+  const member = await getTripMember(tripId, userId);
+  return member?.role === "OWNER";
+}
+
+/**
+ * 현재 사용자가 해당 여행의 호스트(OWNER 또는 HOST)인지 확인한다.
  */
 export async function isHost(tripId: number, userId: string) {
   const member = await getTripMember(tripId, userId);
-  return member?.role === "HOST";
+  return member?.role === "OWNER" || member?.role === "HOST";
+}
+
+/**
+ * 편집 권한 확인. OWNER 또는 HOST만 편집 가능. GUEST는 불가.
+ */
+export async function canEdit(tripId: number, userId: string) {
+  return isHost(tripId, userId);
 }


### PR DESCRIPTION
## Summary

- OWNER/HOST/GUEST 3단계 권한 모델 구현
- 게스트 읽기 전용 (API + UI)
- 초대 시스템: 토큰 기반, 7일 만료, 링크 복사 전달
- 동행자 관리: 승격/강등/제거/탈퇴/양도 API
- 3단계 권한 검증 (비멤버/게스트/호스트/주인)

## Checklist (#78)

- [x] T035~T036 OWNER 역할 추가 + 데이터 보정
- [x] T037 게스트 읽기 전용
- [x] T038~T041 초대 시스템
- [x] T043~T046 승격/강등/제거/탈퇴
- [x] T047 주인 양도
- [x] T048 여행 삭제 주인 전용
- [x] T049 3단계 권한 검증
- [ ] T042 동행자 관리 UI (다음 이터레이션)
- [ ] T050 QS3 + QS5 검증 (프로덕션 배포 후)

## Test plan

- [ ] 주인으로 로그인 → 모든 기능 사용 가능
- [ ] 초대 링크 생성 → 다른 계정으로 수락 → 멤버 등록
- [ ] 게스트로 접속 → 편집 버튼 미표시 + API 403

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)