### PR TITLE
fix: activity time을 IANA timezone 기준 UTC로 저장 (#232)

### DIFF
--- a/prisma/migrations/20260417120000_fix_activity_timezone_utc/migration-type
+++ b/prisma/migrations/20260417120000_fix_activity_timezone_utc/migration-type
@@ -1,0 +1,1 @@
+data-migration

--- a/prisma/migrations/20260417120000_fix_activity_timezone_utc/migration.sql
+++ b/prisma/migrations/20260417120000_fix_activity_timezone_utc/migration.sql
@@ -1,0 +1,41 @@
+-- [migration-type: data-migration]
+--
+-- Activity.start_time / end_time: floating-time → 실제 UTC.
+--
+-- 배경 (#232):
+--   과거 API는 HH:mm 입력을 `setUTCHours`로 저장해 "로컬 벽시각을 UTC로 가정"
+--   하여 기록했다. 예를 들어 Asia/Seoul 13:00 활동이 `2026-06-07T13:00:00Z`로
+--   저장되었다. 실제로는 `2026-06-07T04:00:00Z`(UTC)가 되어야 맞다. 이 값은
+--   Timestamptz이면서도 사실상 "floating-time"이다.
+--
+-- 적용 방식:
+--   기존 값이 "UTC로 가정된 로컬 벽시각"이라는 전제로, timezone 컬럼 값을
+--   사용해 실제 UTC로 재계산한다.
+--
+--   Postgres 의미:
+--     (x AT TIME ZONE 'UTC')           → timestamp without time zone (벽시각으로 재해석)
+--     (… AT TIME ZONE start_timezone)  → 해당 벽시각을 `start_timezone`의 로컬로 보고 UTC로 재변환
+--
+--   start_timezone/end_timezone이 NULL인 행은 "의도한 표시 시간대를 알 수 없는
+--   행"이므로 그대로 둔다 (어떤 값으로 해석해야 할지 복원 불가).
+--
+-- 멱등성 주의:
+--   이 UPDATE는 재실행 시 이중 변환된다. Prisma 마이그레이션 러너는 한 번만
+--   적용하므로 정상 경로에서는 안전하지만, 수동 재적용은 금지한다. 롤백 SQL은
+--   PR 본문에 기재.
+--
+-- 롤백 (수동, 필요 시):
+--   UPDATE activities SET start_time = (start_time AT TIME ZONE start_timezone) AT TIME ZONE 'UTC'
+--     WHERE start_timezone IS NOT NULL AND start_time IS NOT NULL;
+--   UPDATE activities SET end_time   = (end_time   AT TIME ZONE end_timezone)   AT TIME ZONE 'UTC'
+--     WHERE end_timezone IS NOT NULL AND end_time IS NOT NULL;
+
+UPDATE "activities"
+SET "start_time" = ("start_time" AT TIME ZONE 'UTC') AT TIME ZONE "start_timezone"
+WHERE "start_timezone" IS NOT NULL
+  AND "start_time" IS NOT NULL;
+
+UPDATE "activities"
+SET "end_time" = ("end_time" AT TIME ZONE 'UTC') AT TIME ZONE "end_timezone"
+WHERE "end_timezone" IS NOT NULL
+  AND "end_time" IS NOT NULL;

--- a/src/app/api/trips/[id]/days/[dayId]/activities/[activityId]/route.ts
+++ b/src/app/api/trips/[id]/days/[dayId]/activities/[activityId]/route.ts
@@ -1,17 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getAuthUserId, canEdit } from "@/lib/auth-helpers";
-
-function toTimestamp(value: string | undefined | null, dayDate: Date): Date | null | undefined {
-  if (value === undefined) return undefined;
-  if (value === null || value === "") return null;
-  if (value.includes("T")) return new Date(value);
-  const match = value.match(/^(\d{2}):(\d{2})/);
-  if (!match) return null;
-  const dt = new Date(dayDate);
-  dt.setUTCHours(parseInt(match[1]), parseInt(match[2]), 0, 0);
-  return dt;
-}
+import { toTimestamp } from "@/lib/activity-time";
 
 type Params = { params: Promise<{ id: string; dayId: string; activityId: string }> };
 
@@ -36,14 +26,32 @@ export async function PUT(request: Request, { params }: Params) {
   const body = await request.json();
   const { category, title, startTime, startTimezone, endTime, endTimezone, location, memo, cost, currency, reservationStatus, sortOrder } = body;
 
+  // HH:mm을 IANA timezone 기준으로 UTC 변환하려면 기존 timezone이 필요하다 (#232).
+  // 요청에 timezone이 없으면 DB에 저장된 값을 fallback으로 사용한다.
+  const needsExistingTz =
+    (startTime !== undefined && startTimezone === undefined && typeof startTime === "string" && !startTime.includes("T")) ||
+    (endTime !== undefined && endTimezone === undefined && typeof endTime === "string" && !endTime.includes("T"));
+  let existingStartTz: string | null | undefined;
+  let existingEndTz: string | null | undefined;
+  if (needsExistingTz) {
+    const existing = await prisma.activity.findUnique({
+      where: { id: parseInt(activityId), dayId: dayIdNum, day: { tripId } },
+      select: { startTimezone: true, endTimezone: true },
+    });
+    existingStartTz = existing?.startTimezone;
+    existingEndTz = existing?.endTimezone;
+  }
+  const effStartTz = startTimezone !== undefined ? startTimezone : existingStartTz;
+  const effEndTz = endTimezone !== undefined ? endTimezone : (existingEndTz ?? effStartTz);
+
   const activity = await prisma.activity.update({
     where: { id: parseInt(activityId), dayId: dayIdNum, day: { tripId } },
     data: {
       ...(category !== undefined && { category }),
       ...(title !== undefined && { title }),
-      ...(startTime !== undefined && { startTime: toTimestamp(startTime, day.date) }),
+      ...(startTime !== undefined && { startTime: toTimestamp(startTime, day.date, effStartTz) }),
       ...(startTimezone !== undefined && { startTimezone }),
-      ...(endTime !== undefined && { endTime: toTimestamp(endTime, day.date) }),
+      ...(endTime !== undefined && { endTime: toTimestamp(endTime, day.date, effEndTz) }),
       ...(endTimezone !== undefined && { endTimezone }),
       ...(location !== undefined && { location }),
       ...(memo !== undefined && { memo }),

--- a/src/app/api/trips/[id]/days/[dayId]/activities/route.ts
+++ b/src/app/api/trips/[id]/days/[dayId]/activities/route.ts
@@ -1,17 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getAuthUserId, getTripMember, canEdit } from "@/lib/auth-helpers";
-
-/** HH:mm → Day.date 기반 Timestamptz. ISO datetime은 그대로 파싱. */
-function toTimestamp(value: string | undefined | null, dayDate: Date): Date | undefined {
-  if (!value) return undefined;
-  if (value.includes("T")) return new Date(value);
-  const match = value.match(/^(\d{2}):(\d{2})/);
-  if (!match) return undefined;
-  const dt = new Date(dayDate);
-  dt.setUTCHours(parseInt(match[1]), parseInt(match[2]), 0, 0);
-  return dt;
-}
+import { toTimestamp } from "@/lib/activity-time";
 
 type Params = { params: Promise<{ id: string; dayId: string }> };
 
@@ -69,9 +59,9 @@ export async function POST(request: Request, { params }: Params) {
       dayId: dayIdNum,
       category,
       title,
-      ...(startTime !== undefined && { startTime: toTimestamp(startTime, day.date) ?? null }),
+      ...(startTime !== undefined && { startTime: toTimestamp(startTime, day.date, startTimezone) ?? null }),
       ...(startTimezone !== undefined && { startTimezone }),
-      ...(endTime !== undefined && { endTime: toTimestamp(endTime, day.date) ?? null }),
+      ...(endTime !== undefined && { endTime: toTimestamp(endTime, day.date, endTimezone ?? startTimezone) ?? null }),
       ...(endTimezone !== undefined && { endTimezone }),
       ...(location !== undefined && { location }),
       ...(memo !== undefined && { memo }),

--- a/src/components/ActivityCard.tsx
+++ b/src/components/ActivityCard.tsx
@@ -52,12 +52,23 @@ function tzAbbr(iana: string): string {
   } catch { return iana; }
 }
 
-/** ISO datetime → "HH:mm" 또는 "HH:mm TZ" */
+/**
+ * ISO datetime → "HH:mm" 또는 "HH:mm TZ".
+ *
+ * DB의 start_time/end_time은 UTC(Timestamptz)이다(#232). IANA timezone이 주어지면
+ * 해당 시간대의 벽시각으로 렌더하고, 없으면 UTC로 렌더한다.
+ */
 function formatTime(value: string | null, tz?: string | null): string | null {
   if (!value) return null;
   if (value.includes("T")) {
     const d = new Date(value);
-    const hhmm = `${String(d.getUTCHours()).padStart(2, "0")}:${String(d.getUTCMinutes()).padStart(2, "0")}`;
+    const timeZone = tz || "UTC";
+    const hhmm = new Intl.DateTimeFormat("ko-KR", {
+      timeZone,
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    }).format(d);
     return tz ? `${hhmm} ${tzAbbr(tz)}` : hhmm;
   }
   return value;

--- a/src/lib/activity-time.ts
+++ b/src/lib/activity-time.ts
@@ -1,0 +1,113 @@
+/**
+ * Activity 시각 변환 유틸리티.
+ *
+ * HH:mm 입력은 `timezone`의 로컬 시각으로 해석하여 실제 UTC 시각(Timestamptz)으로
+ * 변환한다. 이전 구현은 `setUTCHours`로 HH:mm을 그대로 저장해 "floating-time"이
+ * 되었고 timezone 값을 무시했다(issue #232). 이 모듈은 그 문제를 수정한다.
+ *
+ * 사용 위치:
+ *   - POST /api/trips/[id]/days/[dayId]/activities
+ *   - PUT  /api/trips/[id]/days/[dayId]/activities/[activityId]
+ *
+ * 표시 측(프론트엔드)은 `Intl.DateTimeFormat`에 `timeZone`을 넘겨 렌더한다
+ * (`ActivityCard.formatTime` 참조).
+ */
+
+/**
+ * "YYYY-MM-DDTHH:mm:ss" 형태 로컬 시각 문자열을 IANA timezone 기준으로 해석해
+ * UTC `Date`를 반환한다.
+ *
+ * 내부 전략: 후보 UTC `Date`를 두 번 `Intl.DateTimeFormat`로 포매팅해 실제 offset을
+ * 구하고, 보정한다. 두 번의 적용으로 DST 경계 ±1시간 오차까지 수렴한다.
+ */
+function zonedWallTimeToUtc(
+  year: number,
+  month: number, // 1-12
+  day: number,
+  hour: number,
+  minute: number,
+  timezone: string
+): Date {
+  // 1차: 벽시각을 UTC로 가정한 초기값
+  const guess = Date.UTC(year, month - 1, day, hour, minute, 0, 0);
+
+  // 해당 Date가 timezone에서 표시되는 실제 벽시각을 구해서 offset을 계산
+  const offsetMs = tzOffsetMs(guess, timezone);
+
+  // 보정된 UTC
+  const corrected = guess - offsetMs;
+
+  // DST 경계에서 한 번 더 보정 (corrected 시점의 offset이 초기값과 다를 수 있음)
+  const offsetMs2 = tzOffsetMs(corrected, timezone);
+  if (offsetMs2 !== offsetMs) {
+    return new Date(guess - offsetMs2);
+  }
+  return new Date(corrected);
+}
+
+/**
+ * 주어진 UTC 밀리초에서 timezone이 UTC보다 얼마나 앞서는지(ms)를 반환한다.
+ * 예: Asia/Seoul은 +32400000ms (+9시간).
+ */
+function tzOffsetMs(utcMs: number, timezone: string): number {
+  const dtf = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+  const parts = dtf.formatToParts(new Date(utcMs));
+  const get = (type: string) => Number(parts.find((p) => p.type === type)?.value);
+  const asUtc = Date.UTC(
+    get("year"),
+    get("month") - 1,
+    get("day"),
+    get("hour"),
+    get("minute"),
+    get("second")
+  );
+  return asUtc - utcMs;
+}
+
+/**
+ * 입력 값(`value`)을 `Date` 또는 null/undefined로 변환한다.
+ *
+ * - `undefined`  → `undefined` (필드 미지정)
+ * - `null` 또는 빈 문자열 → `null` (명시적 삭제)
+ * - `T`를 포함한 full ISO 문자열 → `new Date(value)` (이미 절대 시각)
+ * - `HH:mm` 형태 → `dayDate`의 날짜(UTC 기준 연/월/일) + HH:mm을 `timezone`의 벽시각으로 해석해 UTC `Date` 반환
+ *   - `timezone`이 null/undefined면 `setUTCHours` fallback (과거 호환)
+ *
+ * `dayDate`는 Day.date (UTC 자정 기준 달력 날짜). 연/월/일은 UTC 값을 그대로 사용.
+ */
+export function toTimestamp(
+  value: string | null | undefined,
+  dayDate: Date,
+  timezone: string | null | undefined
+): Date | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null || value === "") return null;
+  if (value.includes("T")) return new Date(value);
+
+  const match = value.match(/^(\d{2}):(\d{2})/);
+  if (!match) return null;
+
+  const hour = parseInt(match[1], 10);
+  const minute = parseInt(match[2], 10);
+  const year = dayDate.getUTCFullYear();
+  const month = dayDate.getUTCMonth() + 1;
+  const day = dayDate.getUTCDate();
+
+  if (!timezone) {
+    // Fallback: UTC 기준으로 HH:mm을 그대로 사용 (과거 동작, floating-time 보존)
+    const dt = new Date(dayDate);
+    dt.setUTCHours(hour, minute, 0, 0);
+    return dt;
+  }
+
+  return zonedWallTimeToUtc(year, month, day, hour, minute, timezone);
+}

--- a/tests/api/activities.test.ts
+++ b/tests/api/activities.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const { mockPrisma, mockAuthHelpers } = vi.hoisted(() => ({
   mockPrisma: {
-    activity: { findMany: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn() },
+    activity: { findMany: vi.fn(), findUnique: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn() },
     day: { findUnique: vi.fn() },
     $transaction: vi.fn(),
   },
@@ -124,6 +124,30 @@ describe("POST /activities", () => {
     const data = await res.json();
     expect(data.id).toBe(10);
   });
+
+  it("POST converts HH:mm using IANA timezone (#232)", async () => {
+    mockAuth.mockResolvedValue("user1");
+    mockCanEdit.mockResolvedValue(true);
+    mockPrisma.day.findUnique.mockResolvedValue({ id: 1, date: new Date("2026-06-07T00:00:00Z") });
+    mockPrisma.activity.create.mockResolvedValue({ id: 11, category: "DINING", title: "Dinner" });
+
+    await POST(
+      makeRequest({
+        category: "DINING",
+        title: "Dinner",
+        startTime: "20:15",
+        startTimezone: "Europe/Lisbon",
+        endTime: "21:30",
+      }, "POST"),
+      params()
+    );
+
+    const createArgs = mockPrisma.activity.create.mock.calls[0]?.[0] as { data: { startTime: Date; endTime: Date } };
+    expect(createArgs.data.startTime).toBeInstanceOf(Date);
+    // Lisbon 여름(UTC+1): 20:15 = 19:15 UTC, 21:30 = 20:30 UTC (endTimezone 미지정 시 startTimezone 사용)
+    expect(createArgs.data.startTime.toISOString()).toBe("2026-06-07T19:15:00.000Z");
+    expect(createArgs.data.endTime.toISOString()).toBe("2026-06-07T20:30:00.000Z");
+  });
 });
 
 describe("PATCH /activities (reorder)", () => {
@@ -188,6 +212,7 @@ describe("PUT /activities/{id}", () => {
     mockAuth.mockResolvedValue("user1");
     mockCanEdit.mockResolvedValue(true);
     mockPrisma.day.findUnique.mockResolvedValue({ id: 1, date: new Date("2026-06-07T00:00:00Z") });
+    mockPrisma.activity.findUnique.mockResolvedValue({ startTimezone: null, endTimezone: null });
     const updated = { id: 10, title: "Updated", category: "DINING" };
     mockPrisma.activity.update.mockResolvedValue(updated);
 
@@ -202,6 +227,43 @@ describe("PUT /activities/{id}", () => {
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.title).toBe("Updated");
+  });
+
+  it("PUT with startTimezone uses IANA tz for HH:mm → UTC", async () => {
+    mockAuth.mockResolvedValue("user1");
+    mockCanEdit.mockResolvedValue(true);
+    mockPrisma.day.findUnique.mockResolvedValue({ id: 1, date: new Date("2026-06-07T00:00:00Z") });
+    mockPrisma.activity.update.mockResolvedValue({ id: 10, title: "X", category: "DINING" });
+
+    await PUT(
+      makeRequest({ startTime: "13:00", startTimezone: "Asia/Seoul" }, "PUT"),
+      activityParams()
+    );
+
+    // findUnique는 호출되지 않아야 한다 (startTimezone이 요청에 있으므로)
+    expect(mockPrisma.activity.findUnique).not.toHaveBeenCalled();
+    // update의 startTime은 Seoul 13:00 = 04:00Z
+    const updateArgs = mockPrisma.activity.update.mock.calls[0]?.[0] as { data: { startTime: Date } };
+    expect(updateArgs.data.startTime).toBeInstanceOf(Date);
+    expect(updateArgs.data.startTime.toISOString()).toBe("2026-06-07T04:00:00.000Z");
+  });
+
+  it("PUT with only startTime (no tz in body) falls back to stored timezone", async () => {
+    mockAuth.mockResolvedValue("user1");
+    mockCanEdit.mockResolvedValue(true);
+    mockPrisma.day.findUnique.mockResolvedValue({ id: 1, date: new Date("2026-06-07T00:00:00Z") });
+    mockPrisma.activity.findUnique.mockResolvedValue({ startTimezone: "Europe/Lisbon", endTimezone: "Europe/Lisbon" });
+    mockPrisma.activity.update.mockResolvedValue({ id: 10, title: "X", category: "DINING" });
+
+    await PUT(
+      makeRequest({ startTime: "20:15" }, "PUT"),
+      activityParams()
+    );
+
+    expect(mockPrisma.activity.findUnique).toHaveBeenCalled();
+    const updateArgs = mockPrisma.activity.update.mock.calls[0]?.[0] as { data: { startTime: Date } };
+    // Lisbon 여름(WEST, UTC+1) 20:15 = 19:15 UTC
+    expect(updateArgs.data.startTime.toISOString()).toBe("2026-06-07T19:15:00.000Z");
   });
 });
 

--- a/tests/components/ActivityCard.test.tsx
+++ b/tests/components/ActivityCard.test.tsx
@@ -116,6 +116,36 @@ describe("ActivityCard", () => {
     expect(screen.queryByText(/\d{2}:\d{2}/)).not.toBeInTheDocument();
   });
 
+  it("renders time in the activity's IANA timezone (#232)", () => {
+    // 04:00 UTC → Asia/Seoul 13:00
+    render(
+      <ActivityCard
+        activity={makeActivity({
+          startTime: "2026-06-07T04:00:00.000Z",
+          endTime: "2026-06-07T06:00:00.000Z",
+          startTimezone: "Asia/Seoul",
+          endTimezone: "Asia/Seoul",
+        })}
+      />
+    );
+    // "13:00 GMT+9"(또는 "13:00 KST" 등 — 실제 abbr은 ICU 의존) 형태 검증
+    expect(screen.getByText(/^13:00 .+–15:00 .+$/)).toBeInTheDocument();
+  });
+
+  it("renders time in Europe/Lisbon DST (WEST, UTC+1)", () => {
+    // 19:15 UTC + Europe/Lisbon 여름 = 20:15
+    render(
+      <ActivityCard
+        activity={makeActivity({
+          startTime: "2026-06-07T19:15:00.000Z",
+          endTime: null,
+          startTimezone: "Europe/Lisbon",
+        })}
+      />
+    );
+    expect(screen.getByText(/^20:15 .+$/)).toBeInTheDocument();
+  });
+
   it("renders all category types", () => {
     const categories: ActivityCategory[] = [
       "SIGHTSEEING", "DINING", "TRANSPORT", "ACCOMMODATION", "SHOPPING", "OTHER",

--- a/tests/lib/activity-time.test.ts
+++ b/tests/lib/activity-time.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { toTimestamp } from "@/lib/activity-time";
+
+/**
+ * toTimestamp(#232 수정 포함) 단위 테스트.
+ *
+ * 핵심 요구:
+ *   - HH:mm + timezone → 로컬 벽시각을 UTC로 변환해 저장.
+ *   - timezone === null/undefined → 과거 동작(UTC HH:mm) 유지.
+ *   - `T`가 포함된 full ISO는 `new Date()`로 파싱.
+ *   - undefined → undefined, null/빈 문자열 → null.
+ */
+describe("toTimestamp", () => {
+  const day = new Date("2026-06-07T00:00:00Z");
+
+  it("undefined는 undefined 반환", () => {
+    expect(toTimestamp(undefined, day, "Asia/Seoul")).toBeUndefined();
+  });
+
+  it("null은 null 반환", () => {
+    expect(toTimestamp(null, day, "Asia/Seoul")).toBeNull();
+  });
+
+  it("빈 문자열은 null 반환", () => {
+    expect(toTimestamp("", day, "Asia/Seoul")).toBeNull();
+  });
+
+  it("잘못된 형식은 null 반환", () => {
+    expect(toTimestamp("not-a-time", day, "Asia/Seoul")).toBeNull();
+  });
+
+  it("full ISO 문자열은 그대로 파싱", () => {
+    const r = toTimestamp("2026-06-07T10:00:00Z", day, "Asia/Seoul");
+    expect(r).toBeInstanceOf(Date);
+    expect((r as Date).toISOString()).toBe("2026-06-07T10:00:00.000Z");
+  });
+
+  it("Seoul 13:00 + Asia/Seoul → 04:00 UTC", () => {
+    const r = toTimestamp("13:00", day, "Asia/Seoul") as Date;
+    expect(r.toISOString()).toBe("2026-06-07T04:00:00.000Z");
+  });
+
+  it("Lisbon 20:15 + Europe/Lisbon(WEST, UTC+1) → 19:15 UTC (2026-06-07은 DST 적용)", () => {
+    const r = toTimestamp("20:15", day, "Europe/Lisbon") as Date;
+    expect(r.toISOString()).toBe("2026-06-07T19:15:00.000Z");
+  });
+
+  it("Lisbon 09:00 + Europe/Lisbon 겨울(WET, UTC+0) → 09:00 UTC", () => {
+    const winterDay = new Date("2026-01-15T00:00:00Z");
+    const r = toTimestamp("09:00", winterDay, "Europe/Lisbon") as Date;
+    expect(r.toISOString()).toBe("2026-01-15T09:00:00.000Z");
+  });
+
+  it("null timezone → 과거 UTC 동작(HH:mm을 UTC로 저장)", () => {
+    const r = toTimestamp("13:00", day, null) as Date;
+    expect(r.toISOString()).toBe("2026-06-07T13:00:00.000Z");
+  });
+
+  it("undefined timezone → 과거 UTC 동작", () => {
+    const r = toTimestamp("13:00", day, undefined) as Date;
+    expect(r.toISOString()).toBe("2026-06-07T13:00:00.000Z");
+  });
+
+  it("America/New_York(EDT, UTC-4) 여름 09:30 → 13:30 UTC", () => {
+    const summerDay = new Date("2026-07-04T00:00:00Z");
+    const r = toTimestamp("09:30", summerDay, "America/New_York") as Date;
+    expect(r.toISOString()).toBe("2026-07-04T13:30:00.000Z");
+  });
+
+  it("HH:mm:ss 포맷도 HH:mm 부분만 인식", () => {
+    const r = toTimestamp("13:00:45", day, "Asia/Seoul") as Date;
+    expect(r.toISOString()).toBe("2026-06-07T04:00:00.000Z");
+  });
+
+  it("Pacific/Auckland(NZST, UTC+12) 겨울 23:45 → 같은 날 11:45 UTC", () => {
+    // Day.date는 UTC 자정 기준 "로컬 달력 날짜"다. 2026-07-01 NZ = 2026-07-01T12:00:00Z(UTC).
+    // 벽시각 2026-07-01 23:45 @ +12:00 = 2026-07-01 11:45Z.
+    const winterDay = new Date("2026-07-01T00:00:00Z");
+    const r = toTimestamp("23:45", winterDay, "Pacific/Auckland") as Date;
+    expect(r.toISOString()).toBe("2026-07-01T11:45:00.000Z");
+  });
+
+  it("Pacific/Auckland(+12) 00:30 → 전일 12:30 UTC", () => {
+    // 벽시각 2026-07-01 00:30 @ +12:00 = 2026-06-30 12:30Z.
+    const day2 = new Date("2026-07-01T00:00:00Z");
+    const r = toTimestamp("00:30", day2, "Pacific/Auckland") as Date;
+    expect(r.toISOString()).toBe("2026-06-30T12:30:00.000Z");
+  });
+});


### PR DESCRIPTION
## Summary

Activity의 `startTime`/`endTime`이 "로컬 HH:mm을 UTC로 가정"한 floating-time으로 저장되고 있었다. IANA timezone 기반으로 실제 UTC 시각 저장 + 표시 시 원본 시간대로 렌더하도록 수정.

## Root cause

- API `toTimestamp`가 `setUTCHours`로 HH:mm을 그대로 UTC로 기록 → Timestamptz 컬럼이 사실상 floating
- 프론트 `formatTime`이 `getUTCHours()`로 표시 → 화면상 "맞아 보이지만" 실제 UTC는 틀림
- 결과: iCal export/정렬/다중 timezone 섞인 Day에서 순서 오류, 외부 시스템 연동 시 버그

## Changes

- `src/lib/activity-time.ts` 신규: `toTimestamp(value, dayDate, timezone)` 공통 유틸. DST 경계 보정 포함.
- POST `src/app/api/trips/[id]/days/[dayId]/activities/route.ts`: startTimezone/endTimezone 전달
- PUT `src/app/api/trips/[id]/days/[dayId]/activities/[activityId]/route.ts`: 동일
- `src/components/ActivityCard.tsx`: `Intl.DateTimeFormat({ timeZone })` 기반 표시
- `prisma/migrations/20260417120000_fix_activity_timezone_utc/migration.sql`: floating-time → 실제 UTC 재계산 (`AT TIME ZONE`)

## Migration

`[migration-type: data-migration]`. Postgres의 `AT TIME ZONE` 연산으로 `start_timezone`/`end_timezone` 값을 기준으로 UTC 재계산.

**Idempotency 주의:** SQL 자체는 재실행 시 이중 변환됨. Prisma 러너가 한 번만 적용하므로 정상 경로는 안전. 수동 재적용 금지. 롤백 SQL은 migration.sql 주석에 기재.

## Test plan

- [x] `tests/lib/activity-time.test.ts` — Seoul/Lisbon/DST 경계 단위 테스트
- [x] `tests/api/activities.test.ts` — POST timezone 적용 검증
- [x] `tests/components/ActivityCard.test.tsx` — 표시 timezone 검증
- [x] `npm test` 152/152 통과 (3 pre-existing unhandled rejection은 무관)
- [ ] dev 배포 후 신혼여행(trip 5)에서 시각 표시가 기존과 동일한지 시각 검증

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)