### PR TITLE
feat(006): 마크다운 → 활동 변환 지원 — MCP 도구 + E2E

### DIFF
--- a/e2e/activity-crud.spec.ts
+++ b/e2e/activity-crud.spec.ts
@@ -1,0 +1,135 @@
+import { test, expect } from "@playwright/test";
+
+const BASE = process.env.E2E_BASE_URL ?? "https://trip.idean.me";
+const PAT = process.env.TRIP_PAT!;
+const TRIP_ID = 4;
+const DAY_ID = 43;
+const API = `${BASE}/api/trips/${TRIP_ID}/days/${DAY_ID}`;
+
+// Vercel Deployment Protection bypass
+const BYPASS_TOKEN = process.env.VERCEL_BYPASS_TOKEN;
+
+function headers() {
+  const h: Record<string, string> = {
+    Authorization: `Bearer ${PAT}`,
+    "Content-Type": "application/json",
+  };
+  if (BYPASS_TOKEN) {
+    h["x-vercel-protection-bypass"] = BYPASS_TOKEN;
+  }
+  return h;
+}
+
+test.describe("Activity CRUD E2E", () => {
+  let activityId: number;
+
+  test("GET /days/{dayId} — 단일 일자 조회", async ({ request }) => {
+    const res = await request.get(API, { headers: headers() });
+    // 이 엔드포인트는 #134에서 추가됨 — 프로덕션 머지 전에는 405
+    if (res.status() === 405) {
+      test.skip(true, "GET /days/{dayId} not deployed yet");
+      return;
+    }
+    expect(res.status()).toBe(200);
+    const day = await res.json();
+    expect(day.id).toBe(DAY_ID);
+    expect(day).toHaveProperty("content");
+    expect(day).toHaveProperty("activities");
+  });
+
+  test("POST /activities — 활동 생성", async ({ request }) => {
+    const res = await request.post(`${API}/activities`, {
+      headers: headers(),
+      data: {
+        category: "SIGHTSEEING",
+        title: "E2E 테스트 관광",
+        startTime: "10:00",
+        endTime: "12:00",
+        location: "테스트 장소",
+        memo: "자동 테스트 https://example.com",
+        cost: 15,
+        currency: "EUR",
+        reservationStatus: "RECOMMENDED",
+      },
+    });
+    expect(res.status()).toBe(201);
+    const activity = await res.json();
+    expect(activity.title).toBe("E2E 테스트 관광");
+    expect(activity.category).toBe("SIGHTSEEING");
+    expect(activity.startTime).toBe("10:00");
+    expect(activity.location).toBe("테스트 장소");
+    activityId = activity.id;
+  });
+
+  test("GET /activities — 활동 목록 조회", async ({ request }) => {
+    const res = await request.get(`${API}/activities`, { headers: headers() });
+    expect(res.status()).toBe(200);
+    const activities = await res.json();
+    expect(activities.length).toBeGreaterThan(0);
+    const found = activities.find((a: { id: number }) => a.id === activityId);
+    expect(found).toBeTruthy();
+  });
+
+  test("PUT /activities/{id} — 활동 수정", async ({ request }) => {
+    const res = await request.put(`${API}/activities/${activityId}`, {
+      headers: headers(),
+      data: { title: "E2E 수정됨", memo: "수정 메모 https://test.com" },
+    });
+    expect(res.status()).toBe(200);
+    const updated = await res.json();
+    expect(updated.title).toBe("E2E 수정됨");
+    expect(updated.memo).toContain("https://test.com");
+  });
+
+  test("PATCH /activities reorder — 순서 변경", async ({ request }) => {
+    // 두 번째 활동 생성
+    const res2 = await request.post(`${API}/activities`, {
+      headers: headers(),
+      data: { category: "DINING", title: "E2E 식사", startTime: "13:00", endTime: "14:00" },
+    });
+    const second = await res2.json();
+
+    const res = await request.patch(`${API}/activities`, {
+      headers: headers(),
+      data: { orderedIds: [second.id, activityId] },
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    // 순서 확인
+    const listRes = await request.get(`${API}/activities`, { headers: headers() });
+    const list = await listRes.json();
+    expect(list[0].id).toBe(second.id);
+    expect(list[1].id).toBe(activityId);
+
+    // 두 번째 활동 정리
+    await request.delete(`${API}/activities/${second.id}`, { headers: headers() });
+  });
+
+  test("DELETE /activities/{id} — 활동 삭제", async ({ request }) => {
+    const res = await request.delete(`${API}/activities/${activityId}`, {
+      headers: headers(),
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    // 삭제 확인
+    const listRes = await request.get(`${API}/activities`, { headers: headers() });
+    const list = await listRes.json();
+    const found = list.find((a: { id: number }) => a.id === activityId);
+    expect(found).toBeFalsy();
+  });
+
+  test("GET /days/{dayId} — content 필드로 마크다운 확인", async ({ request }) => {
+    const res = await request.get(API, { headers: headers() });
+    if (res.status() === 405) {
+      test.skip(true, "GET /days/{dayId} not deployed yet");
+      return;
+    }
+    const day = await res.json();
+    expect(day.content).toBeTruthy();
+    expect(day.content.length).toBeGreaterThan(100);
+  });
+});

--- a/mcp/trip_mcp/planner.py
+++ b/mcp/trip_mcp/planner.py
@@ -8,7 +8,7 @@ logger = logging.getLogger("trip-mcp-server")
 
 
 def register_planner_tools(mcp: FastMCP) -> None:
-    """일정 관리 도구 10개를 FastMCP 서버에 등록한다."""
+    """일정 관리 도구 12개를 FastMCP 서버에 등록한다."""
 
     @mcp.tool()
     async def list_trips() -> str:
@@ -339,3 +339,60 @@ def register_planner_tools(mcp: FastMCP) -> None:
             return f"오류: {result['error']}"
 
         return f"활동 순서 변경 완료 ({len(activity_ids)}개)"
+
+    # ── 마크다운 변환 지원 ─────────────────────────────
+
+    @mcp.tool()
+    async def get_day_content(trip_id: int, day_id: int) -> str:
+        """일자의 전체 마크다운 콘텐츠를 조회한다. 활동 변환 시 원본 확인용.
+
+        Args:
+            trip_id: 여행 ID
+            day_id: 일자 ID (get_trip에서 확인)
+        """
+        result = await api_request("GET", f"/api/trips/{trip_id}/days/{day_id}")
+
+        if "error" in result:
+            return f"오류: {result['error']}"
+
+        content = result.get("content", "")
+        if not content:
+            return f"일자 ID {day_id}에 마크다운 콘텐츠가 없습니다."
+
+        activities = result.get("activities", [])
+        header = f"[Day ID: {day_id}] 활동: {len(activities)}개 | 마크다운: {len(content)}자\n"
+        return header + "---\n" + content
+
+    @mcp.tool()
+    async def clear_day_content(trip_id: int, day_id: int) -> str:
+        """일자의 마크다운 콘텐츠를 비운다. 활동 변환 완료 후 정리용.
+
+        주의: 활동이 0개인 상태에서는 실행할 수 없다 (데이터 유실 방지).
+
+        Args:
+            trip_id: 여행 ID
+            day_id: 일자 ID
+        """
+        # 먼저 활동 수 확인
+        day = await api_request("GET", f"/api/trips/{trip_id}/days/{day_id}")
+        if "error" in day:
+            return f"오류: {day['error']}"
+
+        activities = day.get("activities", [])
+        if not activities:
+            return "활동이 0개입니다. 먼저 create_activity로 활동을 추가한 뒤 실행하세요."
+
+        content = day.get("content", "")
+        if not content:
+            return "이미 마크다운 콘텐츠가 비어 있습니다."
+
+        result = await api_request(
+            "PUT",
+            f"/api/trips/{trip_id}/days/{day_id}",
+            json={"content": ""},
+        )
+
+        if "error" in result:
+            return f"오류: {result['error']}"
+
+        return f"마크다운 콘텐츠 삭제 완료 (일자 ID: {day_id}, 활동 {len(activities)}개 유지)"

--- a/mcp/trip_mcp/server.py
+++ b/mcp/trip_mcp/server.py
@@ -19,7 +19,7 @@ logger = logging.getLogger("trip-mcp-server")
 
 mcp = FastMCP("trip")
 
-# 도구 등록: 검색 8개 + CRUD 10개 = 18개
+# 도구 등록: 검색 8개 + CRUD 12개 = 20개
 register_search_tools(mcp)
 register_planner_tools(mcp)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "tailwindcss": "^3.4.19"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@types/node": "^20.19.39",
         "@types/pg": "^8.20.0",
         "@types/react": "^19.2.14",
@@ -1769,6 +1770,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@prisma/adapter-pg": {
@@ -7875,6 +7892,53 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "tailwindcss": "^3.4.19"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@types/node": "^20.19.39",
     "@types/pg": "^8.20.0",
     "@types/react": "^19.2.14",

--- a/src/app/api/trips/[id]/days/[dayId]/route.ts
+++ b/src/app/api/trips/[id]/days/[dayId]/route.ts
@@ -1,8 +1,34 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getAuthUserId, canEdit } from "@/lib/auth-helpers";
+import { getAuthUserId, getTripMember, canEdit } from "@/lib/auth-helpers";
 
 type Params = { params: Promise<{ id: string; dayId: string }> };
+
+export async function GET(request: Request, { params }: Params) {
+  const { id, dayId } = await params;
+  const tripId = parseInt(id);
+  const userId = await getAuthUserId();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const member = await getTripMember(tripId, userId);
+  if (!member) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const day = await prisma.day.findUnique({
+    where: { id: parseInt(dayId), tripId },
+    include: {
+      activities: { orderBy: [{ sortOrder: "asc" }, { startTime: "asc" }] },
+    },
+  });
+  if (!day) {
+    return NextResponse.json({ error: "Not Found" }, { status: 404 });
+  }
+
+  return NextResponse.json(day);
+}
 
 // T030: 일정 수정
 export async function PUT(request: Request, { params }: Params) {

--- a/src/app/trips/[id]/day/[dayId]/page.tsx
+++ b/src/app/trips/[id]/day/[dayId]/page.tsx
@@ -117,7 +117,21 @@ async function DbDayPage({ tripId, dayIdNum }: { tripId: number; dayIdNum: numbe
 
       {day.content && (
         <div className="space-y-2">
-          <h2 className="text-heading-sm font-semibold text-surface-700">메모</h2>
+          <div className="flex items-center justify-between">
+            <h2 className="text-heading-sm font-semibold text-surface-700">레거시 메모</h2>
+          </div>
+          {member.role !== "GUEST" && (
+            <div className="flex items-start gap-2 rounded-card border border-sky-200 bg-sky-50 px-3 py-2 text-body-sm text-sky-700">
+              <span className="shrink-0">💡</span>
+              <span>
+                이 메모를 활동으로 변환하려면 Claude Desktop에서{" "}
+                <code className="rounded bg-sky-100 px-1 py-0.5 text-[11px]">
+                  get_day_content → create_activity × N → clear_day_content
+                </code>{" "}
+                순서로 요청하세요.
+              </span>
+            </div>
+          )}
           <div
             className="prose prose-sm max-w-none rounded-card border border-surface-200 p-4"
             dangerouslySetInnerHTML={{ __html: contentHtml }}


### PR DESCRIPTION
## 작업 내용
기존 Day.content 마크다운을 Activity 단위로 변환하기 위한 MCP 도구 + 안내 UI.

## 변경 사항
- **MCP 도구 2개 추가** (18→20개)
  - `get_day_content`: 일자 전체 마크다운 조회
  - `clear_day_content`: 변환 완료 후 마크다운 정리 (활동 0개 시 차단)
- **API**: GET `/api/trips/{id}/days/{dayId}` 엔드포인트 추가
- **웹 UI**: 레거시 메모 섹션에 구조화 변환 안내 배너
- **E2E**: Playwright Activity CRUD 7케이스

## 변환 흐름
```
Claude Desktop에서:
get_day_content(trip_id, day_id)
→ AI가 마크다운 파싱
→ create_activity × N
→ clear_day_content(trip_id, day_id)
```

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ✅ 통과 | `npx next build` |
| 타입 체크 | ✅ 통과 | `npx tsc --noEmit` |
| MCP 도구 | ✅ 20개 | Python 검증 |
| E2E | ✅ 5 pass, 2 skip | Playwright (skip: 미배포 GET /days) |
| alpha 배포 | ✅ 확인 | 안내 배너 표시 |

Closes #134