### PR TITLE
fix: 초대 링크 비로그인 플로우 복구 — middleware callbackUrl 주입 (#189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.6] - 2026-04-17
+
+### Fixed
+- **초대 링크 비로그인 플로우**: 비로그인 유저가 `/invite/{token}` 접근 시 middleware가 `callbackUrl`을 보존하지 않아 로그인 후 홈으로 이탈하던 문제 수정. 이제 로그인 완료 후 원래 초대 링크로 복귀하여 TripMember가 정상 생성됨. (#189, 디스커션 #185)
+
 ## [2.2.5] - 2026-04-17
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trip-planner-mcp"
-version = "2.2.5"
+version = "2.2.6"
 description = "여행 숙소, 항공편, 관광지 검색 + 구조화 활동 관리 MCP 서버 (20개 도구)"
 requires-python = ">=3.10"
 license = "MIT"

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -19,9 +19,14 @@ export default auth((req) => {
   // 비로그인 사용자의 auth 페이지 접근은 허용
   if (isAuthRoute) return;
 
-  // 비로그인 사용자 → 로그인 페이지로 리다이렉트
+  // 비로그인 사용자 → 로그인 페이지로 리다이렉트 (callbackUrl 보존)
   if (!isLoggedIn) {
-    return Response.redirect(new URL("/auth/signin", req.nextUrl));
+    const signInUrl = new URL("/auth/signin", req.nextUrl);
+    const { pathname, search } = req.nextUrl;
+    if (pathname !== "/") {
+      signInUrl.searchParams.set("callbackUrl", `${pathname}${search}`);
+    }
+    return Response.redirect(signInUrl);
   }
 });
 

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -1,82 +1,64 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
-// middleware.ts uses NextAuth which re-exports auth as a function wrapper.
-// We test the middleware logic by mocking the NextAuth export.
+vi.mock("@/auth.config", () => ({ default: { providers: [], pages: { signIn: "/auth/signin" } } }));
 
-const { mockAuthConfig } = vi.hoisted(() => ({
-  mockAuthConfig: {
-    providers: [],
-    pages: { signIn: "/auth/signin" },
-  },
-}));
-
-// Mock the auth config
-vi.mock("@/auth.config", () => ({ default: mockAuthConfig }));
-
-// Mock next-auth to return a middleware function
+// next-auth wrapper: make `auth(handler)` return the handler as-is so we can invoke it directly.
 vi.mock("next-auth", () => ({
-  default: (config: unknown) => {
-    // Return a function that creates a middleware
-    return (handler: (req: unknown) => unknown) => handler;
-  },
+  default: () => ({
+    auth: (handler: (req: unknown) => unknown) => handler,
+  }),
 }));
 
-// Since middleware uses NextAuth wrapper which is complex to mock entirely,
-// test the logic directly by simulating the middleware behavior
-describe("Middleware auth logic", () => {
-  it("allows API routes without redirect", () => {
-    const pathname = "/api/trips";
-    const isApiRoute = pathname.startsWith("/api/");
-    expect(isApiRoute).toBe(true);
-    // API routes should be passed through
+import middleware from "@/middleware";
+
+type FakeReq = { auth: unknown; nextUrl: URL };
+
+function makeReq(url: string, loggedIn: boolean): FakeReq {
+  return { auth: loggedIn ? { user: { id: "u1" } } : null, nextUrl: new URL(url) };
+}
+
+describe("middleware", () => {
+  it("passes API routes through (no redirect)", () => {
+    const res = middleware(makeReq("https://x.test/api/trips", false) as never, {} as never);
+    expect(res).toBeUndefined();
   });
 
-  it("redirects logged-in users from auth routes to home", () => {
-    const pathname = "/auth/signin";
-    const isLoggedIn = true;
-    const isAuthRoute = pathname.startsWith("/auth");
-
-    if (isAuthRoute && isLoggedIn) {
-      // Should redirect to "/"
-      expect(true).toBe(true);
-    }
+  it("redirects logged-in users away from /auth pages to /", () => {
+    const res = middleware(makeReq("https://x.test/auth/signin", true) as never, {} as never) as Response;
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("https://x.test/");
   });
 
-  it("allows non-logged-in users to access auth routes", () => {
-    const pathname = "/auth/signin";
-    const isLoggedIn = false;
-    const isAuthRoute = pathname.startsWith("/auth");
-
-    // Should not redirect
-    expect(isAuthRoute && !isLoggedIn).toBe(true);
+  it("allows non-logged-in users on /auth pages", () => {
+    const res = middleware(makeReq("https://x.test/auth/signin", false) as never, {} as never);
+    expect(res).toBeUndefined();
   });
 
-  it("redirects non-logged-in users from protected routes to signin", () => {
-    const pathname = "/trips/1";
-    const isLoggedIn = false;
-    const isAuthRoute = pathname.startsWith("/auth");
-    const isApiRoute = pathname.startsWith("/api/");
-
-    if (!isApiRoute && !isAuthRoute && !isLoggedIn) {
-      // Should redirect to "/auth/signin"
-      expect(true).toBe(true);
-    }
+  it("redirects non-logged-in users from invite link with callbackUrl preserved (#189)", () => {
+    const res = middleware(
+      makeReq("https://x.test/invite/abc.def.ghi?ref=email", false) as never,
+      {} as never,
+    ) as Response;
+    expect(res.status).toBe(302);
+    const loc = new URL(res.headers.get("location") ?? "");
+    expect(loc.pathname).toBe("/auth/signin");
+    expect(loc.searchParams.get("callbackUrl")).toBe("/invite/abc.def.ghi?ref=email");
   });
 
-  it("allows logged-in users to access protected routes", () => {
-    const pathname = "/trips/1";
-    const isLoggedIn = true;
-    const isAuthRoute = pathname.startsWith("/auth");
-    const isApiRoute = pathname.startsWith("/api/");
-
-    // Should pass through (no redirect)
-    expect(!isApiRoute && !isAuthRoute && isLoggedIn).toBe(true);
+  it("redirects non-logged-in users from protected routes with callbackUrl", () => {
+    const res = middleware(
+      makeReq("https://x.test/trips/42", false) as never,
+      {} as never,
+    ) as Response;
+    const loc = new URL(res.headers.get("location") ?? "");
+    expect(loc.pathname).toBe("/auth/signin");
+    expect(loc.searchParams.get("callbackUrl")).toBe("/trips/42");
   });
 
-  it("treats /api/auth/cli as API route (pass-through)", () => {
-    const pathname = "/api/auth/cli";
-    const isApiRoute = pathname.startsWith("/api/");
-    expect(isApiRoute).toBe(true);
-    // API routes return early in middleware — no auth redirect
+  it("omits callbackUrl when redirecting from root", () => {
+    const res = middleware(makeReq("https://x.test/", false) as never, {} as never) as Response;
+    const loc = new URL(res.headers.get("location") ?? "");
+    expect(loc.pathname).toBe("/auth/signin");
+    expect(loc.searchParams.has("callbackUrl")).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #189
관련 디스커션: #185 (Case 2)

## Summary
- 비로그인 유저가 `/invite/{token}` 클릭 시 middleware가 callbackUrl 없이 `/auth/signin`으로 리다이렉트하여 로그인 후 홈으로 이탈하던 문제 수정
- 이제 로그인 완료 후 원래 초대 링크로 복귀 → TripMember 정상 생성

## Changes
- `src/middleware.ts` — 비로그인 리다이렉트 시 `callbackUrl=<pathname+search>` 부착 (루트 경로 제외)
- `tests/middleware.test.ts` — 기존 시뮬레이션 테스트 제거, 실제 핸들러 호출 기반 6 케이스로 전환
- `CHANGELOG.md`, `pyproject.toml` — 2.2.6 PATCH 범프

## Test plan
- [x] `vitest run tests/middleware.test.ts` — 6/6 통과
- [x] `tsc --noEmit` — 에러 없음
- [ ] 프리뷰 URL에서 시크릿 창으로 초대 링크 접속 → Google 로그인 → 여행 목록에 합류 확인
- [ ] 디스커션 #185 Case 1(로그인 상태에서도 안됨)은 별도 재현 후 분리 처리 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)