### PR TITLE
fix(005): 네비게이션 동선 개선 — 헤더 홈 링크 + 브레드크럼

### DIFF
--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useRef } from "react";
 
 export default function DocsPage() {
@@ -25,7 +26,7 @@ export default function DocsPage() {
   return (
     <div className="min-h-screen -mx-4 -mt-6">
       <div className="px-4 pt-4 pb-2 flex items-center gap-2 text-body-sm text-surface-500">
-        <a href="/" className="hover:text-surface-700">홈</a>
+        <Link href="/" className="hover:text-surface-700">홈</Link>
         <span>/</span>
         <span className="text-surface-700">API 문서</span>
       </div>

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -24,6 +24,11 @@ export default function DocsPage() {
 
   return (
     <div className="min-h-screen -mx-4 -mt-6">
+      <div className="px-4 pt-4 pb-2 flex items-center gap-2 text-body-sm text-surface-500">
+        <a href="/" className="hover:text-surface-700">홈</a>
+        <span>/</span>
+        <span className="text-surface-700">API 문서</span>
+      </div>
       <div ref={containerRef} />
     </div>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { Inter } from "next/font/google";
+import Link from "next/link";
 import ScrollToTop from "@/components/ScrollToTop";
 import SessionProvider from "@/components/SessionProvider";
 import AuthButton from "@/components/AuthButton";
@@ -27,7 +28,10 @@ export default function RootLayout({
     <html lang="ko">
       <body className={`${inter.className} bg-white text-surface-900 min-h-screen`}>
         <SessionProvider>
-          <header className="max-w-content mx-auto w-full px-4 pt-4 flex justify-end">
+          <header className="max-w-content mx-auto w-full px-4 pt-4 flex items-center justify-between">
+            <Link href="/" className="text-body-sm font-semibold text-surface-700 hover:text-surface-900">
+              우리의 여행
+            </Link>
             <AuthButton />
           </header>
           <main className="max-w-content mx-auto w-full px-4 py-6 pb-16">

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -76,6 +76,11 @@ export default function SettingsPage() {
 
   return (
     <div className="space-y-8">
+      <div className="flex items-center gap-2 text-body-sm text-surface-500">
+        <a href="/" className="hover:text-surface-700">홈</a>
+        <span>/</span>
+        <span className="text-surface-700">설정</span>
+      </div>
       <h1 className="text-2xl font-bold">설정</h1>
 
       <section className="space-y-4">

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useSession } from "next-auth/react";
 import { useState, useCallback } from "react";
 
@@ -77,7 +78,7 @@ export default function SettingsPage() {
   return (
     <div className="space-y-8">
       <div className="flex items-center gap-2 text-body-sm text-surface-500">
-        <a href="/" className="hover:text-surface-700">홈</a>
+        <Link href="/" className="hover:text-surface-700">홈</Link>
         <span>/</span>
         <span className="text-surface-700">설정</span>
       </div>

--- a/src/app/trips/new/page.tsx
+++ b/src/app/trips/new/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 
@@ -40,7 +41,7 @@ export default function NewTripPage() {
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-2 text-body-sm text-surface-500">
-        <a href="/" className="hover:text-surface-700">홈</a>
+        <Link href="/" className="hover:text-surface-700">홈</Link>
         <span>/</span>
         <span className="text-surface-700">새 여행</span>
       </div>

--- a/src/app/trips/new/page.tsx
+++ b/src/app/trips/new/page.tsx
@@ -39,6 +39,11 @@ export default function NewTripPage() {
 
   return (
     <div className="space-y-6">
+      <div className="flex items-center gap-2 text-body-sm text-surface-500">
+        <a href="/" className="hover:text-surface-700">홈</a>
+        <span>/</span>
+        <span className="text-surface-700">새 여행</span>
+      </div>
       <h1 className="text-heading-lg font-bold">새 여행</h1>
 
       <form onSubmit={handleSubmit} className="space-y-4">


### PR DESCRIPTION
## Summary
- layout.tsx 헤더 좌측에 "우리의 여행" 홈 링크 추가 → 모든 페이지에서 홈 복귀 가능
- settings, trips/new, docs 페이지에 `홈 / 현재 페이지` 브레드크럼 추가

## Test plan
- [ ] 설정 페이지: 홈 브레드크럼 + 헤더 홈 링크 동작
- [ ] 새 여행 페이지: 홈 브레드크럼 동작
- [ ] API 문서 페이지: 홈 브레드크럼 동작
- [ ] 기존 여행/일자 페이지 브레드크럼 영향 없음

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)