### PR TITLE
feat(006): 구조화 폼 UI — ActivityForm + 편집/삭제/순서 변경

### DIFF
--- a/src/app/trips/[id]/day/[dayId]/page.tsx
+++ b/src/app/trips/[id]/day/[dayId]/page.tsx
@@ -8,8 +8,7 @@ import remarkGfm from "remark-gfm";
 import html from "remark-html";
 import fs from "fs";
 import path from "path";
-import DayEditor from "@/components/DayEditor";
-import ActivityCard from "@/components/ActivityCard";
+import ActivityList from "@/components/ActivityList";
 import {
   getAllTripSlugs,
   getAllDays,
@@ -109,35 +108,21 @@ async function DbDayPage({ tripId, dayIdNum }: { tripId: number; dayIdNum: numbe
         </p>
       </div>
 
-      {day.activities.length > 0 && (
-        <div className="space-y-2">
-          <h2 className="text-heading-sm font-semibold text-surface-700">
-            활동 ({day.activities.length})
-          </h2>
-          {day.activities.map((activity) => (
-            <ActivityCard key={activity.id} activity={activity} />
-          ))}
-        </div>
-      )}
+      <ActivityList
+        tripId={tripId}
+        dayId={day.id}
+        activities={day.activities}
+        canEdit={member.role !== "GUEST"}
+      />
 
       {day.content && (
-        <DayEditor
-          tripId={tripId}
-          dayId={day.id}
-          initialContent={day.content}
-          initialHtml={contentHtml}
-          canEdit={member.role !== "GUEST"}
-        />
-      )}
-
-      {!day.activities.length && !day.content && (
-        <DayEditor
-          tripId={tripId}
-          dayId={day.id}
-          initialContent=""
-          initialHtml=""
-          canEdit={member.role !== "GUEST"}
-        />
+        <div className="space-y-2">
+          <h2 className="text-heading-sm font-semibold text-surface-700">메모</h2>
+          <div
+            className="prose prose-sm max-w-none rounded-card border border-surface-200 p-4"
+            dangerouslySetInnerHTML={{ __html: contentHtml }}
+          />
+        </div>
       )}
     </div>
   );

--- a/src/components/ActivityCard.tsx
+++ b/src/components/ActivityCard.tsx
@@ -1,5 +1,30 @@
 import type { ActivityCategory, ReservationStatus, Prisma } from "@prisma/client";
 
+const URL_RE = /(https?:\/\/[^\s]+)/g;
+
+function Linkify({ text }: { text: string }) {
+  const parts = text.split(URL_RE);
+  return (
+    <>
+      {parts.map((part, i) =>
+        URL_RE.test(part) ? (
+          <a
+            key={i}
+            href={part}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary-600 underline hover:text-primary-800"
+          >
+            {part}
+          </a>
+        ) : (
+          part
+        )
+      )}
+    </>
+  );
+}
+
 const CATEGORY_LABEL: Record<ActivityCategory, string> = {
   SIGHTSEEING: "관광",
   DINING: "식사",
@@ -38,9 +63,25 @@ interface ActivityCardProps {
     currency: string;
     reservationStatus: ReservationStatus | null;
   };
+  canEdit?: boolean;
+  isFirst?: boolean;
+  isLast?: boolean;
+  onEdit?: () => void;
+  onDelete?: () => void;
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
 }
 
-export default function ActivityCard({ activity }: ActivityCardProps) {
+export default function ActivityCard({
+  activity,
+  canEdit = false,
+  isFirst = false,
+  isLast = false,
+  onEdit,
+  onDelete,
+  onMoveUp,
+  onMoveDown,
+}: ActivityCardProps) {
   const timeRange =
     activity.startTime && activity.endTime
       ? `${activity.startTime}–${activity.endTime}`
@@ -49,7 +90,7 @@ export default function ActivityCard({ activity }: ActivityCardProps) {
   const cost = activity.cost ? Number(activity.cost) : null;
 
   return (
-    <div className="rounded-card border border-surface-200 p-3 transition-shadow hover:shadow-card">
+    <div className="group rounded-card border border-surface-200 p-3 transition-shadow hover:shadow-card">
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
@@ -71,7 +112,9 @@ export default function ActivityCard({ activity }: ActivityCardProps) {
             </p>
           )}
           {activity.memo && (
-            <p className="mt-1 text-body-sm text-surface-400">{activity.memo}</p>
+            <p className="mt-1 text-body-sm text-surface-400">
+              <Linkify text={activity.memo} />
+            </p>
           )}
         </div>
         <div className="flex flex-col items-end gap-1 text-right">
@@ -87,6 +130,43 @@ export default function ActivityCard({ activity }: ActivityCardProps) {
           )}
         </div>
       </div>
+
+      {canEdit && (
+        <div className="mt-2 flex items-center justify-between border-t border-surface-100 pt-2 opacity-0 group-hover:opacity-100 transition-opacity">
+          <div className="flex gap-1">
+            <button
+              onClick={onMoveUp}
+              disabled={isFirst}
+              className="rounded px-1.5 py-0.5 text-[11px] text-surface-400 hover:bg-surface-100 hover:text-surface-600 disabled:opacity-30 disabled:cursor-default"
+              aria-label="위로"
+            >
+              ▲
+            </button>
+            <button
+              onClick={onMoveDown}
+              disabled={isLast}
+              className="rounded px-1.5 py-0.5 text-[11px] text-surface-400 hover:bg-surface-100 hover:text-surface-600 disabled:opacity-30 disabled:cursor-default"
+              aria-label="아래로"
+            >
+              ▼
+            </button>
+          </div>
+          <div className="flex gap-1">
+            <button
+              onClick={onEdit}
+              className="rounded px-2 py-0.5 text-[11px] text-surface-400 hover:bg-surface-100 hover:text-surface-600"
+            >
+              편집
+            </button>
+            <button
+              onClick={onDelete}
+              className="rounded px-2 py-0.5 text-[11px] text-red-400 hover:bg-red-50 hover:text-red-600"
+            >
+              삭제
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/ActivityForm.tsx
+++ b/src/components/ActivityForm.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import type { ActivityCategory, ReservationStatus } from "@prisma/client";
+
+const CATEGORY_OPTIONS: { value: ActivityCategory; label: string }[] = [
+  { value: "SIGHTSEEING", label: "관광" },
+  { value: "DINING", label: "식사" },
+  { value: "TRANSPORT", label: "이동" },
+  { value: "ACCOMMODATION", label: "숙소" },
+  { value: "SHOPPING", label: "쇼핑" },
+  { value: "OTHER", label: "기타" },
+];
+
+const RESERVATION_OPTIONS: { value: ReservationStatus | ""; label: string }[] = [
+  { value: "", label: "선택 안함" },
+  { value: "REQUIRED", label: "사전 예약 필수" },
+  { value: "RECOMMENDED", label: "사전 예약 권장" },
+  { value: "ON_SITE", label: "현장 구매" },
+  { value: "NOT_NEEDED", label: "불필요" },
+];
+
+export interface ActivityFormData {
+  category: ActivityCategory;
+  title: string;
+  startTime: string;
+  endTime: string;
+  location: string;
+  memo: string;
+  cost: string;
+  currency: string;
+  reservationStatus: string;
+}
+
+interface ActivityFormProps {
+  initial?: Partial<ActivityFormData>;
+  onSubmit: (data: ActivityFormData) => Promise<void>;
+  onCancel: () => void;
+  isEdit?: boolean;
+}
+
+function getLocalTimes(): { start: string; end: string } {
+  const now = new Date();
+  const min = now.getMinutes();
+  const startMin = min < 30 ? 30 : 0;
+  if (startMin === 0) now.setHours(now.getHours() + 1);
+  now.setMinutes(startMin);
+  const start = `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
+  now.setHours(now.getHours() + 1);
+  const end = `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
+  return { start, end };
+}
+
+export default function ActivityForm({
+  initial,
+  onSubmit,
+  onCancel,
+  isEdit = false,
+}: ActivityFormProps) {
+  const [form, setForm] = useState<ActivityFormData>({
+    category: initial?.category ?? "SIGHTSEEING",
+    title: initial?.title ?? "",
+    startTime: initial?.startTime ?? "",
+    endTime: initial?.endTime ?? "",
+    location: initial?.location ?? "",
+    memo: initial?.memo ?? "",
+    cost: initial?.cost ?? "",
+    currency: initial?.currency ?? "EUR",
+    reservationStatus: initial?.reservationStatus ?? "",
+  });
+  const [saving, setSaving] = useState(false);
+  const [tzLabel, setTzLabel] = useState("");
+
+  useEffect(() => {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const city = tz.split("/").pop()?.replace(/_/g, " ") ?? tz;
+    const CITY_KO: Record<string, string> = {
+      Seoul: "서울", Tokyo: "도쿄", Lisbon: "리스본", Madrid: "마드리드",
+      Paris: "파리", London: "런던", "New York": "뉴욕", "Los Angeles": "LA",
+      Barcelona: "바르셀로나", Rome: "로마", Berlin: "베를린", Bangkok: "방콕",
+      Singapore: "싱가포르", Shanghai: "상하이", Sydney: "시드니",
+    };
+    setTzLabel(CITY_KO[city] ?? city);
+
+    if (!isEdit && !initial?.startTime && !form.startTime) {
+      const { start, end } = getLocalTimes();
+      setForm((prev) => ({ ...prev, startTime: start, endTime: end }));
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  function update(field: keyof ActivityFormData, value: string) {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!form.title.trim()) return;
+    setSaving(true);
+    try {
+      await onSubmit(form);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="rounded-card border border-surface-200 bg-surface-50 p-4 space-y-3"
+    >
+      <div className="flex items-center gap-2">
+        <div>
+          <label className="block text-[11px] text-surface-400 mb-0.5">
+            유형 <span className="text-red-400">*</span>
+          </label>
+          <select
+            value={form.category}
+            onChange={(e) => update("category", e.target.value)}
+            className="rounded-md border border-surface-200 bg-white px-2 py-1.5 text-body-sm"
+          >
+            {CATEGORY_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex-1">
+          <label className="block text-[11px] text-surface-400 mb-0.5">
+            제목 <span className="text-red-400">*</span>
+          </label>
+          <input
+            type="text"
+            value={form.title}
+            onChange={(e) => update("title", e.target.value)}
+            required
+            className="w-full rounded-md border border-surface-200 px-3 py-1.5 text-body-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <label className="block text-[11px] text-surface-400 mb-0.5">
+            시작 <span className="text-red-400">*</span>
+            {tzLabel && <span className="ml-1 text-surface-300">({tzLabel})</span>}
+          </label>
+          <input
+            type="time"
+            value={form.startTime}
+            onChange={(e) => update("startTime", e.target.value)}
+            required
+            className="w-full rounded-md border border-surface-200 px-2 py-1.5 text-body-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-[11px] text-surface-400 mb-0.5">
+            종료 <span className="text-red-400">*</span>
+            {tzLabel && <span className="ml-1 text-surface-300">({tzLabel})</span>}
+          </label>
+          <input
+            type="time"
+            value={form.endTime}
+            onChange={(e) => update("endTime", e.target.value)}
+            required
+            className="w-full rounded-md border border-surface-200 px-2 py-1.5 text-body-sm"
+          />
+        </div>
+      </div>
+
+      <input
+        type="text"
+        placeholder="장소"
+        value={form.location}
+        onChange={(e) => update("location", e.target.value)}
+        className="w-full rounded-md border border-surface-200 px-3 py-1.5 text-body-sm"
+      />
+
+      <textarea
+        placeholder="메모"
+        value={form.memo}
+        onChange={(e) => update("memo", e.target.value)}
+        rows={2}
+        className="w-full rounded-md border border-surface-200 px-3 py-1.5 text-body-sm resize-none"
+      />
+
+      <div className="grid grid-cols-3 gap-2">
+        <div>
+          <label className="block text-[11px] text-surface-400 mb-0.5">비용</label>
+          <input
+            type="number"
+            step="0.01"
+            min="0"
+            placeholder="0"
+            value={form.cost}
+            onChange={(e) => update("cost", e.target.value)}
+            className="w-full rounded-md border border-surface-200 px-2 py-1.5 text-body-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-[11px] text-surface-400 mb-0.5">통화</label>
+          <input
+            type="text"
+            maxLength={3}
+            value={form.currency}
+            onChange={(e) => update("currency", e.target.value.toUpperCase())}
+            className="w-full rounded-md border border-surface-200 px-2 py-1.5 text-body-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-[11px] text-surface-400 mb-0.5">예약</label>
+          <select
+            value={form.reservationStatus}
+            onChange={(e) => update("reservationStatus", e.target.value)}
+            className="w-full rounded-md border border-surface-200 bg-white px-2 py-1.5 text-body-sm"
+          >
+            {RESERVATION_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="flex justify-end gap-2 pt-1">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md px-3 py-1.5 text-body-sm text-surface-500 hover:bg-surface-100"
+        >
+          취소
+        </button>
+        <button
+          type="submit"
+          disabled={saving || !form.title.trim()}
+          className="rounded-md bg-surface-900 px-3 py-1.5 text-body-sm text-white hover:bg-surface-700 disabled:opacity-50"
+        >
+          {saving ? "저장 중..." : isEdit ? "수정" : "추가"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/ActivityList.tsx
+++ b/src/components/ActivityList.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import type { ActivityCategory, ReservationStatus, Prisma } from "@prisma/client";
+import ActivityCard from "./ActivityCard";
+import ActivityForm, { type ActivityFormData } from "./ActivityForm";
+
+interface Activity {
+  id: number;
+  category: ActivityCategory;
+  title: string;
+  startTime: string | null;
+  endTime: string | null;
+  location: string | null;
+  memo: string | null;
+  cost: Prisma.Decimal | string | number | null;
+  currency: string;
+  reservationStatus: ReservationStatus | null;
+  sortOrder: number;
+}
+
+interface ActivityListProps {
+  tripId: number;
+  dayId: number;
+  activities: Activity[];
+  canEdit: boolean;
+}
+
+export default function ActivityList({
+  tripId,
+  dayId,
+  activities: initialActivities,
+  canEdit,
+}: ActivityListProps) {
+  const router = useRouter();
+  const [activities, setActivities] = useState(initialActivities);
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<number | null>(null);
+
+  const apiBase = `/api/trips/${tripId}/days/${dayId}/activities`;
+
+  async function handleCreate(data: ActivityFormData) {
+    const body: Record<string, unknown> = {
+      category: data.category,
+      title: data.title,
+    };
+    if (data.startTime) body.startTime = data.startTime;
+    if (data.endTime) body.endTime = data.endTime;
+    if (data.location) body.location = data.location;
+    if (data.memo) body.memo = data.memo;
+    if (data.cost) body.cost = parseFloat(data.cost);
+    if (data.currency) body.currency = data.currency;
+    if (data.reservationStatus) body.reservationStatus = data.reservationStatus;
+
+    const res = await fetch(apiBase, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) throw new Error("생성 실패");
+
+    const created = await res.json();
+    setActivities((prev) => [...prev, created]);
+    setShowForm(false);
+  }
+
+  async function handleUpdate(activityId: number, data: ActivityFormData) {
+    const body: Record<string, unknown> = {
+      category: data.category,
+      title: data.title,
+      startTime: data.startTime || null,
+      endTime: data.endTime || null,
+      location: data.location || null,
+      memo: data.memo || null,
+      cost: data.cost ? parseFloat(data.cost) : null,
+      currency: data.currency,
+      reservationStatus: data.reservationStatus || null,
+    };
+
+    const res = await fetch(`${apiBase}/${activityId}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) throw new Error("수정 실패");
+
+    const updated = await res.json();
+    setActivities((prev) =>
+      prev.map((a) => (a.id === activityId ? updated : a))
+    );
+    setEditingId(null);
+  }
+
+  async function handleDelete(activityId: number) {
+    if (!confirm("이 활동을 삭제하시겠습니까?")) return;
+
+    const res = await fetch(`${apiBase}/${activityId}`, { method: "DELETE" });
+    if (!res.ok) throw new Error("삭제 실패");
+
+    setActivities((prev) => prev.filter((a) => a.id !== activityId));
+  }
+
+  async function handleMove(activityId: number, direction: "up" | "down") {
+    const idx = activities.findIndex((a) => a.id === activityId);
+    if (idx < 0) return;
+    const swapIdx = direction === "up" ? idx - 1 : idx + 1;
+    if (swapIdx < 0 || swapIdx >= activities.length) return;
+
+    const reordered = [...activities];
+    [reordered[idx], reordered[swapIdx]] = [reordered[swapIdx], reordered[idx]];
+    setActivities(reordered);
+
+    const orderedIds = reordered.map((a) => a.id);
+    await fetch(apiBase, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ orderedIds }),
+    });
+  }
+
+  return (
+    <div className="space-y-2">
+      {activities.length > 0 && (
+        <h2 className="text-heading-sm font-semibold text-surface-700">
+          활동 ({activities.length})
+        </h2>
+      )}
+
+      {activities.map((activity, idx) =>
+        editingId === activity.id ? (
+          <ActivityForm
+            key={activity.id}
+            isEdit
+            initial={{
+              category: activity.category,
+              title: activity.title,
+              startTime: activity.startTime ?? "",
+              endTime: activity.endTime ?? "",
+              location: activity.location ?? "",
+              memo: activity.memo ?? "",
+              cost: activity.cost ? String(activity.cost) : "",
+              currency: activity.currency,
+              reservationStatus: activity.reservationStatus ?? "",
+            }}
+            onSubmit={(data) => handleUpdate(activity.id, data)}
+            onCancel={() => setEditingId(null)}
+          />
+        ) : (
+          <ActivityCard
+            key={activity.id}
+            activity={activity}
+            canEdit={canEdit}
+            isFirst={idx === 0}
+            isLast={idx === activities.length - 1}
+            onEdit={() => setEditingId(activity.id)}
+            onDelete={() => handleDelete(activity.id)}
+            onMoveUp={() => handleMove(activity.id, "up")}
+            onMoveDown={() => handleMove(activity.id, "down")}
+          />
+        )
+      )}
+
+      {showForm ? (
+        <ActivityForm
+          onSubmit={handleCreate}
+          onCancel={() => setShowForm(false)}
+        />
+      ) : (
+        canEdit && (
+          <button
+            onClick={() => setShowForm(true)}
+            className="w-full rounded-card border border-dashed border-surface-300 py-2.5 text-body-sm text-surface-400 hover:border-surface-400 hover:text-surface-600 transition-colors"
+          >
+            + 활동 추가
+          </button>
+        )
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 작업 내용
마크다운 textarea → 구조화 폼 전환. 웹에서 활동 CRUD + 순서 변경.

## 변경 사항
- **ActivityForm**: 카테고리/제목/시간/장소/메모/비용/예약상태 입력 폼
  - 현지 시각 자동 세팅 (30분 단위, 도시명 표시)
  - 필수 필드(유형, 제목, 시작, 종료) 빨간 `*` 표시
- **ActivityList**: 클라이언트 상태 관리, CRUD + reorder API 호출
- **ActivityCard**: 편집/삭제 버튼, ▲▼ 순서 변경 (hover 시 표시)
- **DayEditor 제거**: 마크다운 콘텐츠는 "메모" 섹션으로 읽기 전용 렌더링

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ✅ 통과 | `npx next build` |
| 타입 체크 | ✅ 통과 | `npx tsc --noEmit` |
| alpha 배포 | ✅ 확인 | 폼 표시, 시간 자동 세팅, CRUD 동작 |
| 문서 동기화 | ⬜ 해당없음 | |

Closes #125
Closes #126