### PR TITLE
feat(005): US3 install.sh 전면 개편 (v2 PAT + 마이그레이션)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -5,7 +5,8 @@
       "args": ["trip-planner-mcp"],
       "env": {
         "RAPIDAPI_KEY": "${RAPIDAPI_KEY}",
-        "RAPIDAPI_HOST": "booking-com15.p.rapidapi.com"
+        "RAPIDAPI_HOST": "booking-com15.p.rapidapi.com",
+        "TRIP_PLANNER_PAT": "${TRIP_PLANNER_PAT}"
       }
     },
     "che-ical-mcp": {

--- a/manifest.json
+++ b/manifest.json
@@ -20,6 +20,13 @@
       "description": "RapidAPI에서 발급받은 API Key (booking-com15 구독 필요, https://rapidapi.com/DataCrawler/api/booking-com15)",
       "sensitive": true,
       "required": true
+    },
+    "trip_planner_pat": {
+      "type": "string",
+      "title": "Trip Planner PAT",
+      "description": "trip.idean.me 설정 페이지에서 생성한 API 토큰 (일정 관리용)",
+      "sensitive": true,
+      "required": false
     }
   },
   "server": {
@@ -30,7 +37,8 @@
       "args": ["run", "trip-planner-mcp"],
       "env": {
         "RAPIDAPI_KEY": "${user_config.rapidapi_key}",
-        "RAPIDAPI_HOST": "booking-com15.p.rapidapi.com"
+        "RAPIDAPI_HOST": "booking-com15.p.rapidapi.com",
+        "TRIP_PLANNER_PAT": "${user_config.trip_planner_pat}"
       }
     }
   }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# trip-planner MCP server 원클릭 설치 스크립트
+# trip-planner MCP server v2 원클릭 설치 스크립트
 # curl 파이프 실행 지원: curl -sSL https://raw.githubusercontent.com/idean3885/trip-planner/main/scripts/install.sh | bash
 
 REPO_URL="https://github.com/idean3885/trip-planner.git"
 INSTALL_DIR="${HOME}/.trip-planner"
 VENV_DIR="${INSTALL_DIR}/.venv"
 ENV_FILE="${INSTALL_DIR}/.env"
-SRC_DIR="${INSTALL_DIR}/src"
 CLAUDE_CONFIG_DIR="${HOME}/Library/Application Support/Claude"
 CLAUDE_CONFIG_FILE="${CLAUDE_CONFIG_DIR}/claude_desktop_config.json"
 
@@ -21,7 +20,7 @@ NC='\033[0m'
 
 echo ""
 echo "============================================================"
-echo -e "${CYAN}  Travel Planner MCP Server 설치${NC}"
+echo -e "${CYAN}  Trip Planner MCP Server v2 설치${NC}"
 echo "============================================================"
 echo ""
 
@@ -57,12 +56,9 @@ echo "▶ 저장소 설치 중..."
 if [ -d "${INSTALL_DIR}/.git" ]; then
     echo "  이미 설치되어 있습니다. 최신 버전으로 업데이트 중..."
     git -C "${INSTALL_DIR}" pull --ff-only 2>&1 | sed 's/^/  /'
-    # 업데이트 후 패키지 재설치 (새 의존성 반영)
-    NEEDS_REINSTALL=true
     echo -e "  ${GREEN}업데이트 완료${NC}"
 else
     if [ -d "${INSTALL_DIR}" ]; then
-        # git 없이 디렉토리만 있는 경우 제거 후 클론
         rm -rf "${INSTALL_DIR}"
     fi
     git clone "${REPO_URL}" "${INSTALL_DIR}" 2>&1 | sed 's/^/  /'
@@ -83,13 +79,12 @@ fi
 echo ""
 echo "▶ 필요한 패키지 설치 중... (잠시 기다려 주세요)"
 "${VENV_DIR}/bin/pip" install --quiet --upgrade pip
-# editable 모드로 설치 — git pull 시 소스 변경이 즉시 반영됨
 "${VENV_DIR}/bin/pip" install --quiet -e "${INSTALL_DIR}"
 echo -e "  ${GREEN}패키지 설치 완료${NC}"
 
 # ── 5. RapidAPI 키 입력 ───────────────────────────────────────────
 KEYCHAIN_SERVICE="trip-planner"
-KEYCHAIN_ACCOUNT="rapidapi-key"
+KEYCHAIN_RAPIDAPI="rapidapi-key"
 USE_KEYCHAIN=false
 RAPIDAPI_KEY_VALUE=""
 
@@ -97,19 +92,18 @@ echo ""
 
 # 기존 저장소 확인: 키체인 → .env
 if command -v security &>/dev/null; then
-    RAPIDAPI_KEY_VALUE=$(security find-generic-password -s "${KEYCHAIN_SERVICE}" -a "${KEYCHAIN_ACCOUNT}" -w 2>/dev/null || true)
+    RAPIDAPI_KEY_VALUE=$(security find-generic-password -s "${KEYCHAIN_SERVICE}" -a "${KEYCHAIN_RAPIDAPI}" -w 2>/dev/null || true)
     if [ -n "${RAPIDAPI_KEY_VALUE}" ]; then
         USE_KEYCHAIN=true
-        echo -e "  ${GREEN}macOS 키체인에서 API 키를 찾았습니다.${NC}"
+        echo -e "  ${GREEN}macOS 키체인에서 RapidAPI 키를 찾았습니다.${NC}"
     fi
 fi
 
 if [ -z "${RAPIDAPI_KEY_VALUE}" ] && [ -f "${ENV_FILE}" ] && grep -q "^RAPIDAPI_KEY=.\+" "${ENV_FILE}" 2>/dev/null; then
     RAPIDAPI_KEY_VALUE=$(grep '^RAPIDAPI_KEY=' "${ENV_FILE}" | cut -d= -f2-)
-    echo -e "  ${GREEN}.env 파일에서 API 키를 찾았습니다.${NC}"
+    echo -e "  ${GREEN}.env 파일에서 RapidAPI 키를 찾았습니다.${NC}"
 fi
 
-# 키가 없으면 입력받기
 if [ -z "${RAPIDAPI_KEY_VALUE}" ]; then
     echo -e "${YELLOW}▶ RapidAPI 키 설정${NC}"
     echo ""
@@ -121,31 +115,22 @@ if [ -z "${RAPIDAPI_KEY_VALUE}" ]; then
     echo "    3) 'X-RapidAPI-Key' 값을 복사"
     echo ""
 
-    # curl 파이프 실행 시 stdin이 터미널이 아니므로 /dev/tty 사용
-    if [ -t 0 ]; then
-        INPUT_DEV="/dev/stdin"
-    else
-        INPUT_DEV="/dev/tty"
-    fi
+    if [ -t 0 ]; then INPUT_DEV="/dev/stdin"; else INPUT_DEV="/dev/tty"; fi
 
     while true; do
         printf "  RapidAPI 키를 입력하세요: "
         read -r RAPIDAPI_KEY_VALUE < "${INPUT_DEV}"
-        if [ -n "${RAPIDAPI_KEY_VALUE}" ]; then
-            break
-        fi
+        if [ -n "${RAPIDAPI_KEY_VALUE}" ]; then break; fi
         echo -e "  ${RED}키를 입력해야 합니다. 다시 시도해 주세요.${NC}"
     done
 fi
 
-# 저장: 키체인 우선, 실패 시 .env 폴백
+# 저장: 키체인 우선
 if command -v security &>/dev/null; then
-    # 기존 항목 삭제 후 새로 추가 (업데이트 지원)
-    security delete-generic-password -s "${KEYCHAIN_SERVICE}" -a "${KEYCHAIN_ACCOUNT}" &>/dev/null || true
-    if security add-generic-password -s "${KEYCHAIN_SERVICE}" -a "${KEYCHAIN_ACCOUNT}" -w "${RAPIDAPI_KEY_VALUE}" &>/dev/null; then
+    security delete-generic-password -s "${KEYCHAIN_SERVICE}" -a "${KEYCHAIN_RAPIDAPI}" &>/dev/null || true
+    if security add-generic-password -s "${KEYCHAIN_SERVICE}" -a "${KEYCHAIN_RAPIDAPI}" -w "${RAPIDAPI_KEY_VALUE}" &>/dev/null; then
         USE_KEYCHAIN=true
-        echo -e "  ${GREEN}macOS 키체인에 API 키 저장 완료${NC}"
-        # 키체인 사용 시 .env 파일 제거 (보안)
+        echo -e "  ${GREEN}macOS 키체인에 RapidAPI 키 저장 완료${NC}"
         rm -f "${ENV_FILE}"
     else
         echo -e "  ${YELLOW}키체인 저장 실패. .env 파일로 저장합니다.${NC}"
@@ -157,10 +142,55 @@ if [ "${USE_KEYCHAIN}" = false ]; then
 RAPIDAPI_KEY=${RAPIDAPI_KEY_VALUE}
 RAPIDAPI_HOST=booking-com15.p.rapidapi.com
 EOF
-    echo -e "  ${GREEN}.env 파일에 API 키 저장 완료${NC}"
+    echo -e "  ${GREEN}.env 파일에 RapidAPI 키 저장 완료${NC}"
 fi
 
-# ── 6. che-ical-mcp (Apple 캘린더) 설치 ──────────────────────────
+# ── 6. Trip Planner PAT 설정 (일정 관리용) ───────────────────────
+KEYCHAIN_PAT="api-pat"
+PAT_VALUE=""
+PAT_INSTALLED=false
+
+echo ""
+
+# 키체인에서 기존 PAT 확인
+if command -v security &>/dev/null; then
+    PAT_VALUE=$(security find-generic-password -s "${KEYCHAIN_SERVICE}" -a "${KEYCHAIN_PAT}" -w 2>/dev/null || true)
+fi
+
+if [ -n "${PAT_VALUE}" ]; then
+    echo -e "  ${GREEN}macOS 키체인에서 Trip Planner 토큰을 찾았습니다.${NC}"
+    PAT_INSTALLED=true
+else
+    echo -e "${YELLOW}▶ Trip Planner API 토큰 설정 (선택사항)${NC}"
+    echo ""
+    echo "  AI 에이전트로 여행 일정을 직접 수정하려면 API 토큰이 필요합니다."
+    echo "  건너뛰려면 Enter를 누르세요. (검색 기능만 사용 가능)"
+    echo ""
+    echo -e "  ${CYAN}토큰 생성 방법:${NC}"
+    echo "    1) https://trip.idean.me/settings 접속"
+    echo "    2) Google 계정으로 로그인"
+    echo "    3) '토큰 생성' 클릭 후 토큰 복사"
+    echo ""
+
+    if [ -t 0 ]; then INPUT_DEV="/dev/stdin"; else INPUT_DEV="/dev/tty"; fi
+
+    printf "  Trip Planner 토큰을 입력하세요 (Enter로 건너뛰기): "
+    read -r PAT_VALUE < "${INPUT_DEV}"
+
+    if [ -n "${PAT_VALUE}" ]; then
+        security delete-generic-password -s "${KEYCHAIN_SERVICE}" -a "${KEYCHAIN_PAT}" &>/dev/null || true
+        if security add-generic-password -s "${KEYCHAIN_SERVICE}" -a "${KEYCHAIN_PAT}" -w "${PAT_VALUE}" &>/dev/null; then
+            echo -e "  ${GREEN}macOS 키체인에 토큰 저장 완료${NC}"
+            PAT_INSTALLED=true
+        else
+            echo -e "  ${YELLOW}키체인 저장 실패. 일정 관리 기능 없이 계속합니다.${NC}"
+        fi
+    else
+        echo "  토큰을 건너뛰었습니다. (검색만 사용 가능)"
+    fi
+fi
+
+# ── 7. che-ical-mcp (Apple 캘린더) 설치 ──────────────────────────
 ICAL_INSTALLED=false
 ICAL_BIN="${INSTALL_DIR}/bin/CheICalMCP"
 ICAL_REPO="kiki830621/che-ical-mcp"
@@ -174,7 +204,6 @@ if [ "$(uname -s)" = "Darwin" ]; then
         ICAL_INSTALLED=true
     else
         mkdir -p "${INSTALL_DIR}/bin"
-        # GitHub API로 최신 릴리즈의 CheICalMCP 바이너리 URL 가져오기
         ICAL_URL=$(curl -sL "https://api.github.com/repos/${ICAL_REPO}/releases/latest" \
             | grep -o '"browser_download_url": *"[^"]*CheICalMCP"' \
             | head -1 \
@@ -183,7 +212,6 @@ if [ "$(uname -s)" = "Darwin" ]; then
         if [ -n "${ICAL_URL}" ]; then
             if curl -sL -o "${ICAL_BIN}" "${ICAL_URL}"; then
                 chmod +x "${ICAL_BIN}"
-                # macOS Gatekeeper 허용
                 xattr -d com.apple.quarantine "${ICAL_BIN}" 2>/dev/null || true
                 echo -e "  ${GREEN}CheICalMCP 설치 완료${NC}"
                 ICAL_INSTALLED=true
@@ -199,57 +227,19 @@ else
     echo -e "  ${YELLOW}macOS가 아닌 환경입니다. Apple 캘린더 MCP는 macOS 전용이므로 건너뜁니다.${NC}"
 fi
 
-# ── 7. GitHub PAT 설정 (피드백 채널) ─────────────────────────────
-GITHUB_PAT_INSTALLED=false
-GITHUB_PAT_VALUE=""
-
-echo ""
-echo "▶ 피드백 채널 (GitHub Discussions) 설정 중..."
-
-# 키체인에서 기존 토큰 확인
-GITHUB_PAT_VALUE=$(security find-generic-password -s "${KEYCHAIN_SERVICE}" -a "github-pat" -w 2>/dev/null || true)
-
-if [ -n "${GITHUB_PAT_VALUE}" ]; then
-    echo -e "  ${GREEN}macOS 키체인에서 GitHub 토큰을 찾았습니다.${NC}"
-    GITHUB_PAT_INSTALLED=true
-else
-    echo -e "${YELLOW}▶ GitHub 토큰 설정 (선택사항)${NC}"
-    echo ""
-    echo "  여행 일정 피드백을 GitHub에 올리려면 토큰이 필요합니다."
-    echo "  건너뛰려면 Enter를 누르세요. 나중에 install.sh를 다시 실행하면 설정할 수 있습니다."
-    echo ""
-    echo -e "  ${CYAN}토큰 발급 방법:${NC}"
-    echo "    1) https://github.com/settings/tokens?type=beta 접속"
-    echo "    2) 'Generate new token' 클릭"
-    echo "    3) Token name: trip-planner"
-    echo "    4) Repository access → 'Only select repositories' → idean3885/trip-planner"
-    echo "    5) Permissions → Discussions → Read and write"
-    echo "    6) 'Generate token' 클릭 후 토큰 복사"
-    echo ""
-
-    if [ -t 0 ]; then
-        INPUT_DEV="/dev/stdin"
-    else
-        INPUT_DEV="/dev/tty"
-    fi
-
-    printf "  GitHub 토큰을 입력하세요 (Enter로 건너뛰기): "
-    read -r GITHUB_PAT_VALUE < "${INPUT_DEV}"
-
-    if [ -n "${GITHUB_PAT_VALUE}" ]; then
+# ── 8. v1 → v2 마이그레이션 ──────────────────────────────────────
+# v1에서 설치한 feedback 서버, github-pat 키체인 정리
+if command -v security &>/dev/null; then
+    OLD_PAT=$(security find-generic-password -s "${KEYCHAIN_SERVICE}" -a "github-pat" -w 2>/dev/null || true)
+    if [ -n "${OLD_PAT}" ]; then
+        echo ""
+        echo -e "  ${YELLOW}v1 → v2 마이그레이션: GitHub PAT 키체인 항목 정리${NC}"
         security delete-generic-password -s "${KEYCHAIN_SERVICE}" -a "github-pat" &>/dev/null || true
-        if security add-generic-password -s "${KEYCHAIN_SERVICE}" -a "github-pat" -w "${GITHUB_PAT_VALUE}" &>/dev/null; then
-            echo -e "  ${GREEN}macOS 키체인에 GitHub 토큰 저장 완료${NC}"
-            GITHUB_PAT_INSTALLED=true
-        else
-            echo -e "  ${YELLOW}키체인 저장 실패. 피드백 기능 없이 계속합니다.${NC}"
-        fi
-    else
-        echo "  GitHub 토큰을 건너뛰었습니다."
+        echo -e "  ${GREEN}정리 완료${NC}"
     fi
 fi
 
-# ── 8. Claude Desktop 자동 설정 ──────────────────────────────────
+# ── 9. Claude Desktop 자동 설정 ──────────────────────────────────
 echo ""
 echo "▶ Claude Desktop 설정 중..."
 
@@ -257,35 +247,29 @@ mkdir -p "${CLAUDE_CONFIG_DIR}"
 
 PYTHON_PATH="${VENV_DIR}/bin/python"
 
-# Python으로 JSON을 안전하게 읽고 쓰기 (sed/jq 미사용)
 "${PYTHON_PATH}" - <<PYEOF
 import json, os, sys
 
 config_file   = "${CLAUDE_CONFIG_FILE}"
 python_path   = "${PYTHON_PATH}"
 install_dir   = "${INSTALL_DIR}"
-src_dir       = "${SRC_DIR}"
-api_key       = "${RAPIDAPI_KEY_VALUE}"
 use_keychain  = "${USE_KEYCHAIN}"
+api_key       = "${RAPIDAPI_KEY_VALUE}"
+pat_installed = "${PAT_INSTALLED}"
 
-travel_entry = {
+# trip 서버 설정 (v2: trip_mcp.server)
+trip_entry = {
     "command": python_path,
-    "args": ["-m", "travel_mcp.server"],
+    "args": ["-m", "trip_mcp.server"],
     "cwd": install_dir,
 }
 
-# 키체인 미사용 시에만 env 블록에 API 키 포함
+env_block = {"RAPIDAPI_HOST": "booking-com15.p.rapidapi.com"}
 if use_keychain == "false":
-    travel_entry["env"] = {
-        "RAPIDAPI_KEY": api_key,
-        "RAPIDAPI_HOST": "booking-com15.p.rapidapi.com",
-    }
-else:
-    travel_entry["env"] = {
-        "RAPIDAPI_HOST": "booking-com15.p.rapidapi.com",
-    }
+    env_block["RAPIDAPI_KEY"] = api_key
+trip_entry["env"] = env_block
 
-# 기존 설정 파일 읽기 (없으면 빈 구조 생성)
+# 기존 설정 읽기
 if os.path.exists(config_file):
     try:
         with open(config_file, "r", encoding="utf-8") as f:
@@ -299,45 +283,34 @@ else:
 if "mcpServers" not in config:
     config["mcpServers"] = {}
 
-action = "업데이트" if "travel" in config["mcpServers"] else "추가"
-config["mcpServers"]["travel"] = travel_entry
+# v1 → v2 마이그레이션: 이전 서버명 제거
+for old_name in ["travel", "feedback"]:
+    if old_name in config["mcpServers"]:
+        del config["mcpServers"][old_name]
+        print(f"  v1 서버 '{old_name}' 설정 제거")
 
-# che-ical-mcp (Apple 캘린더) 설정 — 기존 항목이 없을 때만 추가
+# trip 서버 등록
+action = "업데이트" if "trip" in config["mcpServers"] else "추가"
+config["mcpServers"]["trip"] = trip_entry
+print(f"  trip 서버 설정 {action} 완료")
+
+# che-ical-mcp
 ical_installed = "${ICAL_INSTALLED}"
 ical_bin = "${ICAL_BIN}"
 if ical_installed == "true" and "che-ical-mcp" not in config["mcpServers"]:
-    config["mcpServers"]["che-ical-mcp"] = {
-        "command": ical_bin,
-        "args": [],
-    }
+    config["mcpServers"]["che-ical-mcp"] = {"command": ical_bin, "args": []}
     print("  che-ical-mcp 서버 설정 추가 완료")
-elif ical_installed == "true":
-    print("  che-ical-mcp 서버 설정이 이미 존재합니다. 유지합니다.")
-
-# feedback (GitHub Discussions) 설정 — PAT 입력 시에만, 기존 항목 없을 때만 추가
-github_pat_installed = "${GITHUB_PAT_INSTALLED}"
-if github_pat_installed == "true" and "feedback" not in config["mcpServers"]:
-    config["mcpServers"]["feedback"] = {
-        "command": python_path,
-        "args": ["-m", "feedback_mcp.server"],
-        "cwd": install_dir,
-    }
-    print("  feedback 서버 설정 추가 완료")
-elif github_pat_installed == "true":
-    print("  feedback 서버 설정이 이미 존재합니다. 유지합니다.")
 
 with open(config_file, "w", encoding="utf-8") as f:
     json.dump(config, f, indent=2, ensure_ascii=False)
-
-print(f"  travel 서버 설정 {action} 완료")
 PYEOF
 
 echo -e "  ${GREEN}Claude Desktop 설정 완료${NC}"
 
-# ── 8. 완료 메시지 ────────────────────────────────────────────────
+# ── 10. 완료 메시지 ──────────────────────────────────────────────
 echo ""
 echo "============================================================"
-echo -e "${GREEN}  설치 완료!${NC}"
+echo -e "${GREEN}  설치 완료! (v2.0.0)${NC}"
 echo "============================================================"
 echo ""
 echo -e "  ${YELLOW}Claude Desktop을 재시작하세요${NC}"
@@ -347,22 +320,21 @@ echo -e "  ${CYAN}Claude Desktop에서 아래 메시지를 입력해 보세요:$
 echo ""
 echo '    "바르셀로나 6월 16일~20일 4박 숙소 추천해줘"'
 echo ""
+if [ "${PAT_INSTALLED}" = true ]; then
+    echo -e "  ${GREEN}✓ 일정 관리${NC}: API 토큰 설정됨"
+    echo '    "내 여행 목록 보여줘" 로 일정 조회/수정 가능'
+else
+    echo -e "  ${YELLOW}△ 일정 관리${NC}: 미설정 (trip.idean.me에서 토큰 생성 필요)"
+    echo "    install.sh를 다시 실행하면 설정할 수 있습니다."
+fi
+echo ""
 if [ "${ICAL_INSTALLED}" = true ]; then
     echo -e "  ${GREEN}✓ 캘린더 연동${NC}: Apple 캘린더 MCP 설치됨"
-    echo '    "여행 일정 캘린더에 넣어줘" 로 캘린더 등록 가능'
 else
     echo -e "  ${YELLOW}△ 캘린더 연동${NC}: 미설치 (macOS 전용)"
 fi
 echo ""
-if [ "${GITHUB_PAT_INSTALLED}" = true ]; then
-    echo -e "  ${GREEN}✓ 피드백 채널${NC}: GitHub Discussions 연동됨"
-    echo '    "셋째 날 저녁 식당 추가하고 싶어" 로 일정 보완 요청 가능'
-    echo '    "모바일에서 표가 잘려 보여" 로 디자인 피드백 가능'
-else
-    echo -e "  ${YELLOW}△ 피드백 채널${NC}: 미설정 (GitHub 토큰 필요)"
-    echo "    install.sh를 다시 실행하면 설정할 수 있습니다."
-fi
-echo ""
 echo "  설치 위치: ${INSTALL_DIR}"
 echo "  설정 파일: ${CLAUDE_CONFIG_FILE}"
+echo "  API 문서:  https://trip.idean.me/docs"
 echo ""


### PR DESCRIPTION
## Summary
- install.sh v2: GitHub PAT 제거 → Trip Planner PAT 추가 (trip.idean.me/settings)
- v1→v2 마이그레이션: feedback/travel 서버 자동 제거, github-pat 키체인 정리
- manifest.json, .mcp.json에 TRIP_PLANNER_PAT 환경변수 추가

## Tasks (T028~T032)
- [x] T028 install.sh 전면 개편
- [x] T029 manifest.json PAT user_config
- [x] T030 .mcp.json PAT 환경변수
- [x] T031 example config (Phase 2 완료)
- [ ] T032 클린 환경 E2E (별도 검증)

## Test plan
- [x] `bash -n scripts/install.sh` 문법 검증 통과

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)