### PR TITLE
docs: PR 머지 방식 merge commit 일관 (#218)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,12 +57,14 @@ develop ──●──●──●───●──●──●──●──
 
 ### PR 머지 전략
 
+**전 방향 `Create a merge commit`**. Squash and merge는 off(repo 설정으로 고정).
+
 | PR 방향 | 머지 방식 | 이유 |
 |---------|----------|------|
-| feature/hotfix → develop | **Squash and merge** | 커밋 정리, 깔끔한 develop 히스토리 |
+| feature/hotfix → develop | **Create a merge commit** | 커밋 조절은 개발자가 feature 브랜치에서 직접(push 전 `git rebase -i` 등). AI 하네스로 커밋을 관리하는 상황에서 웹의 수동 squash는 단순 합치기일 뿐 메시지가 의미에 맞게 재구성되지 않음 |
 | develop → main | **Create a merge commit** | 커밋 해시 보존, 역머지 시 충돌 방지 |
 
-> develop → main을 squash하면 커밋 해시가 달라져 main → develop 동기화 시 매번 충돌 발생.
+> 커밋 수가 많아 정리가 필요하면 feature 브랜치에서 rebase/amend로 직접 정돈한 뒤 push한다. 웹 UI의 squash는 사용하지 않는다.
 
 ### 배포 환경 매핑
 


### PR DESCRIPTION
## 작업 내용

이슈 #218. CLAUDE.md의 PR 머지 전략 표에서 feature/hotfix→develop의 `Squash and merge` 권장을 제거하고 **전 방향 `Create a merge commit`**으로 통일.

## 변경 사항

- `CLAUDE.md` "PR 머지 전략" 표 갱신
- 이유 문구에 "AI 하네스로 커밋을 관리하는 상황에서 웹 수동 squash는 단순 합치기" 명시
- 커밋 정리는 feature 브랜치에서 push 전 직접 수행하도록 안내

## 자가 검증

| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ⬜ 해당없음 | 문서 변경 |
| 테스트 | ⬜ 해당없음 | |
| 문서 동기화 | ✅ 완료 | `grep -n squash CLAUDE.md` — 정책 설명 문장에만 존재, 권장 규정 0건 |

## 비고

본 PR의 머지 자체가 새 규정의 첫 적용. 웹 UI에서 "Create a merge commit" 버튼을 사용해 주세요.

Closes #218