### PR TITLE
fix: 여행 상세 일정 목록을 date ASC로 정렬 (#238)

### DIFF
--- a/src/app/api/trips/[id]/days/route.ts
+++ b/src/app/api/trips/[id]/days/route.ts
@@ -17,7 +17,7 @@ export async function GET(request: Request, { params }: Params) {
     getTripMember(tripId, userId),
     prisma.day.findMany({
       where: { tripId },
-      orderBy: { sortOrder: "asc" },
+      orderBy: { date: "asc" },
     }),
   ]);
 

--- a/src/app/api/trips/[id]/route.ts
+++ b/src/app/api/trips/[id]/route.ts
@@ -19,7 +19,7 @@ export async function GET(request: Request, { params }: Params) {
       where: { id: tripId },
       include: {
         days: {
-          orderBy: { sortOrder: "asc" },
+          orderBy: { date: "asc" },
           include: { _count: { select: { activities: true } } },
         },
         tripMembers: {

--- a/src/app/trips/[id]/page.tsx
+++ b/src/app/trips/[id]/page.tsx
@@ -60,7 +60,7 @@ async function DbTripPage({ tripId }: { tripId: number }) {
     prisma.trip.findUnique({
       where: { id: tripId },
       include: {
-        days: { orderBy: { sortOrder: "asc" } },
+        days: { orderBy: { date: "asc" } },
       },
     }),
   ]);


### PR DESCRIPTION
## Summary

Day 목록 정렬 키를 `sortOrder`에서 `date`로 변경.

## Why

Day 72(6/21 귀국일)를 생성했을 때 POST API의 `sortOrder: sortOrder ?? 0` 기본값 때문에 sortOrder=0이 부여되어 최상단에 노출됨. DAY 라벨(번호)은 표시용이고 실제 정렬 키는 `date`여야 한다.

## Changes (3 files, 3 lines)

- `src/app/api/trips/[id]/route.ts`
- `src/app/api/trips/[id]/days/route.ts`
- `src/app/trips/[id]/page.tsx`

모두 `orderBy: { sortOrder: "asc" }` → `orderBy: { date: "asc" }`.

## Out of Scope

- `sortOrder` 자동 증분 로직(현재 POST는 0 기본값) — 별도 이슈 가능
- `DAY {day.sortOrder}` 라벨 표시 개선(현재 DAY 0 표시됨) — 별도 이슈 가능
- 기존 Day 72의 `sortOrder` 재지정 — 본 PR 머지 후 MCP로 수동 보정 가능

## Test plan

- [x] \`npm test -- --run tests/api/trips.test.ts tests/components/ActivityList.test.tsx\` 통과
- [ ] 수동: dev 환경 신혼여행(trip 5) 페이지에서 6/21 "인천 도착 (귀국)"이 목록 맨 아래에 표시되는지 확인

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)