### PR TITLE
fix: v2.2.2 핫픽스 프로세스 정립 + 하네스 develop 보호

### DIFF
--- a/.specify/scripts/bash/enforce-speckit.sh
+++ b/.specify/scripts/bash/enforce-speckit.sh
@@ -55,10 +55,10 @@ esac
 # 4) 브랜치 확인
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
 
-# main/master에서 소스 편집 차단
-if [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
-  echo "BLOCKED: main 브랜치에서 소스 파일 편집은 허용되지 않습니다." >&2
-  echo "→ /devex:flow 로 피처 브랜치를 생성한 후 작업하세요." >&2
+# main/master/develop에서 소스 편집 차단
+if [[ "$BRANCH" == "main" || "$BRANCH" == "master" || "$BRANCH" == "develop" ]]; then
+  echo "BLOCKED: ${BRANCH} 브랜치에서 소스 파일 편집은 허용되지 않습니다." >&2
+  echo "→ 피처 브랜치를 생성한 후 작업하세요." >&2
   exit 2
 fi
 

--- a/.specify/scripts/bash/enforce-submit.sh
+++ b/.specify/scripts/bash/enforce-submit.sh
@@ -36,9 +36,9 @@ fi
 # 브랜치 확인
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
 
-# main에서의 커밋은 speckit-gate가 소스 편집을 이미 차단하므로,
+# main/develop에서의 커밋은 speckit-gate가 소스 편집을 이미 차단하므로,
 # 여기서는 config/spec 파일 커밋을 허용
-if [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
+if [[ "$BRANCH" == "main" || "$BRANCH" == "master" || "$BRANCH" == "develop" ]]; then
   exit 0
 fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2] - 2026-04-16
+
+### Fixed
+- **핫픽스 프로세스**: main 직접 머지 금지, develop 경유 필수로 규칙 정립
+- **speckit 하네스**: develop 브랜치 소스 편집 차단 추가 (enforce-speckit.sh, enforce-submit.sh)
+
+### Changed
+- **CLAUDE.md**: 핫픽스 규칙 + 브랜치 다이어그램에 hotfix 반영
+- **docs/DEVELOPMENT.md**: 핫픽스 프로세스 섹션 추가
+
 ## [2.2.1] - 2026-04-16
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,13 +46,13 @@ main ────────────●────────────
                  ↑               ↑
 develop ──●──●──●───●──●──●──●──● ── (dev: dev.trip.idean.me)
           ↑  ↑  ↑   ↑  ↑  ↑  ↑
-        feat feat hotfix feat feat     (NNN-short-name / hotfix/*)
+        feat feat hotfix feat feat
 ```
 
 - **main**: 프로덕션 브랜치. trip.idean.me 배포. 버전 태그가 붙는 유일한 브랜치.
-- **develop**: 통합 브랜치. dev.trip.idean.me 배포. feature 브랜치가 여기로 머지.
-- **feature**: `NNN-short-name` 형식 (speckit 자동 생성). develop으로 PR 머지.
-- **hotfix**: `hotfix/*` 형식. develop에서 분기 → develop PR → dev 환경 확인 → develop → main PR로 릴리즈. main 직접 머지 금지.
+- **develop**: 통합 브랜치. dev.trip.idean.me 배포. feature/hotfix가 여기로 머지.
+- **feature**: `NNN-short-name` 형식. speckit(`/speckit.specify`) 실행 시 3자리 일련번호를 자동 부여. speckit 프로세스(spec → plan → tasks)를 거친 후 구현 시작. (예: `007-oauth-cli-reauth`)
+- **hotfix**: `hotfix/설명` 형식. speckit 미경유. (예: `hotfix/v2.2.2-gitflow-harness`)
 - 머지된 feature/hotfix 브랜치는 GitHub가 자동 삭제 (`deleteBranchOnMerge: true`).
 
 ### 배포 환경 매핑

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,16 +44,16 @@ trip-planner/
 ```
 main ────────────●───────────────●──── (production: trip.idean.me)
                  ↑               ↑
-develop ──●──●──●───●──●──●──●──● ── (alpha: dev.trip.idean.me)
+develop ──●──●──●───●──●──●──●──● ── (dev: dev.trip.idean.me)
           ↑  ↑  ↑   ↑  ↑  ↑  ↑
-        feat feat feat feat feat feat  (NNN-short-name)
+        feat feat hotfix feat feat     (NNN-short-name / hotfix/*)
 ```
 
 - **main**: 프로덕션 브랜치. trip.idean.me 배포. 버전 태그가 붙는 유일한 브랜치.
 - **develop**: 통합 브랜치. dev.trip.idean.me 배포. feature 브랜치가 여기로 머지.
 - **feature**: `NNN-short-name` 형식 (speckit 자동 생성). develop으로 PR 머지.
-- 머지된 feature 브랜치는 GitHub가 자동 삭제 (`deleteBranchOnMerge: true`).
-- hotfix/release 브랜치는 사용하지 않음 (1인 개발).
+- **hotfix**: `hotfix/*` 형식. develop에서 분기 → develop PR → dev 환경 확인 → develop → main PR로 릴리즈. main 직접 머지 금지.
+- 머지된 feature/hotfix 브랜치는 GitHub가 자동 삭제 (`deleteBranchOnMerge: true`).
 
 ### 배포 환경 매핑
 
@@ -84,6 +84,13 @@ develop ──●──●──●───●──●──●──●──
 - MAJOR: 호환성 깨지는 변경 (API 스키마 변경, MCP 도구 삭제 등)
 - MINOR: 기능 추가 (새 API, 새 MCP 도구, 새 페이지 등)
 - PATCH: 버그 수정, 성능 개선, 문서 수정
+
+**핫픽스 프로세스**:
+1. develop에서 `hotfix/*` 브랜치 생성
+2. 수정 + CHANGELOG + 버전 PATCH 범프
+3. hotfix → develop PR → 머지 → dev 환경 확인
+4. develop → main PR → 머지 → CI 자동 릴리즈
+5. main 직접 머지 금지 — dev 환경 검증 필수
 
 ## 작업 규칙
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -85,11 +85,12 @@ main ────────────●────────────
                  ↑               ↑
 develop ──●──●──●───●──●──●──●──● ── (dev 통합 배포)
           ↑  ↑  ↑   ↑  ↑  ↑  ↑
-        feature branches (NNN-short-name)
+        feat feat hotfix feat feat     (NNN-short-name / hotfix/*)
 ```
 
 - **feature → develop PR**: 피처 개발. dev 환경에서 통합 테스트.
-- **develop → main PR**: 마일스톤 완료 시 릴리즈. CI가 자동으로 태그 + Release + PyPI.
+- **hotfix → develop PR**: 버그 수정. dev 환경 검증 필수. main 직접 머지 금지.
+- **develop → main PR**: 마일스톤 완료 또는 핫픽스 시 릴리즈. CI가 자동으로 태그 + Release + PyPI.
 
 ## 릴리즈 프로세스
 
@@ -107,6 +108,12 @@ develop ──●──●──●───●──●──●──●──
 - MAJOR: 호환성 깨지는 변경
 - MINOR: 기능 추가
 - PATCH: 버그 수정, 문서 수정
+
+**핫픽스 프로세스**:
+1. develop에서 `hotfix/*` 브랜치 생성
+2. 수정 + CHANGELOG + 버전 PATCH 범프
+3. hotfix → develop PR → dev 환경 확인
+4. develop → main PR → CI 자동 릴리즈
 
 ## API 문서
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -85,11 +85,13 @@ main ────────────●────────────
                  ↑               ↑
 develop ──●──●──●───●──●──●──●──● ── (dev 통합 배포)
           ↑  ↑  ↑   ↑  ↑  ↑  ↑
-        feat feat hotfix feat feat     (NNN-short-name / hotfix/*)
+        feat feat hotfix feat feat
 ```
 
-- **feature → develop PR**: 피처 개발. dev 환경에서 통합 테스트.
-- **hotfix → develop PR**: 버그 수정. dev 환경 검증 필수. main 직접 머지 금지.
+- **feature** (`NNN-short-name`): speckit(`/speckit.specify`) 실행 시 자동 생성. spec → plan → tasks 후 구현. (예: `007-oauth-cli-reauth`)
+- **hotfix** (`hotfix/설명`): speckit 미경유. develop에서 분기. (예: `hotfix/v2.2.2-gitflow-harness`)
+- **feature/hotfix → develop PR**: dev 환경에서 통합 테스트.
+- **develop → main PR**: 마일스톤 완료 또는 핫픽스 시 릴리즈. main 직접 머지 금지.
 - **develop → main PR**: 마일스톤 완료 또는 핫픽스 시 릴리즈. CI가 자동으로 태그 + Release + PyPI.
 
 ## 릴리즈 프로세스

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trip-planner-mcp"
-version = "2.2.1"
+version = "2.2.2"
 description = "여행 숙소, 항공편, 관광지 검색 + 구조화 활동 관리 MCP 서버 (20개 도구)"
 requires-python = ">=3.10"
 license = "MIT"


### PR DESCRIPTION
## Summary
- 핫픽스도 develop 경유 필수로 규칙 정립 (main 직접 머지 금지)
- speckit 하네스에 develop 브랜치 보호 추가
- 문서화 (CLAUDE.md, DEVELOPMENT.md)

## 변경
| 파일 | 내용 |
|------|------|
| enforce-speckit.sh | develop 브랜치 소스 편집 차단 추가 |
| enforce-submit.sh | develop 브랜치 config/spec 커밋 허용 |
| CLAUDE.md | 핫픽스 규칙 + 다이어그램 수정 |
| DEVELOPMENT.md | 핫픽스 프로세스 섹션 추가 |

## 핫픽스 플로우 (새 규칙)
```
hotfix/* → develop PR → dev 환경 확인 → develop → main PR → CI 릴리즈
```

## Test plan
- [ ] dev 환경 (dev.trip.idean.me) 배포 확인
- [ ] develop → main 머지 후 auto-tag + auto-release + pypi 파이프라인 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)