### PR TITLE
docs(006): CHANGELOG.md 도입 + README v2.1 + v2.1.0 릴리스

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.1.0] - 2026-04-16
+
+### Added
+- **Activity 데이터 모델**: ActivityCategory/ReservationStatus enum + Activity 테이블 (#124)
+- **Activity CRUD API**: GET/POST/PATCH/PUT/DELETE 엔드포인트 5개 (#127)
+- **MCP 도구 확장**: create/update/delete/reorder_activity, get_day_content, clear_day_content — 14→20개 (#127, #134)
+- **ActivityCard 컴포넌트**: 카테고리/시간/장소/비용/예약상태 카드 뷰 (#127)
+- **ActivityForm 컴포넌트**: 구조화 입력 폼, 현지 시각 자동 세팅, 필수 필드 표시 (#125)
+- **ActivityList 컴포넌트**: CRUD + 순서 변경(▲▼) 클라이언트 상태 관리 (#125)
+- **memo URL 자동 링크**: 메모 내 URL을 클릭 가능한 링크로 렌더링 (새 창) (#125)
+- **마크다운 변환 지원**: get_day_content + clear_day_content MCP 도구, 변환 안내 배너 (#134)
+- **테스트 인프라**: Vitest + React Testing Library + Playwright E2E — 61케이스 (#141)
+- **alpha 환경**: alpha.trip.idean.me 프리뷰 도메인 구성 (#127)
+- **OpenAPI v2.1.0**: Activity 스키마 + 5개 엔드포인트 문서화 (#127)
+- **GET /days/{dayId} API**: 단일 일자 상세 조회 (활동 포함) (#134)
+
+### Changed
+- **일자 상세 페이지**: DayEditor 제거 → ActivityList + 읽기 전용 메모 (#125)
+- **get_trip MCP**: 일자별 활동 수 표시 (#127)
+
+### Fixed
+- **라우트 충돌**: `[id]`/`[slug]` 동적 라우트 통합 — dev 서버 크래시 해소 (#127)
+- **인증 리다이렉트**: 로그인 상태에서 /auth/signin 접근 시 홈으로 (#127)
+- **AUTH_URL Preview 스코프**: 프리뷰 배포 인증 정상화 (#127)
+
+## [2.0.1] - 2026-04-14
+
+### Fixed
+- PAT 인증 수정 + UI 개선
+
+## [2.0.0] - 2026-04-14
+
+### Added
+- Next.js 15 웹앱 (App Router, SSR)
+- Auth.js v5 Google OAuth + PAT 인증
+- Neon Postgres + Prisma 7
+- MCP 14개 도구 (검색 8 + CRUD 6)
+- OpenAPI 3.0 + Scalar 문서 뷰어
+- 여행/일자/멤버 CRUD API
+- 초대 링크 (JWT) + 소유권 이전
+- macOS 키체인 통합 설치 스크립트

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Trip Planner
 
-여행 서포터/플래너 — MCP 검색 + 일정 관리 + Next.js 웹앱 + Neon Postgres
+여행 서포터/플래너 — MCP 검색 + 구조화 일정 관리 + Next.js 웹앱 + Neon Postgres
 
 ## 주요 기능
 
-- **MCP 플러그인**: Claude Desktop/Code에서 숙소, 항공편, 관광지 검색 및 일정 CRUD
+- **구조화 활동 관리**: 카테고리/시간/장소/비용/예약상태를 개별 필드로 관리
+- **MCP 플러그인**: Claude Desktop/Code에서 숙소, 항공편, 관광지 검색 및 활동 CRUD
 - **API 인증**: PAT(Personal Access Token) 기반 외부 클라이언트 인증
 - **API 문서**: OpenAPI 3.0 스펙 + Scalar 인터랙티브 뷰어 (/docs)
 - **캘린더 연동**: 여행 일정을 Apple 캘린더에 자동 등록 (iCloud 공유 지원)
@@ -17,28 +18,32 @@
 trip-planner/
 ├── src/                      # Next.js 웹앱 (Vercel 배포)
 │   ├── app/
+│   │   ├── api/trips/        # 여행/일자/활동/멤버 API
 │   │   ├── api/tokens/       # PAT CRUD API
-│   │   ├── api/trips/        # 여행/일자/멤버 API
 │   │   ├── api/openapi/      # OpenAPI JSON
 │   │   ├── settings/         # PAT 관리 UI
 │   │   └── docs/             # API 문서 뷰어
+│   ├── components/
+│   │   ├── ActivityCard.tsx   # 활동 카드 (카테고리/시간/비용)
+│   │   ├── ActivityForm.tsx   # 활동 입력 폼 (현지 시각 자동)
+│   │   └── ActivityList.tsx   # 활동 목록 + CRUD 관리
 │   └── lib/
 │       ├── auth-helpers.ts   # 세션 + PAT 인증
 │       ├── openapi.ts        # OpenAPI 스펙
 │       └── prisma.ts         # Prisma 클라이언트
 ├── mcp/                      # MCP 서버 (PyPI 배포, 로컬 실행)
 │   └── trip_mcp/
-│       ├── server.py         # 통합 엔트리포인트 (14개 도구)
+│       ├── server.py         # 통합 엔트리포인트 (20개 도구)
 │       ├── search.py         # 검색 도구 8개 (RapidAPI)
-│       ├── planner.py        # 일정 관리 도구 6개 (웹 API)
+│       ├── planner.py        # 일정 관리 도구 12개 (웹 API)
 │       ├── rapidapi.py       # RapidAPI 클라이언트
 │       └── web_client.py     # 웹 API 클라이언트 (PAT 인증)
 ├── prisma/
-│   ├── schema.prisma         # DB 스키마 (Auth.js + App + PAT)
+│   ├── schema.prisma         # DB 스키마 (Auth.js + App + Activity + PAT)
 │   └── migrations/
+├── e2e/                      # Playwright E2E 테스트
+├── tests/                    # 단위 테스트 (Vitest + pytest)
 ├── trips/                    # 여행 일정 데이터 (레거시 마크다운)
-├── scripts/                  # 설치 스크립트
-├── tests/                    # Python 테스트
 ├── specs/                    # 설계 문서 (스펙, 플랜, 태스크)
 └── pyproject.toml            # MCP 서버 (PyPI)
 ```
@@ -69,10 +74,10 @@ Claude Desktop 또는 Claude Code에서:
 "바르셀로나 6월 16일~20일 4박 숙소 추천해줘"
 "포르투에서 리스본 가는 6월 10일 항공편 찾아줘"
 
-# 일정 관리 (PAT 설정 필요)
+# 활동 관리 (PAT 설정 필요)
 "내 여행 목록 보여줘"
-"3일차에 벨렘탑 추가해줘"
-"1일차 숙소 정보 업데이트해줘"
+"3일차에 벨렘탑 관광 추가해줘 (09:00~11:00)"
+"1일차 마크다운을 활동으로 변환해줘"
 ```
 
 ### Claude Code 등록
@@ -81,7 +86,7 @@ Claude Desktop 또는 Claude Code에서:
 claude mcp add trip -s user -- ~/.trip-planner/.venv/bin/python -m trip_mcp.server
 ```
 
-## MCP 도구 (14개)
+## MCP 도구 (20개)
 
 | 카테고리 | 도구 | 설명 |
 |---------|------|------|
@@ -94,11 +99,17 @@ claude mcp add trip -s user -- ~/.trip-planner/.venv/bin/python -m trip_mcp.serv
 | | search_attractions | 관광지 목록 (입장료, 리뷰) |
 | | get_attraction_details | 관광지 상세 (주소, 포함 사항) |
 | 일정 | list_trips | 내 여행 목록 |
-| | get_trip | 여행 상세 + 일자 목록 |
+| | get_trip | 여행 상세 + 일자별 활동 수 |
 | | create_day | 일자 추가 |
 | | update_day | 일자 수정 |
 | | delete_day | 일자 삭제 |
 | | list_members | 멤버 목록 |
+| 활동 | create_activity | 활동 추가 (카테고리/시간/장소/비용) |
+| | update_activity | 활동 수정 |
+| | delete_activity | 활동 삭제 |
+| | reorder_activities | 활동 순서 변경 |
+| 변환 | get_day_content | 일자 마크다운 전체 조회 |
+| | clear_day_content | 변환 후 마크다운 정리 |
 
 ## API 문서
 
@@ -112,26 +123,21 @@ claude mcp add trip -s user -- ~/.trip-planner/.venv/bin/python -m trip_mcp.serv
 npm install
 npm run dev                    # http://localhost:3000
 
+# 테스트
+npm test                       # Vitest (API + 컴포넌트)
+npm run test:coverage          # 커버리지 리포트
+npx playwright test            # E2E 테스트
+
 # MCP 서버 개발
 cd mcp/
 python3 -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
-pytest tests/unit/ -v
+pytest tests/ -v
 
 # PAT 생성 (MCP 테스트용)
 # 1) http://localhost:3000/settings 에서 토큰 생성
 # 2) TRIP_PLANNER_PAT=<token> python -m trip_mcp.server
 ```
-
-## 로드맵
-
-| 마일스톤 | 목표 | 상태 |
-|----------|------|------|
-| [v2.1: 일정 구조화](https://github.com/idean3885/trip-planner/milestone/7) | Activity 스키마 + 구조화 폼 + 컴포넌트 렌더링 | 예정 |
-| [v2.2: 원클릭 인증](https://github.com/idean3885/trip-planner/milestone/8) | OAuth CLI 자동 로그인 + 만료 시 자동 재인증 | 예정 |
-| [v2.x: UX 폴리싱](https://github.com/idean3885/trip-planner/milestone/9) | 네비게이션 IA, 모바일 터치, 접근성 | 상시 |
-
-각 마일스톤은 독립적으로 진행 가능합니다. 이슈 단위로 관리하며, 마일스톤 간 순서 의존은 없습니다.
 
 ## 기술 스택
 
@@ -139,4 +145,5 @@ pytest tests/unit/ -v
 - **웹앱**: Next.js 15 (App Router, SSR), Auth.js v5, Tailwind CSS v3
 - **DB**: Neon Postgres, Prisma 7 (@prisma/adapter-pg TCP)
 - **인증**: Google OAuth (웹), PAT (외부 클라이언트)
+- **테스트**: Vitest, React Testing Library, Playwright, pytest
 - **배포**: Vercel (웹앱), PyPI (MCP)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trip-planner-mcp"
-version = "2.0.0"
-description = "여행 숙소, 항공편, 관광지 검색 + 일정 관리 MCP 서버"
+version = "2.1.0"
+description = "여행 숙소, 항공편, 관광지 검색 + 구조화 활동 관리 MCP 서버 (20개 도구)"
 requires-python = ">=3.10"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
## 작업 내용
v2.1 마일스톤 마무리 — 변경 이력 + 문서 갱신 + 버전 태깅.

## 변경 사항
- **CHANGELOG.md**: Keep a Changelog 형식 도입, v2.0.0/v2.0.1 소급 + v2.1.0 전체 기록
- **README.md**: 구조화 활동 기능 반영, MCP 14→20개, 테스트 명령 추가, 로드맵 섹션 제거
- **pyproject.toml**: version 2.1.0 + description 업데이트

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ⬜ 해당없음 | 문서 변경만 |
| 문서 동기화 | ✅ 완료 | CHANGELOG, README, pyproject |

Closes #135