### PR TITLE
release: v2.3.0 버전 범프 + CHANGELOG 고정

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.3.0] - 2026-04-17
 
 ### Added
 - **speckit 하네스 도입**: 이슈 #181 + 12개 하위 이슈(#205~#216). 스펙 산출물 간 정합성 자동 검증으로 #191 유형(plan 항목 tasks 미매핑 → 데이터 마이그레이션 누락)의 재발을 구조적으로 차단.
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - 검증기 7종 + CI 워크플로우 2종 추가: `validate-metatag-format.sh`, `validate-plan-tasks-cov.sh`, `validate-drift.sh`, `validate-quickstart-ev.sh`, `validate-migration-meta.sh`, `validate-constitution.sh`, `merge-tasks-to-issues.sh` + `speckit-gate.yml`, `drift-audit.yml`
   - 신규 템플릿 2종(`implement-template.md`, `quickstart-template.md`) + 기존 템플릿(`spec-template.md`, `plan-template.md`, `tasks-template.md`) 메타태그 가이드 추가
   - 기존 `enforce-speckit.sh`의 `-maxdepth 1` 버그 수정(카테고리 하위 구조 탐색 정상화)
-  - 3단계 롤아웃: `expand`(현재) → `migrate` → `contract`. 현 단계는 경고만, 머지 차단 없음.
+  - **3단계 롤아웃 완료**: `expand` → `migrate` → `contract`. 현재 `contract` 모드에서 speckit-gate CI가 실제 차단 역할 수행.
+  - **migration-type 사이드카 방식**: `prisma/migrations/<dir>/migration-type` 파일로 레거시 마이그레이션을 Prisma checksum 손상 없이 분류 (10개 소급 적용).
 
 ### Changed
 - **PR 머지 정책**: 전 방향 `Create a merge commit` 고정(#218). Squash and merge off.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trip-planner-mcp"
-version = "2.2.7"
+version = "2.3.0"
 description = "여행 숙소, 항공편, 관광지 검색 + 구조화 활동 관리 MCP 서버 (20개 도구)"
 requires-python = ">=3.10"
 license = "MIT"


### PR DESCRIPTION
## 작업 내용

2.3.0 릴리즈 준비. 버전 범프 + CHANGELOG 날짜 고정. 본 PR 머지 후 **develop → main** PR로 프로덕션 릴리즈 진행.

## 변경 사항

- `pyproject.toml` version `2.2.7` → `2.3.0` (MINOR — speckit 하네스 = 새 기능)
- `CHANGELOG.md` `[Unreleased]` → `[2.3.0] - 2026-04-17`
  - contract 모드 롤아웃 + migration-type 사이드카 결정 사항 명문화

## 자가 검증

| 항목 | 결과 |
|------|------|
| metatag 회귀 | ✅ |
| migration-meta 회귀 (contract) | ✅ |

## 후속

머지 후 **develop → main PR** 생성. 사용자가 리뷰·승인 후 머지 → CI 자동:
1. `auto-tag.yml`: v2.3.0 annotated 태그 생성
2. `auto-release.yml`: CHANGELOG 추출 → GitHub Release
3. `pypi-publish.yml`: PyPI 배포