### PR TITLE
chore: speckit 하네스 훅 추가

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,35 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .specify/scripts/bash/enforce-speckit.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .specify/scripts/bash/enforce-submit.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .specify/scripts/bash/clear-submit-mark.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ build/
 # Claude Code (로컬 설정)
 .claude/settings.local.json
 
+# Speckit state (검증 마커 등 임시 파일)
+.specify/state/
+
 # OMC state
 .omc/
 node_modules/

--- a/.specify/scripts/bash/clear-submit-mark.sh
+++ b/.specify/scripts/bash/clear-submit-mark.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# clear-submit-mark.sh — PostToolUse hook for Bash(git commit)
+# 커밋 성공 후 서브밋 마커를 삭제하여 다음 커밋 시 재검증을 강제한다.
+
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+# git commit 명령인지 정밀 매칭
+IS_COMMIT=false
+if [[ "$COMMAND" =~ ^[[:space:]]*git[[:space:]]+commit ]]; then
+  IS_COMMIT=true
+elif [[ "$COMMAND" =~ (\&\&|;)[[:space:]]*git[[:space:]]+commit ]]; then
+  IS_COMMIT=true
+fi
+
+if [[ "$IS_COMMIT" == "false" ]]; then
+  exit 0
+fi
+
+# 커밋 성공 여부 확인 (PostToolUse이므로 결과가 있음)
+# exit code가 0이 아닌 경우 마커 유지 (재시도 가능)
+TOOL_RESPONSE=$(echo "$INPUT" | jq -r '.tool_response // empty')
+if echo "$TOOL_RESPONSE" | grep -qi "error\|fatal\|abort"; then
+  exit 0  # 커밋 실패 — 마커 유지
+fi
+
+# 마커 삭제
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
+MARKER="$REPO_ROOT/.specify/state/submit-ready.json"
+
+if [[ -f "$MARKER" ]]; then
+  rm -f "$MARKER"
+fi
+
+exit 0

--- a/.specify/scripts/bash/enforce-speckit.sh
+++ b/.specify/scripts/bash/enforce-speckit.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# enforce-speckit.sh — PreToolUse hook for Edit|Write
+# 소스 파일 편집 시 speckit 산출물(spec.md, plan.md, tasks.md) 존재를 강제한다.
+#
+# 차단 조건:
+#   1. main 브랜치에서 소스 파일 편집 시도 → devex:flow 안내
+#   2. 피처 브랜치에서 speckit 산출물 미완성 시 → 누락된 단계 안내
+#
+# 허용 조건:
+#   - 소스 파일이 아닌 경우 (config, spec, markdown 등)
+#   - 피처 브랜치에서 spec.md + plan.md + tasks.md 모두 존재
+
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+# file_path 없으면 패스 (Write 등에서 다른 필드명 사용 가능)
+if [[ -z "$FILE_PATH" ]]; then
+  exit 0
+fi
+
+# 1) 소스 파일 여부 판단 — 코드 확장자만 대상
+case "$FILE_PATH" in
+  *.ts|*.tsx|*.js|*.jsx|*.py|*.css|*.scss|*.prisma)
+    # 소스 파일 — 이후 검증 진행
+    ;;
+  *)
+    exit 0  # 소스 파일 아님 → 허용
+    ;;
+esac
+
+# 2) speckit/config 경로는 제외
+case "$FILE_PATH" in
+  */.specify/*|*/specs/*|*/.claude/*|*/.omc/*|*/node_modules/*|*/.next/*)
+    exit 0
+    ;;
+esac
+
+# 3) 프로젝트 루트 확인
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+if [[ -z "$REPO_ROOT" ]]; then
+  exit 0  # git 레포 아님 → 패스
+fi
+
+# 프로젝트 외부 파일이면 패스
+case "$FILE_PATH" in
+  "$REPO_ROOT"/*)
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+# 4) 브랜치 확인
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+
+# main/master에서 소스 편집 차단
+if [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
+  echo "BLOCKED: main 브랜치에서 소스 파일 편집은 허용되지 않습니다." >&2
+  echo "→ /devex:flow 로 피처 브랜치를 생성한 후 작업하세요." >&2
+  exit 2
+fi
+
+# 5) 피처 브랜치 패턴 확인 (NNN-*)
+if [[ ! "$BRANCH" =~ ^[0-9]{3}- ]]; then
+  exit 0  # 피처 브랜치 규칙 밖 → 패스 (임시 브랜치 등)
+fi
+
+# 6) speckit 산출물 확인
+PREFIX="${BRANCH:0:3}"
+FEATURE_DIR=$(find "$REPO_ROOT/specs" -maxdepth 1 -name "${PREFIX}-*" -type d 2>/dev/null | head -1)
+
+if [[ -z "$FEATURE_DIR" ]]; then
+  echo "BLOCKED: specs/ 디렉토리에 피처 ${BRANCH}의 스펙이 없습니다." >&2
+  echo "→ /speckit.specify 를 실행하여 스펙을 생성하세요." >&2
+  exit 2
+fi
+
+MISSING=()
+[[ ! -f "$FEATURE_DIR/spec.md" ]]  && MISSING+=("spec.md  → /speckit.specify")
+[[ ! -f "$FEATURE_DIR/plan.md" ]]  && MISSING+=("plan.md  → /speckit.plan")
+[[ ! -f "$FEATURE_DIR/tasks.md" ]] && MISSING+=("tasks.md → /speckit.tasks")
+
+if [[ ${#MISSING[@]} -gt 0 ]]; then
+  echo "BLOCKED: speckit 산출물이 완성되지 않았습니다. (${BRANCH})" >&2
+  for m in "${MISSING[@]}"; do
+    echo "  ✗ $m" >&2
+  done
+  echo "→ 위 단계를 완료한 후 구현을 시작하세요." >&2
+  exit 2
+fi
+
+# 모든 조건 충족 → 허용
+exit 0

--- a/.specify/scripts/bash/enforce-submit.sh
+++ b/.specify/scripts/bash/enforce-submit.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# enforce-submit.sh — PreToolUse hook for Bash
+# git commit 실행 전 검증 마커(submit-ready.json) 존재를 강제한다.
+#
+# 차단 조건:
+#   1. git commit 명령인데 검증 마커가 없거나 브랜치가 불일치
+#
+# 허용 조건:
+#   - git commit이 아닌 다른 Bash 명령
+#   - main 브랜치 (speckit 외 작업 — 설정 파일 등)
+#   - 검증 마커가 존재하고 현재 브랜치와 일치
+
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+# git commit 명령인지 정밀 매칭 (문자열 내 포함 방지)
+# 시작이 "git commit" 이거나 "&& git commit" / "; git commit" 패턴만 매칭
+IS_COMMIT=false
+if [[ "$COMMAND" =~ ^[[:space:]]*git[[:space:]]+commit ]]; then
+  IS_COMMIT=true
+elif [[ "$COMMAND" =~ (\&\&|;)[[:space:]]*git[[:space:]]+commit ]]; then
+  IS_COMMIT=true
+fi
+
+if [[ "$IS_COMMIT" == "false" ]]; then
+  exit 0
+fi
+
+# git merge commit, amend 등은 검증 스킵 (수동 확인 필요)
+if [[ "$COMMAND" == *"--amend"* || "$COMMAND" == *"merge"* ]]; then
+  exit 0
+fi
+
+# 브랜치 확인
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+
+# main에서의 커밋은 speckit-gate가 소스 편집을 이미 차단하므로,
+# 여기서는 config/spec 파일 커밋을 허용
+if [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
+  exit 0
+fi
+
+# 피처 브랜치가 아니면 패스
+if [[ ! "$BRANCH" =~ ^[0-9]{3}- ]]; then
+  exit 0
+fi
+
+# 검증 마커 확인
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
+MARKER="$REPO_ROOT/.specify/state/submit-ready.json"
+
+if [[ ! -f "$MARKER" ]]; then
+  echo "BLOCKED: 서브밋 전 검증이 완료되지 않았습니다." >&2
+  echo "" >&2
+  echo "서브밋 전 필수 게이트:" >&2
+  echo "  1. /speckit.analyze  — 스펙 일관성 검증" >&2
+  echo "  2. /cross-verify:cross-verify  — 교차 검증" >&2
+  echo "  3. bash .specify/scripts/bash/mark-submit-ready.sh  — 검증 마커 생성" >&2
+  echo "" >&2
+  echo "→ 위 단계를 순서대로 실행한 후 다시 커밋하세요." >&2
+  exit 2
+fi
+
+# 마커의 브랜치가 현재 브랜치와 일치하는지 확인
+MARKER_BRANCH=$(jq -r '.branch // empty' "$MARKER" 2>/dev/null)
+if [[ "$MARKER_BRANCH" != "$BRANCH" ]]; then
+  echo "BLOCKED: 검증 마커가 다른 브랜치($MARKER_BRANCH)의 것입니다." >&2
+  echo "→ 현재 브랜치($BRANCH)에서 검증을 다시 실행하세요." >&2
+  exit 2
+fi
+
+# 검증 마커 유효 → 허용
+exit 0

--- a/.specify/scripts/bash/mark-submit-ready.sh
+++ b/.specify/scripts/bash/mark-submit-ready.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# mark-submit-ready.sh — 검증 완료 후 서브밋 마커를 생성한다.
+#
+# 사용법:
+#   bash .specify/scripts/bash/mark-submit-ready.sh [check1] [check2] ...
+#
+# 예시:
+#   bash .specify/scripts/bash/mark-submit-ready.sh speckit-analyze cross-verify
+#
+# 마커 파일: .specify/state/submit-ready.json
+
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+STATE_DIR="$REPO_ROOT/.specify/state"
+MARKER="$STATE_DIR/submit-ready.json"
+
+# 피처 브랜치 확인
+if [[ ! "$BRANCH" =~ ^[0-9]{3}- ]]; then
+  echo "ERROR: 피처 브랜치(NNN-*)에서만 실행 가능합니다. 현재: $BRANCH" >&2
+  exit 1
+fi
+
+# speckit 산출물 존재 확인 (마커 생성 전 최종 확인)
+PREFIX="${BRANCH:0:3}"
+FEATURE_DIR=$(find "$REPO_ROOT/specs" -maxdepth 1 -name "${PREFIX}-*" -type d 2>/dev/null | head -1)
+
+if [[ -z "$FEATURE_DIR" ]]; then
+  echo "ERROR: specs/ 디렉토리에 피처 스펙이 없습니다." >&2
+  exit 1
+fi
+
+for artifact in spec.md plan.md tasks.md; do
+  if [[ ! -f "$FEATURE_DIR/$artifact" ]]; then
+    echo "ERROR: $artifact 가 없습니다. speckit 프로세스를 먼저 완료하세요." >&2
+    exit 1
+  fi
+done
+
+# 검증 항목 수집
+CHECKS=("$@")
+if [[ ${#CHECKS[@]} -eq 0 ]]; then
+  CHECKS=("manual")
+fi
+
+# state 디렉토리 생성
+mkdir -p "$STATE_DIR"
+
+# 마커 생성
+CHECKS_JSON=$(printf '%s\n' "${CHECKS[@]}" | jq -R . | jq -s .)
+jq -cn \
+  --arg branch "$BRANCH" \
+  --arg verified_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg feature_dir "$FEATURE_DIR" \
+  --argjson checks "$CHECKS_JSON" \
+  '{branch:$branch, verified_at:$verified_at, feature_dir:$feature_dir, checks:$checks}' \
+  > "$MARKER"
+
+echo "✓ 서브밋 마커 생성 완료 ($BRANCH)"
+echo "  검증 항목: ${CHECKS[*]}"
+echo "  마커 경로: $MARKER"
+echo ""
+echo "이제 git commit 이 허용됩니다."


### PR DESCRIPTION
## Summary
- speckit-gate 훅: 피처 브랜치에서 `spec.md` + `plan.md` + `tasks.md` 없이 소스 파일(ts/tsx/py/css/prisma) 편집 차단
- submit-gate 훅: 검증 마커 없이 `git commit` 차단 (speckit.analyze + cross-verify 완료 후 마커 생성 필요)
- PostToolUse 훅: 커밋 성공 후 마커 자동 삭제로 매 커밋 재검증 강제
- `.specify/state/` gitignore 추가

## Test plan
- [x] main 브랜치 소스 편집 → BLOCK (exit 2)
- [x] main 브랜치 비소스 파일 편집 → ALLOW (exit 0)
- [x] 피처 브랜치 specs 미존재 → BLOCK
- [x] 피처 브랜치 spec+plan만 → BLOCK (tasks 누락)
- [x] 피처 브랜치 3종 완비 → ALLOW
- [x] 검증 마커 없이 commit → BLOCK
- [x] 마커 생성 후 commit → ALLOW
- [x] false positive 방지 (`echo "git commit"` → ALLOW)

🤖 Generated with [Claude Code](https://claude.com/claude-code)