### PR TITLE
fix: AuthButton 이메일 메인 표시 + Phase 5 검증 (#79)

### DIFF
--- a/src/components/AuthButton.tsx
+++ b/src/components/AuthButton.tsx
@@ -7,10 +7,12 @@ export default function AuthButton() {
 
   if (!session?.user) return null;
 
+  const displayName = session.user.email || session.user.name || "사용자";
+
   return (
     <div className="flex items-center gap-3">
       <span className="text-body-sm text-surface-500">
-        {session.user.name}
+        {displayName}
       </span>
       <button
         onClick={() => signOut()}


### PR DESCRIPTION
## Summary

- AuthButton: 이름 → 이메일 메인 표시 (동명이인/다중 계정 구분)
- 이메일 미제공 시 이름 폴백 (카카오 등 대비)

## Test plan

- [ ] 로그인 후 우측 상단에 이메일 표시 확인
- [ ] 게스트 계정으로 접속 시 이메일로 계정 구분 가능 확인
- [ ] T054 재검증: 게스트 편집 버튼 미표시

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)