### PR TITLE
fix: v2.2.3 PR 머지 전략 — develop→main merge commit 필수

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.3] - 2026-04-16
+
+### Fixed
+- **PR 머지 전략**: develop → main은 merge commit 필수 (squash 시 역머지 충돌 문제 해결)
+
+### Changed
+- **CLAUDE.md + DEVELOPMENT.md**: PR 머지 전략 테이블 추가 (squash vs merge commit 사용 구분)
+
 ## [2.2.2] - 2026-04-16
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,15 @@ develop ──●──●──●───●──●──●──●──
 - **hotfix**: `hotfix/설명` 형식. speckit 미경유. (예: `hotfix/v2.2.2-gitflow-harness`)
 - 머지된 feature/hotfix 브랜치는 GitHub가 자동 삭제 (`deleteBranchOnMerge: true`).
 
+### PR 머지 전략
+
+| PR 방향 | 머지 방식 | 이유 |
+|---------|----------|------|
+| feature/hotfix → develop | **Squash and merge** | 커밋 정리, 깔끔한 develop 히스토리 |
+| develop → main | **Create a merge commit** | 커밋 해시 보존, 역머지 시 충돌 방지 |
+
+> develop → main을 squash하면 커밋 해시가 달라져 main → develop 동기화 시 매번 충돌 발생.
+
 ### 배포 환경 매핑
 
 | 브랜치 | 도메인 | 용도 |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -93,6 +93,13 @@ develop ──●──●──●───●──●──●──●──
 - **feature/hotfix → develop PR**: dev 환경에서 통합 테스트.
 - **develop → main PR**: 마일스톤 완료 또는 핫픽스 시 릴리즈. CI가 자동으로 태그 + Release + PyPI. main 직접 머지 금지.
 
+### PR 머지 전략
+
+| PR 방향 | 머지 방식 | 이유 |
+|---------|----------|------|
+| feature/hotfix → develop | **Squash and merge** | 커밋 정리, 깔끔한 develop 히스토리 |
+| develop → main | **Create a merge commit** | 커밋 해시 보존, 역머지 시 충돌 방지 |
+
 ## 릴리즈 프로세스
 
 **수동 (develop에서)**:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trip-planner-mcp"
-version = "2.2.2"
+version = "2.2.3"
 description = "여행 숙소, 항공편, 관광지 검색 + 구조화 활동 관리 MCP 서버 (20개 도구)"
 requires-python = ">=3.10"
 license = "MIT"


### PR DESCRIPTION
## Summary
- develop → main PR은 **Create a merge commit** 필수 (squash 금지)
- feature/hotfix → develop PR은 **Squash and merge** 유지
- squash merge 시 커밋 해시 불일치로 역머지 충돌 반복 발생하던 문제 해결

## Test plan
- [ ] dev 환경 확인
- [ ] develop → main PR을 **merge commit**으로 머지
- [ ] main → develop 역머지 시 충돌 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)