### PR TITLE
fix(005): middleware + API 라우트 PAT 인증 지원

### DIFF
--- a/src/app/api/trips/[id]/days/[dayId]/route.ts
+++ b/src/app/api/trips/[id]/days/[dayId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getSession, canEdit } from "@/lib/auth-helpers";
+import { getAuthUserId, canEdit } from "@/lib/auth-helpers";
 
 type Params = { params: Promise<{ id: string; dayId: string }> };
 
@@ -8,12 +8,12 @@ type Params = { params: Promise<{ id: string; dayId: string }> };
 export async function PUT(request: Request, { params }: Params) {
   const { id, dayId } = await params;
   const tripId = parseInt(id);
-  const session = await getSession();
-  if (!session?.user?.id) {
+  const userId = await getAuthUserId();
+  if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  if (!(await canEdit(tripId, session.user.id))) {
+  if (!(await canEdit(tripId, userId))) {
     return NextResponse.json({ error: "편집 권한이 없습니다" }, { status: 403 });
   }
 
@@ -37,12 +37,12 @@ export async function PUT(request: Request, { params }: Params) {
 export async function DELETE(request: Request, { params }: Params) {
   const { id, dayId } = await params;
   const tripId = parseInt(id);
-  const session = await getSession();
-  if (!session?.user?.id) {
+  const userId = await getAuthUserId();
+  if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  if (!(await canEdit(tripId, session.user.id))) {
+  if (!(await canEdit(tripId, userId))) {
     return NextResponse.json({ error: "편집 권한이 없습니다" }, { status: 403 });
   }
 

--- a/src/app/api/trips/[id]/days/route.ts
+++ b/src/app/api/trips/[id]/days/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getSession, getTripMember, canEdit } from "@/lib/auth-helpers";
+import { getAuthUserId, getTripMember, canEdit } from "@/lib/auth-helpers";
 
 type Params = { params: Promise<{ id: string }> };
 
@@ -8,13 +8,13 @@ type Params = { params: Promise<{ id: string }> };
 export async function GET(request: Request, { params }: Params) {
   const { id } = await params;
   const tripId = parseInt(id);
-  const session = await getSession();
-  if (!session?.user?.id) {
+  const userId = await getAuthUserId();
+  if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const [member, days] = await Promise.all([
-    getTripMember(tripId, session.user.id),
+    getTripMember(tripId, userId),
     prisma.day.findMany({
       where: { tripId },
       orderBy: { sortOrder: "asc" },
@@ -32,12 +32,12 @@ export async function GET(request: Request, { params }: Params) {
 export async function POST(request: Request, { params }: Params) {
   const { id } = await params;
   const tripId = parseInt(id);
-  const session = await getSession();
-  if (!session?.user?.id) {
+  const userId = await getAuthUserId();
+  if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  if (!(await canEdit(tripId, session.user.id))) {
+  if (!(await canEdit(tripId, userId))) {
     return NextResponse.json({ error: "편집 권한이 없습니다" }, { status: 403 });
   }
 

--- a/src/app/api/trips/[id]/invite/route.ts
+++ b/src/app/api/trips/[id]/invite/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getSession, isHost } from "@/lib/auth-helpers";
+import { getAuthUserId, isHost } from "@/lib/auth-helpers";
 import { createInviteToken } from "@/lib/invite-token";
 
 type Params = { params: Promise<{ id: string }> };
@@ -8,12 +8,12 @@ type Params = { params: Promise<{ id: string }> };
 export async function POST(request: Request, { params }: Params) {
   const { id } = await params;
   const tripId = parseInt(id);
-  const session = await getSession();
-  if (!session?.user?.id) {
+  const userId = await getAuthUserId();
+  if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  if (!(await isHost(tripId, session.user.id))) {
+  if (!(await isHost(tripId, userId))) {
     return NextResponse.json({ error: "호스트만 초대할 수 있습니다" }, { status: 403 });
   }
 

--- a/src/app/api/trips/[id]/leave/route.ts
+++ b/src/app/api/trips/[id]/leave/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getSession, getTripMember } from "@/lib/auth-helpers";
+import { getAuthUserId, getTripMember } from "@/lib/auth-helpers";
 
 type Params = { params: Promise<{ id: string }> };
 
@@ -8,12 +8,12 @@ type Params = { params: Promise<{ id: string }> };
 export async function POST(request: Request, { params }: Params) {
   const { id } = await params;
   const tripId = parseInt(id);
-  const session = await getSession();
-  if (!session?.user?.id) {
+  const userId = await getAuthUserId();
+  if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const member = await getTripMember(tripId, session.user.id);
+  const member = await getTripMember(tripId, userId);
   if (!member) {
     return NextResponse.json({ error: "멤버가 아닙니다" }, { status: 400 });
   }

--- a/src/app/api/trips/[id]/members/route.ts
+++ b/src/app/api/trips/[id]/members/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getSession, getTripMember, isHost, isOwner } from "@/lib/auth-helpers";
+import { getAuthUserId, getTripMember, isHost, isOwner } from "@/lib/auth-helpers";
 
 type Params = { params: Promise<{ id: string }> };
 
@@ -8,13 +8,13 @@ type Params = { params: Promise<{ id: string }> };
 export async function GET(request: Request, { params }: Params) {
   const { id } = await params;
   const tripId = parseInt(id);
-  const session = await getSession();
-  if (!session?.user?.id) {
+  const userId = await getAuthUserId();
+  if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const [member, members] = await Promise.all([
-    getTripMember(tripId, session.user.id),
+    getTripMember(tripId, userId),
     prisma.tripMember.findMany({
       where: { tripId },
       include: { user: { select: { id: true, name: true, email: true, image: true } } },
@@ -33,8 +33,8 @@ export async function GET(request: Request, { params }: Params) {
 export async function PATCH(request: Request, { params }: Params) {
   const { id } = await params;
   const tripId = parseInt(id);
-  const session = await getSession();
-  if (!session?.user?.id) {
+  const userId = await getAuthUserId();
+  if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
@@ -55,7 +55,7 @@ export async function PATCH(request: Request, { params }: Params) {
     if (target.role !== "GUEST") {
       return NextResponse.json({ error: "게스트만 승격할 수 있습니다" }, { status: 400 });
     }
-    if (!(await isHost(tripId, session.user.id))) {
+    if (!(await isHost(tripId, userId))) {
       return NextResponse.json({ error: "호스트만 승격할 수 있습니다" }, { status: 403 });
     }
     await prisma.tripMember.update({ where: { id: memberId }, data: { role: "HOST" } });
@@ -64,7 +64,7 @@ export async function PATCH(request: Request, { params }: Params) {
     if (target.role !== "HOST") {
       return NextResponse.json({ error: "호스트만 강등할 수 있습니다" }, { status: 400 });
     }
-    if (!(await isOwner(tripId, session.user.id))) {
+    if (!(await isOwner(tripId, userId))) {
       return NextResponse.json({ error: "주인만 강등할 수 있습니다" }, { status: 403 });
     }
     await prisma.tripMember.update({ where: { id: memberId }, data: { role: "GUEST" } });
@@ -77,8 +77,8 @@ export async function PATCH(request: Request, { params }: Params) {
 export async function DELETE(request: Request, { params }: Params) {
   const { id } = await params;
   const tripId = parseInt(id);
-  const session = await getSession();
-  if (!session?.user?.id) {
+  const userId = await getAuthUserId();
+  if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
@@ -100,12 +100,12 @@ export async function DELETE(request: Request, { params }: Params) {
   }
 
   // 호스트 제거는 주인만
-  if (target.role === "HOST" && !(await isOwner(tripId, session.user.id))) {
+  if (target.role === "HOST" && !(await isOwner(tripId, userId))) {
     return NextResponse.json({ error: "주인만 호스트를 제거할 수 있습니다" }, { status: 403 });
   }
 
   // 게스트 제거는 호스트면 가능
-  if (target.role === "GUEST" && !(await isHost(tripId, session.user.id))) {
+  if (target.role === "GUEST" && !(await isHost(tripId, userId))) {
     return NextResponse.json({ error: "호스트만 게스트를 제거할 수 있습니다" }, { status: 403 });
   }
 

--- a/src/app/api/trips/[id]/route.ts
+++ b/src/app/api/trips/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getSession, getTripMember, canEdit, isOwner } from "@/lib/auth-helpers";
+import { getAuthUserId, getTripMember, canEdit, isOwner } from "@/lib/auth-helpers";
 
 type Params = { params: Promise<{ id: string }> };
 
@@ -8,13 +8,13 @@ type Params = { params: Promise<{ id: string }> };
 export async function GET(request: Request, { params }: Params) {
   const { id } = await params;
   const tripId = parseInt(id);
-  const session = await getSession();
-  if (!session?.user?.id) {
+  const userId = await getAuthUserId();
+  if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const [member, trip] = await Promise.all([
-    getTripMember(tripId, session.user.id),
+    getTripMember(tripId, userId),
     prisma.trip.findUnique({
       where: { id: tripId },
       include: {
@@ -40,12 +40,12 @@ export async function GET(request: Request, { params }: Params) {
 export async function PUT(request: Request, { params }: Params) {
   const { id } = await params;
   const tripId = parseInt(id);
-  const session = await getSession();
-  if (!session?.user?.id) {
+  const userId = await getAuthUserId();
+  if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  if (!(await canEdit(tripId, session.user.id))) {
+  if (!(await canEdit(tripId, userId))) {
     return NextResponse.json({ error: "편집 권한이 없습니다" }, { status: 403 });
   }
 
@@ -59,7 +59,7 @@ export async function PUT(request: Request, { params }: Params) {
       ...(description !== undefined && { description }),
       ...(startDate !== undefined && { startDate: startDate ? new Date(startDate) : null }),
       ...(endDate !== undefined && { endDate: endDate ? new Date(endDate) : null }),
-      updatedBy: session.user.id,
+      updatedBy: userId,
     },
   });
 
@@ -70,12 +70,12 @@ export async function PUT(request: Request, { params }: Params) {
 export async function DELETE(request: Request, { params }: Params) {
   const { id } = await params;
   const tripId = parseInt(id);
-  const session = await getSession();
-  if (!session?.user?.id) {
+  const userId = await getAuthUserId();
+  if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  if (!(await isOwner(tripId, session.user.id))) {
+  if (!(await isOwner(tripId, userId))) {
     return NextResponse.json({ error: "주인만 삭제할 수 있습니다" }, { status: 403 });
   }
 

--- a/src/app/api/trips/[id]/transfer/route.ts
+++ b/src/app/api/trips/[id]/transfer/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getSession, isOwner } from "@/lib/auth-helpers";
+import { getAuthUserId, isOwner } from "@/lib/auth-helpers";
 
 type Params = { params: Promise<{ id: string }> };
 
@@ -8,12 +8,12 @@ type Params = { params: Promise<{ id: string }> };
 export async function POST(request: Request, { params }: Params) {
   const { id } = await params;
   const tripId = parseInt(id);
-  const session = await getSession();
-  if (!session?.user?.id) {
+  const userId = await getAuthUserId();
+  if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  if (!(await isOwner(tripId, session.user.id))) {
+  if (!(await isOwner(tripId, userId))) {
     return NextResponse.json({ error: "주인만 양도할 수 있습니다" }, { status: 403 });
   }
 
@@ -31,7 +31,7 @@ export async function POST(request: Request, { params }: Params) {
 
   // 트랜잭션: 대상 → OWNER, 기존 주인 → HOST
   const currentOwner = await prisma.tripMember.findFirst({
-    where: { tripId, userId: session.user.id, role: "OWNER" },
+    where: { tripId, userId, role: "OWNER" },
   });
 
   if (!currentOwner) {

--- a/src/app/api/trips/route.ts
+++ b/src/app/api/trips/route.ts
@@ -1,17 +1,17 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getSession } from "@/lib/auth-helpers";
+import { getAuthUserId } from "@/lib/auth-helpers";
 
 // T024: 여행 목록 (TripMember 기반 필터)
 export async function GET() {
-  const session = await getSession();
-  if (!session?.user?.id) {
+  const userId = await getAuthUserId();
+  if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const trips = await prisma.trip.findMany({
     where: {
-      tripMembers: { some: { userId: session.user.id } },
+      tripMembers: { some: { userId } },
     },
     include: {
       tripMembers: { select: { role: true, userId: true } },
@@ -25,8 +25,8 @@ export async function GET() {
 
 // T025: 여행 생성 (생성자를 HOST로 등록)
 export async function POST(request: Request) {
-  const session = await getSession();
-  if (!session?.user?.id) {
+  const userId = await getAuthUserId();
+  if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
@@ -43,10 +43,10 @@ export async function POST(request: Request) {
       description,
       startDate: startDate ? new Date(startDate) : null,
       endDate: endDate ? new Date(endDate) : null,
-      createdBy: session.user.id,
-      updatedBy: session.user.id,
+      createdBy: userId,
+      updatedBy: userId,
       tripMembers: {
-        create: { userId: session.user.id, role: "HOST" },
+        create: { userId, role: "HOST" },
       },
     },
   });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,10 +6,10 @@ const { auth } = NextAuth(authConfig);
 export default auth((req) => {
   const isLoggedIn = !!req.auth;
   const isAuthRoute = req.nextUrl.pathname.startsWith("/auth");
-  const isApiAuthRoute = req.nextUrl.pathname.startsWith("/api/auth");
+  const isApiRoute = req.nextUrl.pathname.startsWith("/api/");
 
-  // Auth API 라우트는 항상 허용
-  if (isApiAuthRoute) return;
+  // API 라우트는 자체 인증 처리 (PAT Bearer 토큰 + 세션 병행, auth-helpers.ts)
+  if (isApiRoute) return;
 
   // 로그인 페이지는 항상 허용
   if (isAuthRoute) return;


### PR DESCRIPTION
## Summary
- middleware.ts에서 `/api/` 라우트를 세션 리다이렉트에서 제외 — API는 `getAuthUserId()`로 자체 인증 처리
- 모든 trip API 라우트(8개 파일)를 `getSession()` → `getAuthUserId()`로 전환
- PAT Bearer 토큰으로 API 호출 시 302 리다이렉트 → 정상 응답

## Test plan
- [ ] `curl -H "Authorization: Bearer tp_..." https://trip.idean.me/api/trips` → 200 응답
- [ ] 웹 브라우저 세션 인증 기존 동작 유지 확인
- [ ] MCP CRUD 도구 E2E 검증 (list_trips → get_trip → create_day → update_day → delete_day)

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)