### PR TITLE
fix: auto-release 릴리즈 노트 셸 확장 오류 수정

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -22,28 +22,20 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: CHANGELOG에서 릴리즈 노트 추출
-        id: notes
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           # CHANGELOG.md에서 해당 버전 섹션 추출
           # ## [X.Y.Z] 부터 다음 ## [ 까지
-          NOTES=$(awk "/^## \\[${VERSION}\\]/{found=1; next} /^## \\[/{if(found) exit} found" CHANGELOG.md)
+          awk "/^## \\[${VERSION}\\]/{found=1; next} /^## \\[/{if(found) exit} found" CHANGELOG.md > /tmp/release-notes.md
 
-          if [ -z "$NOTES" ]; then
-            NOTES="릴리즈 노트가 CHANGELOG.md에 없습니다. 커밋 로그를 확인하세요."
+          if [ ! -s /tmp/release-notes.md ]; then
+            echo "릴리즈 노트가 CHANGELOG.md에 없습니다. 커밋 로그를 확인하세요." > /tmp/release-notes.md
           fi
-
-          # GitHub Actions 멀티라인 출력
-          {
-            echo "notes<<NOTES_EOF"
-            echo "$NOTES"
-            echo "NOTES_EOF"
-          } >> "$GITHUB_OUTPUT"
 
       - name: GitHub Release 생성
         run: |
           gh release create "${{ steps.version.outputs.tag }}" \
             --title "${{ steps.version.outputs.tag }}" \
-            --notes "${{ steps.notes.outputs.notes }}"
+            --notes-file /tmp/release-notes.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 작업 내용
v2.2.4 Auto Release 실패 원인 수정

## 변경 사항
- CHANGELOG 내용을 GITHUB_OUTPUT 변수 대신 파일에 직접 쓰고 `--notes-file`로 전달
- 특수문자(`@`, `:`, 백틱 등)가 셸 명령으로 해석되는 문제 원천 차단

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ⬜ 해당없음 | CI 워크플로우만 변경 |
| 테스트 | ⬜ 해당없음 | 태그 push 시 검증 |