### PR TITLE
docs: CHANGELOG 2.2.7 정리 — Changed 병합 + 멤버 목록 UI 누락 보완

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **URL 도출 전략 재설계**: 환경별 외부 env(AUTH_URL 등) 의존 제거. `src/lib/app-url.ts` 헬퍼 + Auth.js `trustHost: true`로 각 환경이 자기 요청 origin만 보고 동작. "dev가 prod 참조, local이 dev 참조" 교차 참조를 구조적으로 차단. 문서: `docs/ENVIRONMENTS.md`. (#194)
-
-### Changed
 - **설정 페이지 PAT 발급 UX 재정비**: 자동 발급(install.sh)을 기본 시각으로 설명하고 수동 발급 폼은 `<details>` 접힘 "수동 발급 (고급)" 영역으로 이동. 설치 가이드·API 문서 링크 추가. 웹 전용 유저도 self-serve 가능하게 유지. `POST /api/tokens` deprecated 표기 해제(공식 경로로 유지). (#199, 디스커션 #187 후속)
+
+### Added
+- **여행 멤버 목록 UI**: 여행 상세 페이지에 동행자 섹션 추가 — 아바타/이름/역할 배지(주인·호스트·게스트). OWNER → HOST → GUEST 순 정렬 후 joined_at 오름차순. (#193, 디스커션 #186)
 
 ### Fixed
 - **여행 삭제/양도 전면 불가 상태 복구**: `POST /api/trips`가 생성자를 `HOST`로 기록해 OWNER가 존재하지 않던 문제 수정. 생성자는 이제 OWNER로 등록되며, 기존 여행은 마이그레이션으로 `tripMember.userId == trip.createdBy` 조건에서 OWNER로 승격됨. 홈 목록의 "호스트" 표시도 정상적으로 "내 여행"으로 복구됨. (#191, 디스커션 #188)


### PR DESCRIPTION
릴리즈 PR 직전 정리.

- `### Changed` 섹션이 두 번 나오던 중복을 단일 섹션으로 병합
- PR #196 머지 시 CHANGELOG에 반영되지 않았던 `### Added` 멤버 목록 UI(#193) 항목 추가

이후 develop → main 릴리즈 PR 진행 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)