### PR TITLE
release: v2.2.0 — 원클릭 인증 + Git Flow Lite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2026-04-16
+
+### Added
+- **OAuth CLI 인증**: install.sh에서 브라우저 Google 로그인 1회로 PAT 자동 발급·저장 (#128)
+- **MCP 런타임 재인증**: 토큰 만료(401) 시 브라우저 자동 재인증 + 요청 재시도 (#129)
+- **PAT 미설정 초기 인증**: MCP 첫 호출 시 토큰 없어도 브라우저 인증으로 자동 발급
+- **auto-release.yml**: 태그 push 시 CHANGELOG 기반 GitHub Release 자동 생성
+- **Git Flow Lite 전략**: main(production) + develop(dev) + feature 브랜치 전략 도입 (#148)
+- **dev.trip.idean.me**: develop 브랜치 전용 알파 배포 도메인
+
+### Changed
+- **auto-tag.yml**: lightweight → annotated 태그 전환
+- **install.sh**: 수동 PAT 입력 → 브라우저 OAuth 우선 (수동은 폴백)
+- **token-helpers.ts**: createPAT 공유 헬퍼 추출, /api/tokens 리팩터
+- **web_client.py**: asyncio.Lock 기반 동시 재인증 방지, 키체인 자동 갱신
+
 ## [2.1.0] - 2026-04-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,149 +1,52 @@
-# Trip Planner
+# 우리의 여행 ✈️
 
-여행 서포터/플래너 — MCP 검색 + 구조화 일정 관리 + Next.js 웹앱 + Neon Postgres
+AI 에이전트가 숙소, 항공편, 관광지를 검색하고 일정을 관리해주는 여행 플래너입니다.
 
-## 주요 기능
+**[trip.idean.me](https://trip.idean.me)** 에서 바로 사용할 수 있습니다.
 
-- **구조화 활동 관리**: 카테고리/시간/장소/비용/예약상태를 개별 필드로 관리
-- **MCP 플러그인**: Claude Desktop/Code에서 숙소, 항공편, 관광지 검색 및 활동 CRUD
-- **API 인증**: PAT(Personal Access Token) 기반 외부 클라이언트 인증
-- **API 문서**: OpenAPI 3.0 스펙 + Scalar 인터랙티브 뷰어 (/docs)
-- **캘린더 연동**: 여행 일정을 Apple 캘린더에 자동 등록 (iCloud 공유 지원)
-- **일정 웹앱**: DB 기반 일정을 모바일 친화적 웹페이지로 공유
-- **macOS 키체인**: API 키, PAT를 안전하게 관리
+## 이렇게 쓰세요
 
-## 프로젝트 구조
+### 1. 웹에서 일정 관리
 
-```
-trip-planner/
-├── src/                      # Next.js 웹앱 (Vercel 배포)
-│   ├── app/
-│   │   ├── api/trips/        # 여행/일자/활동/멤버 API
-│   │   ├── api/tokens/       # PAT CRUD API
-│   │   ├── api/openapi/      # OpenAPI JSON
-│   │   ├── settings/         # PAT 관리 UI
-│   │   └── docs/             # API 문서 뷰어
-│   ├── components/
-│   │   ├── ActivityCard.tsx   # 활동 카드 (카테고리/시간/비용)
-│   │   ├── ActivityForm.tsx   # 활동 입력 폼 (현지 시각 자동)
-│   │   └── ActivityList.tsx   # 활동 목록 + CRUD 관리
-│   └── lib/
-│       ├── auth-helpers.ts   # 세션 + PAT 인증
-│       ├── openapi.ts        # OpenAPI 스펙
-│       └── prisma.ts         # Prisma 클라이언트
-├── mcp/                      # MCP 서버 (PyPI 배포, 로컬 실행)
-│   └── trip_mcp/
-│       ├── server.py         # 통합 엔트리포인트 (20개 도구)
-│       ├── search.py         # 검색 도구 8개 (RapidAPI)
-│       ├── planner.py        # 일정 관리 도구 12개 (웹 API)
-│       ├── rapidapi.py       # RapidAPI 클라이언트
-│       └── web_client.py     # 웹 API 클라이언트 (PAT 인증)
-├── prisma/
-│   ├── schema.prisma         # DB 스키마 (Auth.js + App + Activity + PAT)
-│   └── migrations/
-├── e2e/                      # Playwright E2E 테스트
-├── tests/                    # 단위 테스트 (Vitest + pytest)
-├── trips/                    # 여행 일정 데이터 (레거시 마크다운)
-├── specs/                    # 설계 문서 (스펙, 플랜, 태스크)
-└── pyproject.toml            # MCP 서버 (PyPI)
-```
+[trip.idean.me](https://trip.idean.me)에 접속하여 Google 계정으로 로그인하면 바로 사용 가능합니다.
 
-## 설치 / 업데이트 (맥북, 1줄)
+- 여행 생성 → 날짜별 일정 추가 → 활동(관광/식사/이동/숙소) 등록
+- 동행자 초대 — 링크 공유로 함께 일정 확인
+- 모바일 최적화 — 여행 중 스마트폰으로 일정 확인
 
-신규 설치와 기존 v1 업데이트 모두 동일한 명령입니다:
+### 2. AI 에이전트로 검색 + 자동 일정 생성
 
+[Claude Desktop](https://claude.ai/download) 또는 [Claude Code](https://claude.ai/claude-code)에서 AI가 대신 검색하고 일정을 만들어줍니다.
+
+**설치 (맥북, 1줄)**:
 ```bash
 curl -sSL https://raw.githubusercontent.com/idean3885/trip-planner/main/scripts/install.sh | bash
 ```
+설치 중 브라우저가 열리면 Google 로그인만 하세요. 토큰이 자동 저장됩니다.
 
-실행 후 **Claude Desktop을 재시작**하면 바로 사용 가능합니다.
-
-자동 처리 항목:
-- RapidAPI 키 → 키체인 저장 (검색용, 이미 있으면 스킵)
-- Trip Planner PAT → 키체인 저장 (일정 관리용, 선택)
-- Claude Desktop MCP 설정 자동 등록/업데이트
-- Apple 캘린더 MCP 자동 설치 (macOS 전용)
-- v1 → v2 자동 마이그레이션 (구 서버 설정 제거, GitHub PAT 정리)
-
-## 사용법
-
-Claude Desktop 또는 Claude Code에서:
-
+**사용 예시** — Claude에게 말하듯 입력하면 됩니다:
 ```
-# 검색
 "바르셀로나 6월 16일~20일 4박 숙소 추천해줘"
 "포르투에서 리스본 가는 6월 10일 항공편 찾아줘"
-
-# 활동 관리 (PAT 설정 필요)
 "내 여행 목록 보여줘"
 "3일차에 벨렘탑 관광 추가해줘 (09:00~11:00)"
-"1일차 마크다운을 활동으로 변환해줘"
 ```
 
-### Claude Code 등록
+AI가 할 수 있는 것 (20개 도구):
 
-```bash
-claude mcp add trip -s user -- ~/.trip-planner/.venv/bin/python -m trip_mcp.server
-```
+| 할 수 있는 것 | 예시 |
+|--------------|------|
+| 숙소 검색 | 도시, 날짜, 인원 기준 호텔 추천 (가격/리뷰/할인) |
+| 항공편 검색 | 출발/도착 도시, 날짜 기준 항공편 비교 |
+| 관광지 검색 | 도시 기반 관광지 목록 (입장료/리뷰/예약 링크) |
+| 일정 관리 | 여행 생성, 일자 추가, 활동 등록/수정/삭제/순서 변경 |
+| 마크다운 변환 | 기존 텍스트 일정을 구조화 활동으로 변환 |
 
-## MCP 도구 (20개)
+## 링크
 
-| 카테고리 | 도구 | 설명 |
-|---------|------|------|
-| 숙소 | search_destinations | 도시/목적지 검색 |
-| | get_hotels | 호텔 목록 (한화, 리뷰, 할인) |
-| | get_hotel_details | 호텔 상세 (시설, 예약 링크) |
-| 항공편 | search_flight_destinations | 공항/도시 검색 |
-| | search_flights | 항공편 목록 (가격, 경유, 수하물) |
-| 관광지 | search_attraction_locations | 관광지 위치 검색 |
-| | search_attractions | 관광지 목록 (입장료, 리뷰) |
-| | get_attraction_details | 관광지 상세 (주소, 포함 사항) |
-| 일정 | list_trips | 내 여행 목록 |
-| | get_trip | 여행 상세 + 일자별 활동 수 |
-| | create_day | 일자 추가 |
-| | update_day | 일자 수정 |
-| | delete_day | 일자 삭제 |
-| | list_members | 멤버 목록 |
-| 활동 | create_activity | 활동 추가 (카테고리/시간/장소/비용) |
-| | update_activity | 활동 수정 |
-| | delete_activity | 활동 삭제 |
-| | reorder_activities | 활동 순서 변경 |
-| 변환 | get_day_content | 일자 마크다운 전체 조회 |
-| | clear_day_content | 변환 후 마크다운 정리 |
-
-## API 문서
-
-- **웹 뷰어**: https://trip.idean.me/docs
-- **OpenAPI JSON**: https://trip.idean.me/api/openapi
-
-## 개발자용
-
-```bash
-# 웹앱 개발
-npm install
-npm run dev                    # http://localhost:3000
-
-# 테스트
-npm test                       # Vitest (API + 컴포넌트)
-npm run test:coverage          # 커버리지 리포트
-npx playwright test            # E2E 테스트
-
-# MCP 서버 개발
-cd mcp/
-python3 -m venv .venv && source .venv/bin/activate
-pip install -e ".[dev]"
-pytest tests/ -v
-
-# PAT 생성 (MCP 테스트용)
-# 1) http://localhost:3000/settings 에서 토큰 생성
-# 2) TRIP_PLANNER_PAT=<token> python -m trip_mcp.server
-```
-
-## 기술 스택
-
-- **MCP 서버**: Python 3.10+, FastMCP, httpx, macOS Keychain
-- **웹앱**: Next.js 15 (App Router, SSR), Auth.js v5, Tailwind CSS v3
-- **DB**: Neon Postgres, Prisma 7 (@prisma/adapter-pg TCP)
-- **인증**: Google OAuth (웹), PAT (외부 클라이언트)
-- **테스트**: Vitest, React Testing Library, Playwright, pytest
-- **배포**: Vercel (웹앱), PyPI (MCP)
+| | |
+|---|---|
+| 웹앱 | [trip.idean.me](https://trip.idean.me) |
+| API 문서 | [trip.idean.me/docs](https://trip.idean.me/docs) |
+| 개발 문서 | [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) |
+| 변경 이력 | [CHANGELOG.md](CHANGELOG.md) |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,139 @@
+# 개발 가이드
+
+## 기술 스택
+
+- **MCP 서버**: Python 3.10+, FastMCP, httpx, macOS Keychain
+- **웹앱**: Next.js 15 (App Router, SSR), Auth.js v5, Tailwind CSS v3
+- **DB**: Neon Postgres, Prisma 7 (@prisma/adapter-pg TCP)
+- **인증**: Google OAuth (웹), PAT (외부 클라이언트), OAuth CLI (자동 발급)
+- **테스트**: Vitest, React Testing Library, Playwright, pytest
+- **배포**: Vercel (웹앱), PyPI (MCP)
+
+## 프로젝트 구조
+
+```
+trip-planner/
+├── src/                      # Next.js 웹앱 (Vercel 배포)
+│   ├── app/
+│   │   ├── api/trips/        # 여행/일자/활동/멤버 API
+│   │   ├── api/tokens/       # PAT CRUD API
+│   │   ├── api/auth/cli/     # OAuth CLI 인증 엔드포인트
+│   │   ├── api/openapi/      # OpenAPI JSON
+│   │   ├── settings/         # PAT 관리 UI
+│   │   └── docs/             # API 문서 뷰어 (Scalar)
+│   ├── components/
+│   │   ├── ActivityCard.tsx   # 활동 카드 (카테고리/시간/비용)
+│   │   ├── ActivityForm.tsx   # 활동 입력 폼
+│   │   └── ActivityList.tsx   # 활동 목록 + CRUD
+│   └── lib/
+│       ├── auth-helpers.ts   # 세션 + PAT 듀얼 인증
+│       ├── token-helpers.ts  # PAT 생성 공유 헬퍼
+│       ├── openapi.ts        # OpenAPI 스펙
+│       └── prisma.ts         # Prisma 클라이언트
+├── mcp/                      # MCP 서버 (PyPI 배포)
+│   └── trip_mcp/
+│       ├── server.py         # 통합 엔트리포인트 (20개 도구)
+│       ├── search.py         # 검색 도구 8개 (RapidAPI)
+│       ├── planner.py        # 일정 관리 도구 12개 (웹 API)
+│       ├── rapidapi.py       # RapidAPI 클라이언트
+│       └── web_client.py     # 웹 API 클라이언트 (PAT 인증 + 자동 재인증)
+├── prisma/schema.prisma      # DB 스키마
+├── tests/                    # 단위 테스트 (Vitest + pytest)
+├── e2e/                      # Playwright E2E 테스트
+├── specs/                    # 설계 문서 (speckit)
+└── .github/workflows/        # CI/CD (auto-tag, auto-release, pypi-publish)
+```
+
+## 로컬 개발
+
+```bash
+# 웹앱
+npm install
+npm run dev                    # http://localhost:3000
+
+# MCP 서버
+cd mcp/
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"
+
+# Claude Code에 MCP 등록
+claude mcp add trip -s user -- ~/.trip-planner/.venv/bin/python -m trip_mcp.server
+```
+
+## 테스트
+
+```bash
+npm test                       # Vitest (API + 컴포넌트)
+npm run test:coverage          # 커버리지 리포트
+npx playwright test            # E2E 테스트
+pytest tests/ -v               # MCP 서버 테스트
+npx tsc --noEmit               # 타입 체크
+```
+
+## 배포 환경
+
+| 환경 | 도메인 | 브랜치 | 용도 |
+|------|--------|--------|------|
+| Production | [trip.idean.me](https://trip.idean.me) | main | 정식 릴리즈 |
+| Dev | [dev.trip.idean.me](https://dev.trip.idean.me) | develop | 마일스톤 통합 테스트 |
+| Preview | PR별 자동 생성 | feature/* | 피처 단위 프리뷰 |
+
+## Git 전략: Git Flow Lite
+
+```
+main ────────────●───────────────●──── (production 릴리즈 + 버전 태그)
+                 ↑               ↑
+develop ──●──●──●───●──●──●──●──● ── (dev 통합 배포)
+          ↑  ↑  ↑   ↑  ↑  ↑  ↑
+        feature branches (NNN-short-name)
+```
+
+- **feature → develop PR**: 피처 개발. dev 환경에서 통합 테스트.
+- **develop → main PR**: 마일스톤 완료 시 릴리즈. CI가 자동으로 태그 + Release + PyPI.
+
+## 릴리즈 프로세스
+
+**수동 (develop에서)**:
+1. `CHANGELOG.md`에 새 버전 섹션 추가
+2. `pyproject.toml` version 범프
+3. develop → main PR → 머지
+
+**CI 자동 (main 머지 후)**:
+4. `auto-tag.yml`: annotated 태그 생성
+5. `auto-release.yml`: CHANGELOG 추출 → GitHub Release
+6. `pypi-publish.yml`: 테스트 → PyPI 배포
+
+**버전 범프 기준 (SemVer)**:
+- MAJOR: 호환성 깨지는 변경
+- MINOR: 기능 추가
+- PATCH: 버그 수정, 문서 수정
+
+## API 문서
+
+- **웹 뷰어**: [trip.idean.me/docs](https://trip.idean.me/docs)
+- **OpenAPI JSON**: [trip.idean.me/api/openapi](https://trip.idean.me/api/openapi)
+
+## MCP 도구 (20개)
+
+| 카테고리 | 도구 | 설명 |
+|---------|------|------|
+| 숙소 | search_destinations | 도시/목적지 검색 |
+| | get_hotels | 호텔 목록 (한화, 리뷰, 할인) |
+| | get_hotel_details | 호텔 상세 (시설, 예약 링크) |
+| 항공편 | search_flight_destinations | 공항/도시 검색 |
+| | search_flights | 항공편 목록 (가격, 경유, 수하물) |
+| 관광지 | search_attraction_locations | 관광지 위치 검색 |
+| | search_attractions | 관광지 목록 (입장료, 리뷰) |
+| | get_attraction_details | 관광지 상세 (주소, 포함 사항) |
+| 일정 | list_trips | 내 여행 목록 |
+| | get_trip | 여행 상세 + 일자별 활동 수 |
+| | create_day | 일자 추가 |
+| | update_day | 일자 수정 |
+| | delete_day | 일자 삭제 |
+| | list_members | 멤버 목록 |
+| 활동 | create_activity | 활동 추가 (카테고리/시간/장소/비용) |
+| | update_activity | 활동 수정 |
+| | delete_activity | 활동 삭제 |
+| | reorder_activities | 활동 순서 변경 |
+| 변환 | get_day_content | 일자 마크다운 전체 조회 |
+| | clear_day_content | 변환 후 마크다운 정리 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trip-planner-mcp"
-version = "2.1.0"
+version = "2.2.0"
 description = "여행 숙소, 항공편, 관광지 검색 + 구조화 활동 관리 MCP 서버 (20개 도구)"
 requires-python = ">=3.10"
 license = "MIT"

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1,28 +1,9 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useRef } from "react";
+import Script from "next/script";
 
 export default function DocsPage() {
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const script = document.createElement("script");
-    script.src = "https://cdn.jsdelivr.net/npm/@scalar/api-reference";
-    script.onload = () => {
-      if (containerRef.current && containerRef.current.children.length === 0) {
-        const el = document.createElement("api-reference");
-        el.setAttribute("data-url", "/api/openapi");
-        el.setAttribute("data-configuration", JSON.stringify({
-          theme: "default",
-          hideDownloadButton: true,
-        }));
-        containerRef.current.appendChild(el);
-      }
-    };
-    document.head.appendChild(script);
-  }, []);
-
   return (
     <div className="min-h-screen -mx-4 -mt-6">
       <div className="px-4 pt-4 pb-2 flex items-center gap-2 text-body-sm text-surface-500">
@@ -30,7 +11,15 @@ export default function DocsPage() {
         <span>/</span>
         <span className="text-surface-700">API 문서</span>
       </div>
-      <div ref={containerRef} />
+      <div
+        id="api-reference"
+        data-url="/api/openapi"
+        data-configuration={JSON.stringify({
+          theme: "default",
+          hideDownloadButton: true,
+        })}
+      />
+      <Script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference" />
     </div>
   );
 }


### PR DESCRIPTION
## v2.2.0 Production Release

develop → main 머지. 새 Git Flow Lite 전략의 첫 프로덕션 릴리즈.

### Added
- **OAuth CLI 인증**: install.sh에서 브라우저 Google 로그인 1회로 PAT 자동 발급 (#128)
- **MCP 런타임 재인증**: 토큰 만료(401) 시 브라우저 자동 재인증 + 요청 재시도 (#129)
- **PAT 미설정 초기 인증**: MCP 첫 호출 시 토큰 없어도 브라우저 인증으로 자동 발급
- **auto-release.yml**: 태그 push 시 CHANGELOG 기반 GitHub Release 자동 생성
- **Git Flow Lite**: main(production) + develop(dev) + feature 브랜치 전략 (#148)
- **dev.trip.idean.me**: develop 브랜치 전용 dev 배포 도메인
- **docs/DEVELOPMENT.md**: 개발 문서 분리

### Changed
- **README.md**: 개발자 중심 → 사용자/기획자 대문으로 전면 개편
- **auto-tag.yml**: lightweight → annotated 태그
- **install.sh**: 수동 PAT 입력 → 브라우저 OAuth 우선 (수동 폴백)
- **token-helpers.ts**: createPAT 공유 헬퍼 추출

### Fixed
- **/docs 빈 화면**: Scalar CDN 스크립트 로딩 순서 버그 수정

## CI 자동화 확인
이 PR 머지 후 auto-tag → auto-release → pypi-publish 파이프라인이 동작합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)