### PR TITLE
refactor: URL 도출 3-layer 헬퍼 + trustHost — AUTH_URL 의존 제거 (#194)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.2.7] - 2026-04-17
 
+### Changed
+- **URL 도출 전략 재설계**: 환경별 외부 env(AUTH_URL 등) 의존 제거. `src/lib/app-url.ts` 헬퍼 + Auth.js `trustHost: true`로 각 환경이 자기 요청 origin만 보고 동작. "dev가 prod 참조, local이 dev 참조" 교차 참조를 구조적으로 차단. 문서: `docs/ENVIRONMENTS.md`. (#194)
+
 ### Fixed
 - **여행 삭제/양도 전면 불가 상태 복구**: `POST /api/trips`가 생성자를 `HOST`로 기록해 OWNER가 존재하지 않던 문제 수정. 생성자는 이제 OWNER로 등록되며, 기존 여행은 마이그레이션으로 `tripMember.userId == trip.createdBy` 조건에서 OWNER로 승격됨. 홈 목록의 "호스트" 표시도 정상적으로 "내 여행"으로 복구됨. (#191, 디스커션 #188)
 - **여행 삭제 UI 노출**: 여행 상세 페이지에 OWNER 전용 "여행 삭제" 버튼 추가. 확인 다이얼로그 포함. (#191)
 - **여행 나가기 UI 노출**: HOST/GUEST 대상 "여행 나가기" 버튼 추가 — 초대 → 합류 → 나가기 플로우 완결. OWNER는 양도 후 탈퇴 필요 (API가 차단). (#191)
+- **초대 링크 상대경로 생성**: dev 환경에서 invite URL이 `/invite/...` 상대경로로 생성되어 외부 앱 붙여넣기 시 `file://`로 해석되던 문제 수정. 위 URL 도출 재설계로 재발 불가. (#194, 디스커션 #185 Case 1 실제 원인)
 
 ## [2.2.6] - 2026-04-17
 

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -1,0 +1,59 @@
+# 환경과 URL 도출 전략
+
+각 환경(prod / dev / preview / local)이 **자기 origin만 바라보고 동작**하도록, 외부 환경변수 의존을 구조적으로 제거한다. "dev가 prod 참조, local이 dev 참조" 같은 교차 참조를 원천 차단.
+
+## 3-Layer 분리
+
+| Layer | 용도 | 도출 방식 | env 의존 |
+|-------|------|-----------|----------|
+| Layer 1 — 앱 내부 링크 | 초대 링크, 공유 링크, 리다이렉트 | **요청 origin** (`new URL(request.url).origin`) | 0 |
+| Layer 2 — OAuth 콜백 | Google 등 외부 프로바이더의 `redirect_uri` | Auth.js `trustHost: true` + 요청 Host 헤더 | 0 (Vercel 기본) |
+| Layer 3 — Canonical 외부 URL | 이메일, SEO/OG 메타, 외부 알림 | `APP_PRODUCTION_URL` 또는 `VERCEL_PROJECT_PRODUCTION_URL` | 0~1 |
+
+핵심: **Layer 1·2는 요청이 도달한 origin이 곧 진실**. 다른 환경을 참조할 구조적 여지가 없다.
+
+## Layer 1 — 앱 내부 링크
+
+- 구현: `src/lib/app-url.ts` → `getAppOrigin(request)`
+- 원칙: 내부 링크는 수신자가 **보낸 사람과 같은 환경**에 있을 것으로 간주
+  - dev에서 만든 초대 링크는 dev 수신자용 (prod 링크로 보내지 말 것)
+  - preview에서 만든 링크는 그 preview 배포용
+- 안전성: Vercel이 Host 헤더를 검증 후 전달하므로 스푸핑 여지 없음
+
+## Layer 2 — OAuth 콜백
+
+- 구현: `src/auth.config.ts` → `trustHost: true`
+- 의미: Auth.js v5가 요청의 Host 헤더를 신뢰하여 `redirect_uri`를 자체 조립
+- 효과: **`AUTH_URL` / `NEXTAUTH_URL` 수동 설정 불필요**
+- 전제: Google OAuth 콘솔에 각 환경의 redirect URI를 등록해야 함
+  - prod: `https://trip.idean.me/api/auth/callback/google`
+  - dev: `https://dev.trip.idean.me/api/auth/callback/google`
+  - preview: 고정 URI 불가 → 동일 수준의 지원이 필요하면 "preview용 별칭 도메인"을 1개 두고 그것만 등록 (현재 사용 안 함)
+
+## Layer 3 — Canonical 외부 URL
+
+- 구현: `src/lib/app-url.ts` → `getCanonicalOrigin()`
+- 반환: `APP_PRODUCTION_URL` → `VERCEL_PROJECT_PRODUCTION_URL` → `null`
+- `VERCEL_PROJECT_PRODUCTION_URL`는 **Vercel이 자동 주입**하므로 수동 설정 0
+- 호출자가 `null`을 받으면 문맥에 맞는 폴백 결정 (예: 내부 문맥이면 `getAppOrigin(request)`)
+
+## 환경별 요약
+
+| 환경 | Layer 1 | Layer 2 (OAuth) | Layer 3 |
+|------|---------|------------------|---------|
+| prod (trip.idean.me) | request origin | trustHost | `VERCEL_PROJECT_PRODUCTION_URL` (자동) |
+| dev (dev.trip.idean.me) | request origin | trustHost | 프로덕션 URL 자동 주입 — dev가 prod를 참조하는 유일한 지점은 **외부 노출 링크에서만** 프로덕션을 향하고, 나머지는 dev에 고립 |
+| preview (*.vercel.app) | request origin | trustHost | 동일 |
+| local (localhost:3000) | request origin | trustHost | `null` → 호출자가 결정 |
+
+## 무엇을 하면 안 되는가
+
+- ❌ `AUTH_URL`을 여러 환경에 수동 관리 — `trustHost`로 자체 도출
+- ❌ 내부 링크를 canonical 도메인으로 강제 — 환경 교차 참조 유발
+- ❌ `process.env.AUTH_URL`을 앱 로직에서 직접 참조 — 이미 `getAppOrigin` / `getCanonicalOrigin` 헬퍼 존재
+
+## 과거 회귀(#194)
+
+- 증상: dev에서 초대 링크가 `/invite/TOKEN` 상대경로로 복사됨 → 붙여넣기 시 `file:///invite/...`
+- 원인: `AUTH_URL`이 dev에 미설정이라 빈 문자열로 baseUrl 계산
+- 수정: Layer 1 헬퍼 적용. env 의존 제거. 결과적으로 재발 불가능한 구조로 변경

--- a/src/app/api/trips/[id]/invite/route.ts
+++ b/src/app/api/trips/[id]/invite/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getAuthUserId, isHost } from "@/lib/auth-helpers";
 import { createInviteToken } from "@/lib/invite-token";
+import { getAppOrigin } from "@/lib/app-url";
 
 type Params = { params: Promise<{ id: string }> };
 
@@ -25,8 +26,7 @@ export async function POST(request: Request, { params }: Params) {
   }
 
   const token = await createInviteToken({ tripId, role });
-  const baseUrl = process.env.AUTH_URL || process.env.NEXTAUTH_URL || "";
-  const inviteUrl = `${baseUrl}/invite/${token}`;
+  const inviteUrl = `${getAppOrigin(request)}/invite/${token}`;
 
   return NextResponse.json({ inviteUrl }, { status: 201 });
 }

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -2,6 +2,10 @@ import Google from "next-auth/providers/google";
 import type { NextAuthConfig } from "next-auth";
 
 export default {
+  // 요청 Host 헤더를 신뢰하여 OAuth 콜백 URL을 자체 도출.
+  // Vercel/Next.js 배포에서는 Host가 플랫폼에서 검증되므로 안전.
+  // 효과: AUTH_URL 수동 설정 없이도 각 환경(prod/dev/preview/local)이 자기 origin만 보고 동작.
+  trustHost: true,
   providers: [Google({ allowDangerousEmailAccountLinking: true })],
   pages: {
     signIn: "/auth/signin",

--- a/src/lib/app-url.ts
+++ b/src/lib/app-url.ts
@@ -1,0 +1,48 @@
+/**
+ * 앱 URL 도출 헬퍼.
+ *
+ * 목적: 환경별 외부 설정(AUTH_URL 등) 의존을 제거하고, 각 환경이 자기 origin만 바라보게 만든다.
+ * "dev가 prod 참조, local이 dev 참조" 같은 교차 참조를 구조적으로 차단.
+ *
+ * 3-layer 구분:
+ * - Layer 1 (앱 내부 링크): 요청 origin 기반. env 의존 0. 사용처: 초대 링크, 공유 링크 등
+ * - Layer 2 (OAuth 콜백): Auth.js의 trustHost + Vercel 자동 env로 자체 해결. 본 파일 미사용
+ * - Layer 3 (canonical 외부 노출): 프로덕션 도메인. Vercel built-in `VERCEL_PROJECT_PRODUCTION_URL`로 흡수
+ */
+
+/**
+ * Layer 1 — 현재 요청이 도달한 origin을 그대로 돌려준다.
+ * 초대 링크, 공유 링크, 리다이렉트 등 **내부 링크** 생성에 사용.
+ *
+ * Vercel이 Host 헤더를 검증해 주므로 신뢰 가능. 자체 호스팅 환경에서도 프록시가
+ * Host를 정상 전달한다는 전제 위에서 안전.
+ */
+export function getAppOrigin(request: Request): string {
+  return new URL(request.url).origin;
+}
+
+/**
+ * Layer 3 — 프로덕션 canonical URL.
+ * 사용처: 이메일 본문, SEO/OG 메타, 외부 알림 등 **수신자 환경과 무관하게 안정적이어야 하는** 링크.
+ *
+ * 우선순위:
+ *  1. `APP_PRODUCTION_URL` — 프로젝트가 명시한 canonical (도메인 소유권 주장)
+ *  2. `VERCEL_PROJECT_PRODUCTION_URL` — Vercel 자동 제공 (프로젝트의 프로덕션 도메인)
+ *  3. 폴백 없음 — 위 둘 다 없으면 `null` 반환. 호출자가 의미 있는 폴백을 결정해야 함
+ *     (예: 내부 링크 문맥에서는 `getAppOrigin(request)`로 폴백)
+ */
+export function getCanonicalOrigin(): string | null {
+  const explicit = process.env.APP_PRODUCTION_URL;
+  if (explicit) return normalizeOrigin(explicit);
+
+  const vercelProd = process.env.VERCEL_PROJECT_PRODUCTION_URL;
+  if (vercelProd) return normalizeOrigin(vercelProd);
+
+  return null;
+}
+
+function normalizeOrigin(raw: string): string {
+  const trimmed = raw.trim().replace(/\/$/, "");
+  if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) return trimmed;
+  return `https://${trimmed}`;
+}

--- a/tests/api/invite.test.ts
+++ b/tests/api/invite.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockAuthHelpers, mockInviteToken } = vi.hoisted(() => ({
+  mockAuthHelpers: {
+    getAuthUserId: vi.fn(),
+    isHost: vi.fn(),
+  },
+  mockInviteToken: {
+    createInviteToken: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/auth-helpers", () => mockAuthHelpers);
+vi.mock("@/lib/invite-token", () => mockInviteToken);
+
+import { POST } from "@/app/api/trips/[id]/invite/route";
+
+const mockAuth = mockAuthHelpers.getAuthUserId;
+const mockIsHost = mockAuthHelpers.isHost;
+const mockCreate = mockInviteToken.createInviteToken;
+
+function tripParams(id = "1") {
+  return { params: Promise.resolve({ id }) };
+}
+
+function jsonRequest(url: string, body: unknown) {
+  return new Request(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/trips/{id}/invite — 초대 링크 생성 (#194)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("builds invite URL from request origin — dev", async () => {
+    mockAuth.mockResolvedValue("user1");
+    mockIsHost.mockResolvedValue(true);
+    mockCreate.mockResolvedValue("TOKEN_DEV");
+
+    const res = await POST(
+      jsonRequest("https://dev.trip.idean.me/api/trips/1/invite", { role: "HOST" }),
+      tripParams(),
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.inviteUrl).toBe("https://dev.trip.idean.me/invite/TOKEN_DEV");
+  });
+
+  it("builds invite URL from request origin — prod", async () => {
+    mockAuth.mockResolvedValue("user1");
+    mockIsHost.mockResolvedValue(true);
+    mockCreate.mockResolvedValue("TOKEN_PROD");
+
+    const res = await POST(
+      jsonRequest("https://trip.idean.me/api/trips/1/invite", { role: "GUEST" }),
+      tripParams(),
+    );
+
+    const body = await res.json();
+    expect(body.inviteUrl).toBe("https://trip.idean.me/invite/TOKEN_PROD");
+  });
+
+  it("builds invite URL from request origin — preview (Vercel random)", async () => {
+    mockAuth.mockResolvedValue("user1");
+    mockIsHost.mockResolvedValue(true);
+    mockCreate.mockResolvedValue("TOKEN_PREVIEW");
+
+    const res = await POST(
+      jsonRequest("https://trip-planner-abc.vercel.app/api/trips/1/invite", { role: "HOST" }),
+      tripParams(),
+    );
+
+    const body = await res.json();
+    expect(body.inviteUrl).toBe("https://trip-planner-abc.vercel.app/invite/TOKEN_PREVIEW");
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+    const res = await POST(jsonRequest("https://x.test/api/trips/1/invite", { role: "HOST" }), tripParams());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when not a host", async () => {
+    mockAuth.mockResolvedValue("user1");
+    mockIsHost.mockResolvedValue(false);
+    const res = await POST(jsonRequest("https://x.test/api/trips/1/invite", { role: "HOST" }), tripParams());
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 for invalid role", async () => {
+    mockAuth.mockResolvedValue("user1");
+    mockIsHost.mockResolvedValue(true);
+    const res = await POST(jsonRequest("https://x.test/api/trips/1/invite", { role: "OWNER" }), tripParams());
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/lib/app-url.test.ts
+++ b/tests/lib/app-url.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { getAppOrigin, getCanonicalOrigin } from "@/lib/app-url";
+
+describe("getAppOrigin — Layer 1 (내부 링크)", () => {
+  it("returns origin from request URL — dev", () => {
+    const req = new Request("https://dev.trip.idean.me/api/trips/1/invite");
+    expect(getAppOrigin(req)).toBe("https://dev.trip.idean.me");
+  });
+
+  it("returns origin from request URL — prod", () => {
+    const req = new Request("https://trip.idean.me/api/trips/1");
+    expect(getAppOrigin(req)).toBe("https://trip.idean.me");
+  });
+
+  it("preserves port for localhost", () => {
+    const req = new Request("http://localhost:3000/api/foo");
+    expect(getAppOrigin(req)).toBe("http://localhost:3000");
+  });
+
+  it("returns origin even with query/hash", () => {
+    const req = new Request("https://preview.vercel.app/api/foo?bar=1");
+    expect(getAppOrigin(req)).toBe("https://preview.vercel.app");
+  });
+});
+
+describe("getCanonicalOrigin — Layer 3 (외부 노출용)", () => {
+  const originalAppProd = process.env.APP_PRODUCTION_URL;
+  const originalVercelProd = process.env.VERCEL_PROJECT_PRODUCTION_URL;
+
+  beforeEach(() => {
+    delete process.env.APP_PRODUCTION_URL;
+    delete process.env.VERCEL_PROJECT_PRODUCTION_URL;
+  });
+
+  afterEach(() => {
+    if (originalAppProd !== undefined) process.env.APP_PRODUCTION_URL = originalAppProd;
+    else delete process.env.APP_PRODUCTION_URL;
+    if (originalVercelProd !== undefined) process.env.VERCEL_PROJECT_PRODUCTION_URL = originalVercelProd;
+    else delete process.env.VERCEL_PROJECT_PRODUCTION_URL;
+  });
+
+  it("prefers APP_PRODUCTION_URL over VERCEL_PROJECT_PRODUCTION_URL", () => {
+    process.env.APP_PRODUCTION_URL = "https://trip.idean.me";
+    process.env.VERCEL_PROJECT_PRODUCTION_URL = "trip-planner.vercel.app";
+    expect(getCanonicalOrigin()).toBe("https://trip.idean.me");
+  });
+
+  it("falls back to VERCEL_PROJECT_PRODUCTION_URL and adds https://", () => {
+    process.env.VERCEL_PROJECT_PRODUCTION_URL = "trip-planner.vercel.app";
+    expect(getCanonicalOrigin()).toBe("https://trip-planner.vercel.app");
+  });
+
+  it("returns null when neither env is set", () => {
+    expect(getCanonicalOrigin()).toBeNull();
+  });
+
+  it("strips trailing slash", () => {
+    process.env.APP_PRODUCTION_URL = "https://trip.idean.me/";
+    expect(getCanonicalOrigin()).toBe("https://trip.idean.me");
+  });
+
+  it("preserves explicit http:// scheme", () => {
+    process.env.APP_PRODUCTION_URL = "http://localhost:3000";
+    expect(getCanonicalOrigin()).toBe("http://localhost:3000");
+  });
+});


### PR DESCRIPTION
Closes #194
관련 디스커션: #185 Case 1 (실제 근인)
마일스톤: v2.2.7 — QA 라운드 1

## 배경
dev 환경에서 초대 링크가 \`/invite/TOKEN\` 상대경로로 복사되어 외부 앱 붙여넣기 시 \`file:///invite/TOKEN\`이 되던 문제. 1차 분석 시 env 폴백 한 줄로 땜방 가능했으나 **AUTH_URL이 환경별 수동 관리라는 구조 자체가 회귀 재발을 유발**. 근본 재설계.

## 3-layer 전략
| Layer | 용도 | 도출 | env 의존 |
|-------|------|------|---------|
| 1 — 앱 내부 링크 | invite/share | \`getAppOrigin(request)\` | 0 |
| 2 — OAuth 콜백 | Google redirect_uri | Auth.js \`trustHost: true\` | 0 |
| 3 — Canonical 외부 URL | email/SEO | \`getCanonicalOrigin()\` (Vercel built-in) | 0~1 |

**효과**: 각 환경이 자기 요청 origin만 보고 동작. "dev가 prod 참조, local이 dev 참조" 교차 참조 구조적 소멸. AUTH_URL / NEXTAUTH_URL 수동 설정 불필요.

## Changes
- **`src/lib/app-url.ts`** (신규)
  - \`getAppOrigin(request)\` — Layer 1
  - \`getCanonicalOrigin()\` — Layer 3 (\`APP_PRODUCTION_URL\` → \`VERCEL_PROJECT_PRODUCTION_URL\` → null)
- **\`src/auth.config.ts\`** — \`trustHost: true\` 명시
- **\`src/app/api/trips/[id]/invite/route.ts\`** — \`getAppOrigin(request)\`로 단순화, env 분기 제거
- **\`docs/ENVIRONMENTS.md\`** (신규) — 3-layer 전략, 환경별 동작, 과거 회귀(#194) 원인 기록
- **\`tests/lib/app-url.test.ts\`** — 9 케이스 (Layer 1 origin 도출, Layer 3 env 우선순위/정규화)
- **\`tests/api/invite.test.ts\`** — dev/prod/preview origin 기반으로 재작성 (6 케이스)

## 호환성
- **제거 요구 없음**: 기존 \`AUTH_URL\`/\`NEXTAUTH_URL\` 환경변수가 설정되어 있어도 더는 참조되지 않음 (deprecated). Vercel/dotenv에서 정리 권장하나 즉시 제거 불요.
- **Google OAuth 콘솔 redirect URI 등록**은 기존대로 유지 (prod/dev 각 등록).

## Test plan
- [x] \`vitest run\` — 119/119 통과
- [x] \`tsc --noEmit\` — 에러 없음
- [x] \`eslint\` — 클린
- [ ] dev 프리뷰 재배포 후 초대 링크 복사 → \`https://dev.trip.idean.me/invite/...\` 확인
- [ ] Google 로그인 OAuth 콜백 정상 (dev/prod 모두)
- [ ] 로컬 \`next dev\` 기동 후 초대 링크 → \`http://localhost:3000/invite/...\` 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)