### PR TITLE
fix: 홈 역할 표시 (OWNER→내 여행) + 초대 이메일 소문자 정규화 (#92)

### DIFF
--- a/src/app/api/trips/[id]/invitations/route.ts
+++ b/src/app/api/trips/[id]/invitations/route.ts
@@ -46,13 +46,15 @@ export async function POST(request: Request, { params }: Params) {
     return NextResponse.json({ error: "이메일은 필수입니다" }, { status: 400 });
   }
 
+  const normalizedEmail = email.trim().toLowerCase();
+
   if (role && !["HOST", "GUEST"].includes(role)) {
     return NextResponse.json({ error: "역할은 HOST 또는 GUEST만 가능합니다" }, { status: 400 });
   }
 
   // 기존 대기 중 초대 만료 처리
   await prisma.invitation.updateMany({
-    where: { tripId, email, status: "PENDING" },
+    where: { tripId, email: normalizedEmail, status: "PENDING" },
     data: { status: "EXPIRED" },
   });
 
@@ -63,7 +65,7 @@ export async function POST(request: Request, { params }: Params) {
     data: {
       tripId,
       invitedById: session.user.id,
-      email,
+      email: normalizedEmail,
       token,
       role: role || "GUEST",
       expiresAt,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -51,7 +51,11 @@ export default async function Home() {
             )}
             <span>{trip._count.days}일</span>
             <span className="text-primary-600">
-              {trip.tripMembers[0]?.role === "HOST" ? "호스트" : "게스트"}
+              {trip.tripMembers[0]?.role === "OWNER"
+                ? "내 여행"
+                : trip.tripMembers[0]?.role === "HOST"
+                  ? "호스트"
+                  : "게스트"}
             </span>
           </div>
 


### PR DESCRIPTION
## Summary

- 홈 목록 역할: OWNER→"내 여행", HOST→"호스트", GUEST→"게스트"
- 초대 이메일: `email.trim().toLowerCase()` 정규화

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)