### PR TITLE
fix: 활동 카드 표시 개선 — memo 줄바꿈, 시간대, 예약 라벨 (#169)

### DIFF
--- a/mcp/trip_mcp/planner.py
+++ b/mcp/trip_mcp/planner.py
@@ -194,8 +194,8 @@ def register_planner_tools(mcp: FastMCP) -> None:
             day_id: 일자 ID (get_trip에서 확인)
             category: 활동 유형 (SIGHTSEEING, DINING, TRANSPORT, ACCOMMODATION, SHOPPING, OTHER)
             title: 활동 제목 (예: "벨렝 탑 방문")
-            start_time: 시작 시간 HH:mm (예: "09:30", 선택)
-            end_time: 종료 시간 HH:mm (예: "11:00", 선택)
+            start_time: 시작 시간 HH:mm 또는 HH:mm TZ (예: "09:30", "13:00 KST", 선택)
+            end_time: 종료 시간 HH:mm 또는 HH:mm TZ (예: "11:00", "20:15 WET", 선택)
             location: 장소명 (예: "Torre de Belém", 선택)
             memo: 메모 (선택)
             cost: 예상 비용 (0이면 미입력, 선택)
@@ -210,7 +210,7 @@ def register_planner_tools(mcp: FastMCP) -> None:
         if location:
             body["location"] = location
         if memo:
-            body["memo"] = memo
+            body["memo"] = memo.replace("\\n", "\n")
         if cost:
             body["cost"] = cost
         if reservation_status:
@@ -256,8 +256,8 @@ def register_planner_tools(mcp: FastMCP) -> None:
             day_id: 일자 ID
             activity_id: 활동 ID
             title: 변경할 제목 (빈 문자열이면 변경하지 않음)
-            start_time: 변경할 시작 시간 HH:mm
-            end_time: 변경할 종료 시간 HH:mm
+            start_time: 변경할 시작 시간 HH:mm 또는 HH:mm TZ (예: "13:00 KST")
+            end_time: 변경할 종료 시간 HH:mm 또는 HH:mm TZ (예: "20:15 WET")
             location: 변경할 장소명
             memo: 변경할 메모
             cost: 변경할 비용 (0이면 변경하지 않음)
@@ -275,7 +275,7 @@ def register_planner_tools(mcp: FastMCP) -> None:
         if location:
             body["location"] = location
         if memo:
-            body["memo"] = memo
+            body["memo"] = memo.replace("\\n", "\n")
         if cost:
             body["cost"] = cost
         if currency:

--- a/prisma/migrations/20260416_widen_activity_time/migration.sql
+++ b/prisma/migrations/20260416_widen_activity_time/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable: widen start_time / end_time to allow timezone suffix (e.g. "13:00 KST")
+ALTER TABLE "activities" ALTER COLUMN "start_time" TYPE VARCHAR(12);
+ALTER TABLE "activities" ALTER COLUMN "end_time" TYPE VARCHAR(12);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -131,8 +131,8 @@ model Activity {
   dayId             Int                @map("day_id")
   category          ActivityCategory
   title             String
-  startTime         String?            @map("start_time") @db.VarChar(5)
-  endTime           String?            @map("end_time") @db.VarChar(5)
+  startTime         String?            @map("start_time") @db.VarChar(12)
+  endTime           String?            @map("end_time") @db.VarChar(12)
   location          String?
   memo              String?            @db.Text
   cost              Decimal?           @db.Decimal(10, 2)

--- a/src/components/ActivityCard.tsx
+++ b/src/components/ActivityCard.tsx
@@ -47,7 +47,7 @@ const RESERVATION_LABEL: Record<ReservationStatus, string> = {
   REQUIRED: "사전 예약 필수",
   RECOMMENDED: "사전 예약 권장",
   ON_SITE: "현장 구매",
-  NOT_NEEDED: "불필요",
+  NOT_NEEDED: "예약 불필요",
 };
 
 interface ActivityCardProps {


### PR DESCRIPTION
## 작업 내용
활동 카드 표시 관련 3건 통합 수정

## 변경 사항
- MCP `create_activity`/`update_activity`에서 memo 필드의 `\n` 리터럴을 실제 줄바꿈으로 변환
- 예약상태 라벨 "불필요" → "예약 불필요"로 문구 보완
- `startTime`/`endTime` VarChar(5→12) 확장하여 시간대 접미사 지원 (예: `13:00 KST`)

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ⬜ 해당없음 | Vercel 프리뷰에서 확인 |
| 테스트 | ✅ 통과 | `vitest run` 104/104 |
| 문서 동기화 | ✅ 완료 | MCP docstring 시간대 형식 반영 |

Closes #169