### PR TITLE
chore: 설정 페이지 API 토큰 수동 생성 UI 제거 (#197)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **URL 도출 전략 재설계**: 환경별 외부 env(AUTH_URL 등) 의존 제거. `src/lib/app-url.ts` 헬퍼 + Auth.js `trustHost: true`로 각 환경이 자기 요청 origin만 보고 동작. "dev가 prod 참조, local이 dev 참조" 교차 참조를 구조적으로 차단. 문서: `docs/ENVIRONMENTS.md`. (#194)
 
+### Removed
+- **설정 페이지 API 토큰 수동 생성 폼 제거**: v2.2.0의 OAuth CLI 자동 발급과 중복. 설정 페이지는 "발급된 API 토큰" 목록 + 폐기만 제공. `POST /api/tokens`는 OpenAPI에 deprecated 표기 후 하위 호환 유지. (#197, 디스커션 #187)
+
 ### Fixed
 - **여행 삭제/양도 전면 불가 상태 복구**: `POST /api/trips`가 생성자를 `HOST`로 기록해 OWNER가 존재하지 않던 문제 수정. 생성자는 이제 OWNER로 등록되며, 기존 여행은 마이그레이션으로 `tripMember.userId == trip.createdBy` 조건에서 OWNER로 승격됨. 홈 목록의 "호스트" 표시도 정상적으로 "내 여행"으로 복구됨. (#191, 디스커션 #188)
 - **여행 삭제 UI 노출**: 여행 상세 페이지에 OWNER 전용 "여행 삭제" 버튼 추가. 확인 다이얼로그 포함. (#191)

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -7,7 +7,6 @@ import { useState, useCallback } from "react";
 interface Token {
   id: number;
   name: string;
-  token?: string; // 생성 직후에만 존재
   tokenPrefix: string;
   expiresAt: string | null;
   lastUsedAt: string | null;
@@ -17,10 +16,6 @@ interface Token {
 export default function SettingsPage() {
   const { status } = useSession();
   const [tokens, setTokens] = useState<Token[]>([]);
-  const [newTokenName, setNewTokenName] = useState("");
-  const [createdToken, setCreatedToken] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
-  const [loading, setLoading] = useState(false);
   const [initialized, setInitialized] = useState(false);
 
   const fetchTokens = useCallback(async () => {
@@ -36,42 +31,11 @@ export default function SettingsPage() {
   if (status === "loading") return <p>로딩 중...</p>;
   if (status === "unauthenticated") return <p>로그인이 필요합니다.</p>;
 
-  async function handleCreate(e: React.FormEvent) {
-    e.preventDefault();
-    if (!newTokenName.trim() || loading) return;
-
-    setLoading(true);
-    setCreatedToken(null);
-    setCopied(false);
-
-    const res = await fetch("/api/tokens", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name: newTokenName.trim() }),
-    });
-
-    if (res.ok) {
-      const data = await res.json();
-      setCreatedToken(data.token);
-      setNewTokenName("");
-      await fetchTokens();
-    }
-
-    setLoading(false);
-  }
-
-  async function handleDelete(id: number) {
+  async function handleRevoke(id: number, name: string) {
+    if (!window.confirm(`"${name}" 토큰을 폐기하시겠습니까? 해당 장치의 API 호출이 즉시 차단됩니다.`)) return;
     const res = await fetch(`/api/tokens/${id}`, { method: "DELETE" });
     if (res.ok) {
       setTokens((prev) => prev.filter((t) => t.id !== id));
-    }
-  }
-
-  async function handleCopy() {
-    if (createdToken) {
-      await navigator.clipboard.writeText(createdToken);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
     }
   }
 
@@ -85,53 +49,14 @@ export default function SettingsPage() {
       <h1 className="text-2xl font-bold">설정</h1>
 
       <section className="space-y-4">
-        <h2 className="text-lg font-semibold">API 토큰</h2>
+        <h2 className="text-lg font-semibold">발급된 API 토큰</h2>
         <p className="text-sm text-surface-600">
-          외부 도구(MCP 서버 등)에서 API를 호출할 때 사용하는 인증 토큰입니다.
+          <code className="text-xs bg-surface-100 px-1 py-0.5 rounded">install.sh</code> 설치 시 장치별로 자동 발급됩니다.
+          추가 장치에 설치하거나 토큰을 재발급하려면 해당 장치에서 설치 스크립트를 다시 실행하세요.
         </p>
 
-        {/* 토큰 생성 */}
-        <form onSubmit={handleCreate} className="flex gap-2">
-          <input
-            type="text"
-            value={newTokenName}
-            onChange={(e) => setNewTokenName(e.target.value)}
-            placeholder="토큰 이름 (예: My MacBook)"
-            maxLength={100}
-            className="flex-1 border rounded px-3 py-2 text-sm"
-          />
-          <button
-            type="submit"
-            disabled={loading || !newTokenName.trim()}
-            className="bg-primary-600 text-white px-4 py-2 rounded text-sm font-medium disabled:opacity-50"
-          >
-            생성
-          </button>
-        </form>
-
-        {/* 생성된 토큰 노출 (1회) */}
-        {createdToken && (
-          <div className="bg-green-50 border border-green-200 rounded p-4 space-y-2">
-            <p className="text-sm font-medium text-green-800">
-              토큰이 생성되었습니다. 이 값은 다시 표시되지 않으니 복사해두세요.
-            </p>
-            <div className="flex items-center gap-2">
-              <code className="flex-1 bg-white border rounded px-3 py-2 text-xs break-all select-all">
-                {createdToken}
-              </code>
-              <button
-                onClick={handleCopy}
-                className="bg-green-600 text-white px-3 py-2 rounded text-xs font-medium shrink-0"
-              >
-                {copied ? "복사됨" : "복사"}
-              </button>
-            </div>
-          </div>
-        )}
-
-        {/* 토큰 목록 */}
         {tokens.length === 0 ? (
-          <p className="text-sm text-surface-500">생성된 토큰이 없습니다.</p>
+          <p className="text-sm text-surface-500">발급된 토큰이 없습니다.</p>
         ) : (
           <div className="border rounded divide-y">
             {tokens.map((token) => (
@@ -155,10 +80,10 @@ export default function SettingsPage() {
                   </div>
                 </div>
                 <button
-                  onClick={() => handleDelete(token.id)}
+                  onClick={() => handleRevoke(token.id, token.name)}
                   className="text-red-600 text-sm hover:underline"
                 >
-                  삭제
+                  폐기
                 </button>
               </div>
             ))}

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -491,8 +491,9 @@ export const openApiSpec = {
       },
       post: {
         tags: ["Tokens"],
-        summary: "토큰 생성",
-        description: "세션 인증 필수. 생성된 토큰 원문은 이 응답에서만 노출된다.",
+        summary: "토큰 생성 (deprecated)",
+        deprecated: true,
+        description: "세션 인증 필수. 생성된 토큰 원문은 이 응답에서만 노출된다. **비권장**: 장치별 PAT는 `install.sh`의 OAuth CLI 플로우가 자동 발급합니다. 본 엔드포인트는 하위 호환을 위해 유지되며 이후 릴리즈에서 제거될 수 있음.",
         security: [{ SessionAuth: [] }],
         requestBody: {
           required: true,


### PR DESCRIPTION
Closes #197
관련 디스커션: #187
마일스톤: v2.2.7 — QA 라운드 1

## Summary
v2.2.0의 OAuth CLI 자동 발급(install.sh)이 있는데 수동 생성 폼이 남아있던 중복 제거. 사용자 제보 "자동인데 왜 남아있나" 응답.

## Changes
- **\`src/app/settings/page.tsx\`**
  - 토큰 생성 폼(name 입력 + 생성 버튼) 제거
  - 관련 클라이언트 상태(createdToken/copied/newTokenName/loading) 정리
  - 섹션 제목 "API 토큰" → "발급된 API 토큰"
  - 설명: \`install.sh\`가 장치별 자동 발급. 재발급은 설치 스크립트 재실행
  - "삭제" → "폐기"로 표기 변경 + 확인 다이얼로그
- **\`src/lib/openapi.ts\`**
  - POST /api/tokens \`deprecated: true\` 표기 + 설명에 자동 발급 안내

## 하위 호환
- \`POST /api/tokens\` 엔드포인트는 즉시 제거하지 않고 OpenAPI에 deprecated로 유지. 호출 경로가 UI에서 사라졌으므로 다음 메이저에서 제거 가능.
- \`GET /api/tokens\`, \`DELETE /api/tokens/{id}\`는 설정 페이지가 계속 사용 — 영향 없음.
- \`/api/auth/cli\` OAuth 플로우는 \`createPAT()\`를 직접 사용 → 이번 변경과 무관.

## Test plan
- [x] \`vitest run\` — 133/133 통과
- [x] \`tsc --noEmit\` — 에러 없음
- [x] \`eslint\` — 클린
- [ ] dev 프리뷰 설정 페이지 접근 → 생성 폼 미노출 확인
- [ ] 기존 토큰 목록 노출 + 폐기 다이얼로그 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)