### PR TITLE
fix: PrismaNeon HTTP → PrismaPg TCP 드라이버 전환 (#96)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ trip-planner/
 - Bash (install.sh) + che-ical-mcp (macOS 네이티브 바이너리, GitHub Releases) (002-bundle-ical-mcp)
 - Python 3.10+ (기존 travel_mcp과 동일), Bash (install.sh) + FastMCP, httpx (기존 의존성 재활용) (003-companion-feedback-channel)
 - macOS Keychain (GitHub PAT 저장) (003-companion-feedback-channel)
-- TypeScript 5.x, Node.js 20+ + Next.js 15 (App Router), Auth.js v5 (next-auth@5.x), Prisma, @auth/prisma-adapter, @neondatabase/serverless (004-fullstack-transition)
+- TypeScript 5.x, Node.js 20+ + Next.js 15 (App Router), Auth.js v5 (next-auth@5.x), Prisma 7.x (@prisma/adapter-pg TCP), @auth/prisma-adapter (004-fullstack-transition)
 - Neon Postgres (Vercel Marketplace 통합, 무료 티어 0.5GB) (004-fullstack-transition)
 
 ## Recent Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,14 @@
       "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.1",
-        "@neondatabase/serverless": "^1.0.2",
-        "@prisma/adapter-neon": "^7.7.0",
+        "@prisma/adapter-pg": "^7.7.0",
         "@prisma/client": "^7.7.0",
         "@tailwindcss/typography": "^0.5.19",
         "autoprefixer": "^10.4.27",
         "gray-matter": "^4.0.3",
         "next": "^15.5.14",
         "next-auth": "^5.0.0-beta.30",
+        "pg": "^8.20.0",
         "postcss": "^8.5.8",
         "prisma": "^7.7.0",
         "react": "^19.2.4",
@@ -25,14 +25,13 @@
         "remark": "^15.0.1",
         "remark-gfm": "^4.0.1",
         "remark-html": "^16.0.1",
-        "tailwindcss": "^3.4.19",
-        "ws": "^8.20.0"
+        "tailwindcss": "^3.4.19"
       },
       "devDependencies": {
         "@types/node": "^20.19.39",
+        "@types/pg": "^8.20.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
-        "@types/ws": "^8.18.1",
         "eslint": "^9.39.4",
         "eslint-config-next": "^16.2.2",
         "tsx": "^4.21.0",
@@ -1573,28 +1572,6 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
-    "node_modules/@neondatabase/serverless": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-1.0.2.tgz",
-      "integrity": "sha512-I5sbpSIAHiB+b6UttofhrN/UJXII+4tZPAq1qugzwCwLIL8EZLV7F/JyHUrEIiGgQpEXzpnjlJ+zwcEhheGvCw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^22.15.30",
-        "@types/pg": "^8.8.0"
-      },
-      "engines": {
-        "node": ">=19.0.0"
-      }
-    },
-    "node_modules/@neondatabase/serverless/node_modules/@types/node": {
-      "version": "22.19.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
-      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
     "node_modules/@next/env": {
       "version": "15.5.14",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.14.tgz",
@@ -1793,14 +1770,15 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
-    "node_modules/@prisma/adapter-neon": {
+    "node_modules/@prisma/adapter-pg": {
       "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@prisma/adapter-neon/-/adapter-neon-7.7.0.tgz",
-      "integrity": "sha512-nnQBGUqDBuLDbClSNyZ7T8jv3+wXx9ncA8zaZhVZtP+utq7SdT4azLotTfZjP4hJaP1NXIvCKjp0RfzMq5dyew==",
+      "resolved": "https://registry.npmjs.org/@prisma/adapter-pg/-/adapter-pg-7.7.0.tgz",
+      "integrity": "sha512-q33Ta8sKbgzEpAy0lx45tAq//yMv0qcb+8nj+TCA3P4wiAY+OBFEFk/NDkZncAfHaNJeGo5WJpJdpbL+ijYx8g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@neondatabase/serverless": ">0.6.0 <2",
         "@prisma/driver-adapter-utils": "7.7.0",
+        "@types/pg": "^8.16.0",
+        "pg": "^8.16.3",
         "postgres-array": "3.0.4"
       }
     },
@@ -2294,16 +2272,6 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
-    },
-    "node_modules/@types/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.0",
@@ -7563,6 +7531,46 @@
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -7570,6 +7578,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
@@ -7601,6 +7618,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
       }
     },
     "node_modules/picocolors": {
@@ -8667,6 +8693,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -9690,27 +9725,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.11.1",
-    "@neondatabase/serverless": "^1.0.2",
-    "@prisma/adapter-neon": "^7.7.0",
+    "@prisma/adapter-pg": "^7.7.0",
     "@prisma/client": "^7.7.0",
     "@tailwindcss/typography": "^0.5.19",
     "autoprefixer": "^10.4.27",
     "gray-matter": "^4.0.3",
     "next": "^15.5.14",
     "next-auth": "^5.0.0-beta.30",
+    "pg": "^8.20.0",
     "postcss": "^8.5.8",
     "prisma": "^7.7.0",
     "react": "^19.2.4",
@@ -26,14 +26,13 @@
     "remark": "^15.0.1",
     "remark-gfm": "^4.0.1",
     "remark-html": "^16.0.1",
-    "tailwindcss": "^3.4.19",
-    "ws": "^8.20.0"
+    "tailwindcss": "^3.4.19"
   },
   "devDependencies": {
     "@types/node": "^20.19.39",
+    "@types/pg": "^8.20.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@types/ws": "^8.18.1",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.2",
     "tsx": "^4.21.0",

--- a/scripts/migrate-markdown.ts
+++ b/scripts/migrate-markdown.ts
@@ -7,15 +7,10 @@
  * 전제: 로그인한 사용자(AUTH_USER_EMAIL)가 Trip 생성자 겸 HOST로 등록된다.
  */
 
-import { neonConfig } from "@neondatabase/serverless";
-import { PrismaNeon } from "@prisma/adapter-neon";
+import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@prisma/client";
 import * as fs from "fs";
 import * as path from "path";
-import ws from "ws";
-
-// Node.js 환경에서 WebSocket 폴리필 (Neon 서버리스 드라이버 요구)
-neonConfig.webSocketConstructor = ws;
 
 /** 영어 slug → 한국어 표시명 */
 const CITY_DISPLAY: Record<string, string> = {
@@ -33,10 +28,9 @@ function toKoreanTitle(slug: string): string {
     .join(" · ");
 }
 
-const adapter = new PrismaNeon({
-  connectionString: process.env.DATABASE_URL!,
+const prisma = new PrismaClient({
+  adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL! }),
 });
-const prisma = new PrismaClient({ adapter });
 
 const TRIPS_DIR = path.join(process.cwd(), "trips");
 const AUTH_USER_EMAIL = process.env.AUTH_USER_EMAIL;

--- a/src/app/api/trips/[id]/days/route.ts
+++ b/src/app/api/trips/[id]/days/route.ts
@@ -13,15 +13,17 @@ export async function GET(request: Request, { params }: Params) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const member = await getTripMember(tripId, session.user.id);
+  const [member, days] = await Promise.all([
+    getTripMember(tripId, session.user.id),
+    prisma.day.findMany({
+      where: { tripId },
+      orderBy: { sortOrder: "asc" },
+    }),
+  ]);
+
   if (!member) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
-
-  const days = await prisma.day.findMany({
-    where: { tripId },
-    orderBy: { sortOrder: "asc" },
-  });
 
   return NextResponse.json(days);
 }

--- a/src/app/api/trips/[id]/members/route.ts
+++ b/src/app/api/trips/[id]/members/route.ts
@@ -13,16 +13,18 @@ export async function GET(request: Request, { params }: Params) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const member = await getTripMember(tripId, session.user.id);
+  const [member, members] = await Promise.all([
+    getTripMember(tripId, session.user.id),
+    prisma.tripMember.findMany({
+      where: { tripId },
+      include: { user: { select: { id: true, name: true, email: true, image: true } } },
+      orderBy: [{ role: "asc" }, { joinedAt: "asc" }],
+    }),
+  ]);
+
   if (!member) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
-
-  const members = await prisma.tripMember.findMany({
-    where: { tripId },
-    include: { user: { select: { id: true, name: true, email: true, image: true } } },
-    orderBy: [{ role: "asc" }, { joinedAt: "asc" }],
-  });
 
   return NextResponse.json({ members, myRole: member.role });
 }

--- a/src/app/api/trips/[id]/route.ts
+++ b/src/app/api/trips/[id]/route.ts
@@ -13,21 +13,22 @@ export async function GET(request: Request, { params }: Params) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const member = await getTripMember(tripId, session.user.id);
+  const [member, trip] = await Promise.all([
+    getTripMember(tripId, session.user.id),
+    prisma.trip.findUnique({
+      where: { id: tripId },
+      include: {
+        days: { orderBy: { sortOrder: "asc" } },
+        tripMembers: {
+          include: { user: { select: { id: true, name: true, image: true } } },
+        },
+      },
+    }),
+  ]);
+
   if (!member) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
-
-  const trip = await prisma.trip.findUnique({
-    where: { id: tripId },
-    include: {
-      days: { orderBy: { sortOrder: "asc" } },
-      tripMembers: {
-        include: { user: { select: { id: true, name: true, image: true } } },
-      },
-    },
-  });
-
   if (!trip) {
     return NextResponse.json({ error: "Not Found" }, { status: 404 });
   }

--- a/src/app/trips/[id]/day/[dayId]/page.tsx
+++ b/src/app/trips/[id]/day/[dayId]/page.tsx
@@ -29,16 +29,16 @@ export default async function DayDetailPage({
   const session = await auth();
   if (!session?.user?.id) redirect("/auth/signin");
 
-  const member = await prisma.tripMember.findUnique({
-    where: { tripId_userId: { tripId, userId: session.user.id } },
-  });
-  if (!member) notFound();
-
-  const day = await prisma.day.findUnique({
-    where: { id: dayIdNum, tripId },
-    include: { trip: { select: { title: true } } },
-  });
-  if (!day) notFound();
+  const [member, day] = await Promise.all([
+    prisma.tripMember.findUnique({
+      where: { tripId_userId: { tripId, userId: session.user.id } },
+    }),
+    prisma.day.findUnique({
+      where: { id: dayIdNum, tripId },
+      include: { trip: { select: { title: true } } },
+    }),
+  ]);
+  if (!member || !day) notFound();
 
   const contentHtml = day.content ? await markdownToHtml(day.content) : "";
 

--- a/src/app/trips/[id]/page.tsx
+++ b/src/app/trips/[id]/page.tsx
@@ -28,18 +28,18 @@ export default async function TripDetailPage({
   const session = await auth();
   if (!session?.user?.id) redirect("/auth/signin");
 
-  const member = await prisma.tripMember.findUnique({
-    where: { tripId_userId: { tripId, userId: session.user.id } },
-  });
-  if (!member) notFound();
-
-  const trip = await prisma.trip.findUnique({
-    where: { id: tripId },
-    include: {
-      days: { orderBy: { sortOrder: "asc" } },
-    },
-  });
-  if (!trip) notFound();
+  const [member, trip] = await Promise.all([
+    prisma.tripMember.findUnique({
+      where: { tripId_userId: { tripId, userId: session.user.id } },
+    }),
+    prisma.trip.findUnique({
+      where: { id: tripId },
+      include: {
+        days: { orderBy: { sortOrder: "asc" } },
+      },
+    }),
+  ]);
+  if (!member || !trip) notFound();
 
   const descriptionHtml = trip.description
     ? await markdownToHtml(trip.description)

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,4 +1,4 @@
-import { PrismaNeon } from "@prisma/adapter-neon";
+import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@prisma/client";
 
 const globalForPrisma = globalThis as unknown as {
@@ -8,9 +8,7 @@ const globalForPrisma = globalThis as unknown as {
 export const prisma =
   globalForPrisma.prisma ??
   new PrismaClient({
-    adapter: new PrismaNeon({
-      connectionString: process.env.DATABASE_URL!,
-    }),
+    adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL! }),
   });
 
 if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;


### PR DESCRIPTION
## 작업 내용
모든 요청이 수초 이상 걸리는 치명적 성능 문제 수정.

`PrismaNeon` HTTP 어댑터가 모든 Prisma 쿼리를 Neon HTTP 프록시로 전송하여 쿼리당 50-200ms 오버헤드 발생.
`PrismaPg` TCP 어댑터로 전환하여 표준 PostgreSQL TCP 연결 사용.

## 커밋 내역
| 커밋 | 내용 |
|------|------|
| `fix: PrismaNeon HTTP 어댑터 → PrismaPg TCP 드라이버 전환` | 어댑터 교체 + 순차 쿼리 병렬화 + 의존성 정리 |

## 변경 사항
- `src/lib/prisma.ts` — `PrismaNeon`(HTTP) → `PrismaPg`(TCP) 전환
- `scripts/migrate-markdown.ts` — 동일 어댑터 전환
- 순차 DB 쿼리 병렬화 (`Promise.all`): trip detail, day detail 페이지 + API routes
- 의존성 제거: `@prisma/adapter-neon`, `@neondatabase/serverless`, `ws`, `@types/ws`
- 의존성 추가: `@prisma/adapter-pg`, `pg`, `@types/pg`

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ✅ 통과 | `next build` 성공 |
| 테스트 | ⬜ 해당없음 | 테스트 미구성 |
| 문서 동기화 | ✅ 완료 | CLAUDE.md 기술 스택 갱신 |

Closes #96