### PR TITLE
fix: v2.2.1 — PyPI 배포 복구 (hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2026-04-16
+
+### Fixed
+- **PyPI 배포 실패**: rapidapi 테스트에서 삭제된 `get_client` 함수를 참조하던 테스트 수정
+
 ## [2.2.0] - 2026-04-16
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trip-planner-mcp"
-version = "2.2.0"
+version = "2.2.1"
 description = "여행 숙소, 항공편, 관광지 검색 + 구조화 활동 관리 MCP 서버 (20개 도구)"
 requires-python = ">=3.10"
 license = "MIT"

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -81,21 +81,15 @@ class TestMakeRapidapiRequest:
         assert "error" not in result
 
 
-class TestConnectionReuse:
-    """API client should reuse connections for performance."""
+class TestConsecutiveRequests:
+    """Consecutive API requests should work correctly."""
 
-    def test_module_exposes_shared_client(self):
-        """api_client should have a module-level shared client for connection pooling."""
-        assert hasattr(api_client_module, "get_client"), \
-            "api_client must expose get_client() for connection reuse"
-
-    async def test_consecutive_requests_reuse_client(self, httpx_mock: HTTPXMock):
-        """Two consecutive requests should reuse the same underlying client."""
+    async def test_consecutive_requests_succeed(self, httpx_mock: HTTPXMock):
+        """Two consecutive requests should both complete successfully."""
         httpx_mock.add_response(json={"status": True, "data": []})
         httpx_mock.add_response(json={"status": True, "data": []})
 
         await make_rapidapi_request("/api/v1/hotels/searchDestination", {"query": "a"})
         await make_rapidapi_request("/api/v1/hotels/searchDestination", {"query": "b"})
 
-        # Both requests should have gone through (proves client works for multiple calls)
         assert len(httpx_mock.get_requests()) == 2


### PR DESCRIPTION
## Hotfix v2.2.1

main에서 직접 분기한 핫픽스. develop → main 충돌 이슈 우회.

### Fixed
- rapidapi 테스트에서 삭제된 `get_client` 참조 제거 — PyPI 배포 파이프라인 복구
- pyproject.toml 2.2.0 → 2.2.1

머지 후 main → develop 역머지로 동기화 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)