### PR TITLE
feat: 여행 멤버 목록 UI — 동행자 섹션 추가 (#193)

### DIFF
--- a/src/app/trips/[id]/page.tsx
+++ b/src/app/trips/[id]/page.tsx
@@ -6,6 +6,7 @@ import { formatCalendarDateFull, formatCalendarDate } from "@/lib/date-utils";
 import InviteButton from "@/components/InviteButton";
 import DeleteTripButton from "@/components/DeleteTripButton";
 import LeaveTripButton from "@/components/LeaveTripButton";
+import MemberList from "@/components/MemberList";
 import { remark } from "remark";
 import remarkGfm from "remark-gfm";
 import html from "remark-html";
@@ -110,6 +111,8 @@ async function DbTripPage({ tripId }: { tripId: number }) {
           />
         </details>
       )}
+
+      <MemberList tripId={tripId} />
 
       <div className="space-y-3">
         <h2 className="text-heading-sm font-semibold">일정</h2>

--- a/src/components/MemberList.tsx
+++ b/src/components/MemberList.tsx
@@ -1,0 +1,78 @@
+import Image from "next/image";
+import { prisma } from "@/lib/prisma";
+
+interface MemberListProps {
+  tripId: number;
+}
+
+const ROLE_ORDER: Record<string, number> = { OWNER: 0, HOST: 1, GUEST: 2 };
+
+function roleBadge(role: string) {
+  const base = "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium";
+  switch (role) {
+    case "OWNER":
+      return `${base} bg-primary-100 text-primary-700`;
+    case "HOST":
+      return `${base} bg-surface-200 text-surface-700`;
+    default:
+      return `${base} bg-surface-100 text-surface-500`;
+  }
+}
+
+function roleLabel(role: string) {
+  if (role === "OWNER") return "주인";
+  if (role === "HOST") return "호스트";
+  return "게스트";
+}
+
+export default async function MemberList({ tripId }: MemberListProps) {
+  const members = await prisma.tripMember.findMany({
+    where: { tripId },
+    include: { user: { select: { id: true, name: true, email: true, image: true } } },
+  });
+
+  const sorted = [...members].sort((a, b) => {
+    const byRole = (ROLE_ORDER[a.role] ?? 99) - (ROLE_ORDER[b.role] ?? 99);
+    if (byRole !== 0) return byRole;
+    return a.joinedAt.getTime() - b.joinedAt.getTime();
+  });
+
+  return (
+    <section className="rounded-card shadow-card p-5">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-heading-sm font-semibold">동행자 ({members.length})</h2>
+      </div>
+      <ul className="space-y-2">
+        {sorted.map((m) => {
+          const displayName = m.user.name || m.user.email || "이름 없음";
+          return (
+            <li key={m.id} className="flex items-center gap-3">
+              {m.user.image ? (
+                <Image
+                  src={m.user.image}
+                  alt={displayName}
+                  width={32}
+                  height={32}
+                  className="rounded-full"
+                />
+              ) : (
+                <div className="h-8 w-8 rounded-full bg-surface-200 flex items-center justify-center text-sm text-surface-500">
+                  {displayName[0]?.toUpperCase() ?? "?"}
+                </div>
+              )}
+              <div className="flex-1 min-w-0">
+                <p className="text-body-sm font-medium text-surface-900 truncate">
+                  {displayName}
+                </p>
+                {m.user.email && m.user.name && (
+                  <p className="text-xs text-surface-500 truncate">{m.user.email}</p>
+                )}
+              </div>
+              <span className={roleBadge(m.role)}>{roleLabel(m.role)}</span>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/tests/api/members.test.ts
+++ b/tests/api/members.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma, mockAuthHelpers } = vi.hoisted(() => ({
+  mockPrisma: {
+    tripMember: { findMany: vi.fn() },
+  },
+  mockAuthHelpers: {
+    getAuthUserId: vi.fn(),
+    getTripMember: vi.fn(),
+    isHost: vi.fn(),
+    isOwner: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/auth-helpers", () => mockAuthHelpers);
+
+import { GET } from "@/app/api/trips/[id]/members/route";
+
+const mockAuth = mockAuthHelpers.getAuthUserId;
+const mockGetMember = mockAuthHelpers.getTripMember;
+
+function tripParams(id = "1") {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe("GET /api/trips/{id}/members — 멤버 목록 (#193)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+    const res = await GET(new Request("http://localhost/api/trips/1/members"), tripParams());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when requester is not a member", async () => {
+    mockAuth.mockResolvedValue("user1");
+    mockGetMember.mockResolvedValue(null);
+    mockPrisma.tripMember.findMany.mockResolvedValue([]);
+    const res = await GET(new Request("http://localhost/api/trips/1/members"), tripParams());
+    expect(res.status).toBe(403);
+  });
+
+  it("returns members with myRole when member", async () => {
+    mockAuth.mockResolvedValue("user1");
+    mockGetMember.mockResolvedValue({ id: 1, userId: "user1", role: "OWNER" });
+    mockPrisma.tripMember.findMany.mockResolvedValue([
+      { id: 1, userId: "user1", role: "OWNER", user: { id: "user1", name: "A" } },
+      { id: 2, userId: "user2", role: "HOST", user: { id: "user2", name: "B" } },
+      { id: 3, userId: "user3", role: "GUEST", user: { id: "user3", name: "C" } },
+    ]);
+
+    const res = await GET(new Request("http://localhost/api/trips/1/members"), tripParams());
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.myRole).toBe("OWNER");
+    expect(body.members).toHaveLength(3);
+    expect(body.members.map((m: { role: string }) => m.role)).toEqual(["OWNER", "HOST", "GUEST"]);
+  });
+});


### PR DESCRIPTION
Closes #193
관련 디스커션: #186
마일스톤: v2.2.7 — QA 라운드 1

## Summary
GET /api/trips/{id}/members API는 이미 존재했으나 UI 진입점이 없어 누가 참여 중인지 확인 불가였음. 여행 상세 페이지에 동행자 섹션 추가.

## Changes
- **`src/components/MemberList.tsx`** — 서버 컴포넌트. 아바타(Google 프로필 image) / 이름·이메일 / 역할 배지(주인·호스트·게스트). OWNER → HOST → GUEST 순 정렬 후 joined_at 오름차순.
- **`src/app/trips/[id]/page.tsx`** — 여행 개요와 일정 사이에 동행자 섹션 렌더링.
- **`tests/api/members.test.ts`** — GET 401 / 403(비멤버) / 200(myRole + members) 3 케이스.

## Scope out
권한 변경(승격/강등/제거) UI는 별도 이슈로 분리. 004 tasks.md T041/T043 관리 액션 부분은 더 큰 UX 설계가 필요해서 이번 QA 라운드와 분리.

## Test plan
- [x] \`vitest run tests/api/members.test.ts\` — 3/3 통과
- [x] \`tsc --noEmit\` / \`eslint\` — 클린
- [ ] dev 프리뷰: 멤버 2명 이상 트립에서 동행자 섹션 노출 확인 — 아바타/역할 배지 정렬 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)