### PR TITLE
chore: pg SSL 경고 제거 — sslmode=verify-full (#99)

### DIFF
--- a/scripts/migrate-markdown.ts
+++ b/scripts/migrate-markdown.ts
@@ -28,11 +28,12 @@ function toKoreanTitle(slug: string): string {
     .join(" · ");
 }
 
+const connectionString = process.env.DATABASE_URL!.replace(
+  "sslmode=require",
+  "sslmode=verify-full",
+);
 const prisma = new PrismaClient({
-  adapter: new PrismaPg({
-    connectionString: process.env.DATABASE_URL!,
-    ssl: { rejectUnauthorized: true },
-  }),
+  adapter: new PrismaPg({ connectionString }),
 });
 
 const TRIPS_DIR = path.join(process.cwd(), "trips");

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,6 +1,11 @@
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@prisma/client";
 
+const connectionString = process.env.DATABASE_URL!.replace(
+  "sslmode=require",
+  "sslmode=verify-full",
+);
+
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;
 };
@@ -8,10 +13,7 @@ const globalForPrisma = globalThis as unknown as {
 export const prisma =
   globalForPrisma.prisma ??
   new PrismaClient({
-    adapter: new PrismaPg({
-      connectionString: process.env.DATABASE_URL!,
-      ssl: { rejectUnauthorized: true },
-    }),
+    adapter: new PrismaPg({ connectionString }),
   });
 
 if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;


### PR DESCRIPTION
## 작업 내용
pg 드라이버가 `sslmode=require`를 `verify-full`로 자동 승격하면서 발생하는 SSL 경고 제거.

커넥션 스트링에서 `sslmode=require` → `sslmode=verify-full`로 변환하여 명시적으로 설정.

## 변경 사항
- `src/lib/prisma.ts` — connectionString 변환 로직 추가
- `scripts/migrate-markdown.ts` — 동일 적용

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ✅ 통과 | |
| 테스트 | ⬜ 해당없음 | |

Closes #99