### PR TITLE
chore: dependabot npm-major/pip-major 그룹 해제 (#248)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,29 +4,26 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     groups:
       npm-minor-patch:
         update-types:
           - "minor"
           - "patch"
-      npm-major:
-        update-types:
-          - "major"
+    # major는 그룹화하지 않는다. 패키지별 개별 PR로 breaking change 영향을
+    # 독립 평가·머지할 수 있도록 유지. (#248 참조)
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     groups:
       pip-minor-patch:
         update-types:
           - "minor"
           - "patch"
-      pip-major:
-        update-types:
-          - "major"
+    # major는 그룹화하지 않는다. (#248 참조)
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

npm/pip major 업데이트의 단일 그룹화를 해제. 패키지별 개별 PR로 분리하여 breaking change 영향을 독립 평가·머지.

## Why

#247 (7개 npm major 한 덩어리)에서 Vercel 빌드 실패 시 전체가 머지 불가 상태가 됨. 메이저 업그레이드는 각각 codemod·마이그레이션·검증 루트가 달라 묶을 이유가 없음.

## Changes

- `.github/dependabot.yml`
  - `npm-major`, `pip-major` 그룹 정의 제거
  - `open-pull-requests-limit` 5 → 10

minor/patch와 github-actions 그룹은 그대로 유지.

## Follow-up

- #247 close (원본 7건 덩어리 PR)
- 다음 dependabot 스캔 주기에 패키지별 major PR이 올라오면 분할 이슈(#249~#254)에서 각각 머지

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)