### PR TITLE
chore: 설정 페이지 PAT 발급 UX 재정비 — 자동 기본 + 수동 고급 복원 (#199)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **URL 도출 전략 재설계**: 환경별 외부 env(AUTH_URL 등) 의존 제거. `src/lib/app-url.ts` 헬퍼 + Auth.js `trustHost: true`로 각 환경이 자기 요청 origin만 보고 동작. "dev가 prod 참조, local이 dev 참조" 교차 참조를 구조적으로 차단. 문서: `docs/ENVIRONMENTS.md`. (#194)
 
-### Removed
-- **설정 페이지 API 토큰 수동 생성 폼 제거**: v2.2.0의 OAuth CLI 자동 발급과 중복. 설정 페이지는 "발급된 API 토큰" 목록 + 폐기만 제공. `POST /api/tokens`는 OpenAPI에 deprecated 표기 후 하위 호환 유지. (#197, 디스커션 #187)
+### Changed
+- **설정 페이지 PAT 발급 UX 재정비**: 자동 발급(install.sh)을 기본 시각으로 설명하고 수동 발급 폼은 `<details>` 접힘 "수동 발급 (고급)" 영역으로 이동. 설치 가이드·API 문서 링크 추가. 웹 전용 유저도 self-serve 가능하게 유지. `POST /api/tokens` deprecated 표기 해제(공식 경로로 유지). (#199, 디스커션 #187 후속)
 
 ### Fixed
 - **여행 삭제/양도 전면 불가 상태 복구**: `POST /api/trips`가 생성자를 `HOST`로 기록해 OWNER가 존재하지 않던 문제 수정. 생성자는 이제 OWNER로 등록되며, 기존 여행은 마이그레이션으로 `tripMember.userId == trip.createdBy` 조건에서 OWNER로 승격됨. 홈 목록의 "호스트" 표시도 정상적으로 "내 여행"으로 복구됨. (#191, 디스커션 #188)

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -7,15 +7,22 @@ import { useState, useCallback } from "react";
 interface Token {
   id: number;
   name: string;
+  token?: string; // 생성 직후에만 존재
   tokenPrefix: string;
   expiresAt: string | null;
   lastUsedAt: string | null;
   createdAt: string;
 }
 
+const INSTALL_GUIDE_URL = "https://github.com/idean3885/trip-planner#2-ai-에이전트로-검색--자동-일정-생성";
+
 export default function SettingsPage() {
   const { status } = useSession();
   const [tokens, setTokens] = useState<Token[]>([]);
+  const [newTokenName, setNewTokenName] = useState("");
+  const [createdToken, setCreatedToken] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [loading, setLoading] = useState(false);
   const [initialized, setInitialized] = useState(false);
 
   const fetchTokens = useCallback(async () => {
@@ -31,11 +38,43 @@ export default function SettingsPage() {
   if (status === "loading") return <p>로딩 중...</p>;
   if (status === "unauthenticated") return <p>로그인이 필요합니다.</p>;
 
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    if (!newTokenName.trim() || loading) return;
+
+    setLoading(true);
+    setCreatedToken(null);
+    setCopied(false);
+
+    const res = await fetch("/api/tokens", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: newTokenName.trim() }),
+    });
+
+    if (res.ok) {
+      const data = await res.json();
+      setCreatedToken(data.token);
+      setNewTokenName("");
+      await fetchTokens();
+    }
+
+    setLoading(false);
+  }
+
   async function handleRevoke(id: number, name: string) {
     if (!window.confirm(`"${name}" 토큰을 폐기하시겠습니까? 해당 장치의 API 호출이 즉시 차단됩니다.`)) return;
     const res = await fetch(`/api/tokens/${id}`, { method: "DELETE" });
     if (res.ok) {
       setTokens((prev) => prev.filter((t) => t.id !== id));
+    }
+  }
+
+  async function handleCopy() {
+    if (createdToken) {
+      await navigator.clipboard.writeText(createdToken);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
     }
   }
 
@@ -49,12 +88,28 @@ export default function SettingsPage() {
       <h1 className="text-2xl font-bold">설정</h1>
 
       <section className="space-y-4">
-        <h2 className="text-lg font-semibold">발급된 API 토큰</h2>
+        <h2 className="text-lg font-semibold">API 토큰</h2>
         <p className="text-sm text-surface-600">
-          <code className="text-xs bg-surface-100 px-1 py-0.5 rounded">install.sh</code> 설치 시 장치별로 자동 발급됩니다.
-          추가 장치에 설치하거나 토큰을 재발급하려면 해당 장치에서 설치 스크립트를 다시 실행하세요.
+          보통은{" "}
+          <code className="text-xs bg-surface-100 px-1 py-0.5 rounded">install.sh</code>{" "}
+          설치 시 장치별로 자동 발급됩니다.{" "}
+          <a
+            href={INSTALL_GUIDE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary-600 hover:underline"
+          >
+            설치 가이드 →
+          </a>
+        </p>
+        <p className="text-xs text-surface-500">
+          API를 직접 호출할 때 사용하는 인증 토큰입니다. 외부 도구(MCP 서버, 스크립트)에서 Bearer로 전달.{" "}
+          <a href="/docs" className="text-primary-600 hover:underline">
+            API 문서 →
+          </a>
         </p>
 
+        {/* 발급된 토큰 목록 */}
         {tokens.length === 0 ? (
           <p className="text-sm text-surface-500">발급된 토큰이 없습니다.</p>
         ) : (
@@ -89,6 +144,55 @@ export default function SettingsPage() {
             ))}
           </div>
         )}
+
+        {/* 수동 발급 (고급) — 웹 전용 유저용 */}
+        <details className="border rounded-lg">
+          <summary className="cursor-pointer px-4 py-3 text-sm font-medium text-surface-700 hover:bg-surface-50">
+            수동 발급 (고급)
+          </summary>
+          <div className="px-4 pb-4 space-y-3">
+            <p className="text-xs text-surface-500">
+              CLI 설치 없이 웹에서 직접 토큰이 필요할 때 사용합니다. 생성된 토큰 원문은 한 번만 표시되므로 즉시 복사하세요.
+            </p>
+
+            <form onSubmit={handleCreate} className="flex gap-2">
+              <input
+                type="text"
+                value={newTokenName}
+                onChange={(e) => setNewTokenName(e.target.value)}
+                placeholder="토큰 이름 (예: My MacBook)"
+                maxLength={100}
+                className="flex-1 border rounded px-3 py-2 text-sm"
+              />
+              <button
+                type="submit"
+                disabled={loading || !newTokenName.trim()}
+                className="bg-primary-600 text-white px-4 py-2 rounded text-sm font-medium disabled:opacity-50"
+              >
+                생성
+              </button>
+            </form>
+
+            {createdToken && (
+              <div className="bg-green-50 border border-green-200 rounded p-4 space-y-2">
+                <p className="text-sm font-medium text-green-800">
+                  토큰이 생성되었습니다. 이 값은 다시 표시되지 않으니 복사해두세요.
+                </p>
+                <div className="flex items-center gap-2">
+                  <code className="flex-1 bg-white border rounded px-3 py-2 text-xs break-all select-all">
+                    {createdToken}
+                  </code>
+                  <button
+                    onClick={handleCopy}
+                    className="bg-green-600 text-white px-3 py-2 rounded text-xs font-medium shrink-0"
+                  >
+                    {copied ? "복사됨" : "복사"}
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        </details>
       </section>
     </div>
   );

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -491,9 +491,8 @@ export const openApiSpec = {
       },
       post: {
         tags: ["Tokens"],
-        summary: "토큰 생성 (deprecated)",
-        deprecated: true,
-        description: "세션 인증 필수. 생성된 토큰 원문은 이 응답에서만 노출된다. **비권장**: 장치별 PAT는 `install.sh`의 OAuth CLI 플로우가 자동 발급합니다. 본 엔드포인트는 하위 호환을 위해 유지되며 이후 릴리즈에서 제거될 수 있음.",
+        summary: "토큰 수동 생성",
+        description: "세션 인증 필수. 생성된 토큰 원문은 이 응답에서만 노출된다. 권장 경로는 `install.sh`의 OAuth CLI 자동 발급이며, 본 엔드포인트는 웹 전용 사용자의 수동 발급용으로 유지된다.",
         security: [{ SessionAuth: [] }],
         requestBody: {
           required: true,


### PR DESCRIPTION
Closes #199
관련 디스커션: #187 (후속)
마일스톤: v2.2.7 — QA 라운드 1

## 배경
#197에서 PAT 생성 폼을 전체 제거했으나, 웹 전용 유저가 API 호출 진입점을 잃는 문제. PAT는 결국 생성 방식(CLI 자동 vs 웹 수동) 차이이므로 수동 경로도 공식 지원으로 유지하되 **주 경로인 CLI를 기본 시각**으로 둠.

## Changes
### \`src/app/settings/page.tsx\`
- 섹션 상단: "보통은 \`install.sh\` 설치 시 자동 발급됩니다" + GitHub 설치 가이드 링크
- "API 문서 →" 링크 추가 (\`/docs\` Scalar 페이지)
- 발급된 토큰 목록 + 폐기 유지
- \`<details>\` 접힘 **"수동 발급 (고급)"** 블록 → 펼치면 이름 입력 + 생성 버튼 + 1회 노출/복사 UI

### \`src/lib/openapi.ts\`
- \`POST /api/tokens\` \`deprecated\` 해제 (공식 수동 경로로 유지)
- 설명: "수동 생성 (권장 경로는 install.sh)"

## UX 의도
- CLI 유저 → 기본 시각에서 자동 발급 경로 즉시 인지
- 웹 유저 → "수동 발급 (고급)" 펼쳐서 self-serve
- #187 "자동인데 왜 남아있나" 의문은 기본 안내 문구로 방지

## Test plan
- [x] \`vitest run\` — 133/133 통과
- [x] \`tsc --noEmit\` — 에러 없음
- [x] \`eslint\` — 클린
- [ ] dev 프리뷰 설정 페이지: 기본 문구/가이드 링크/API 문서 링크 노출 확인
- [ ] "수동 발급 (고급)" 클릭 → 폼 펼침 확인
- [ ] 테스트 토큰 생성 → 원문 1회 노출 + 복사 → 목록 반영 → 폐기까지 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)