### PR TITLE
chore: 기본 방어선 활성화 - dependabot + SECURITY.md (#220)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+      npm-major:
+        update-types:
+          - "major"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    groups:
+      pip-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+      pip-major:
+        update-types:
+          - "major"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+보안 취약점을 발견하시면 공개 이슈 대신 아래 채널로 제보 부탁드립니다.
+
+- GitHub Private Vulnerability Reporting: 레포 상단 `Security` 탭 → `Report a vulnerability`
+- 이메일: dykimDev3885@gmail.com
+
+개인 운영 프로젝트 특성상 응답이 수 일 걸릴 수 있습니다. 재현 절차와 영향 범위를 함께 공유해주시면 빠른 확인에 도움이 됩니다.


### PR DESCRIPTION
## 작업 내용
공개 레포 기본 방어선 최소 허들 활성화 (#220).

## 변경 사항
- `.github/dependabot.yml` 추가 — npm(web)/pip(mcp)/github-actions 월 1회 업데이트. `groups`로 PR 수 억제.
- `SECURITY.md` 추가 — GitHub Private Vulnerability Reporting + 이메일 제보 채널.
- apppaas webhook 제거 (API 직접 삭제, Vercel 전환 후 미사용).

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ⬜ 해당없음 | 소스 변경 없음 |
| 테스트 | ⬜ 해당없음 | 소스 변경 없음 |
| 문서 동기화 | ✅ 완료 | SECURITY.md 신설 |

## 잔여 작업 (사용자 수행)
- [ ] Secret scanning Enable — Settings → Code security
- [ ] Secret push protection Enable — **최우선**
- [ ] Dependabot security updates Enable
- [ ] AUTO_TAG_PAT scope 점검 — https://github.com/settings/tokens (`contents:write`로 충분, 만료일 재설정)

## 스킵 사유 (참고)
- 이슈 생성 콜라보레이터 제한 — GitHub 네이티브 토글 없음, Action 기반은 유지 부담. 실제 스팸 발생 시 interaction limits 6mo로 대응

Closes #220