### PR TITLE
chore: pg SSL 경고 제거 (#99)

### DIFF
--- a/scripts/migrate-markdown.ts
+++ b/scripts/migrate-markdown.ts
@@ -29,7 +29,10 @@ function toKoreanTitle(slug: string): string {
 }
 
 const prisma = new PrismaClient({
-  adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL! }),
+  adapter: new PrismaPg({
+    connectionString: process.env.DATABASE_URL!,
+    ssl: { rejectUnauthorized: true },
+  }),
 });
 
 const TRIPS_DIR = path.join(process.cwd(), "trips");

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -8,7 +8,10 @@ const globalForPrisma = globalThis as unknown as {
 export const prisma =
   globalForPrisma.prisma ??
   new PrismaClient({
-    adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL! }),
+    adapter: new PrismaPg({
+      connectionString: process.env.DATABASE_URL!,
+      ssl: { rejectUnauthorized: true },
+    }),
   });
 
 if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;


### PR DESCRIPTION
## 작업 내용
Vercel 런타임 로그에 pg 드라이버 SSL 보안 경고 제거.

PrismaPg 어댑터에 `ssl: { rejectUnauthorized: true }` 명시하여 `sslmode=require` → `verify-full` 자동 승격 경고를 제거.

## 변경 사항
- `src/lib/prisma.ts` — SSL 옵션 명시
- `scripts/migrate-markdown.ts` — 동일 적용

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ✅ 통과 | `next build` 성공 |
| 테스트 | ⬜ 해당없음 | |
| 문서 동기화 | ⬜ 해당없음 | |

Closes #99