### PR TITLE
release: v2.3.2 — 핫픽스 (Day 상세 500 / DYNAMIC_SERVER_USAGE)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"5e35dfd5-87c3-41ff-9276-ccf8e5624467","pid":14020,"acquiredAt":1776422183728}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"5e35dfd5-87c3-41ff-9276-ccf8e5624467","pid":14020,"acquiredAt":1776422183728}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,29 +4,26 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     groups:
       npm-minor-patch:
         update-types:
           - "minor"
           - "patch"
-      npm-major:
-        update-types:
-          - "major"
+    # major는 그룹화하지 않는다. 패키지별 개별 PR로 breaking change 영향을
+    # 독립 평가·머지할 수 있도록 유지. (#248 참조)
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     groups:
       pip-minor-patch:
         update-types:
           - "minor"
           - "patch"
-      pip-major:
-        update-types:
-          - "major"
+    # major는 그룹화하지 않는다. (#248 참조)
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ next-env.d.ts
 out/
 .vercel
 .env*.local
+.claude/scheduled_tasks.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.2] - 2026-04-19
+
+### Fixed
+- **Hotfix: Day 상세 페이지 500 (DYNAMIC_SERVER_USAGE)**: v2.3.1의 `trips/` 디렉토리 제거(#239)로 `generateStaticParams`가 빈 배열을 반환하면서, `auth()`를 호출하는 동일 페이지가 Next.js의 SSG 플래그와 충돌해 런타임 500이 발생. `src/app/trips/[id]/page.tsx`, `src/app/trips/[id]/day/[dayId]/page.tsx`, `src/app/day/[num]/page.tsx`에서 `generateStaticParams` 제거 + `export const dynamic = "force-dynamic"` 명시로 세션 기반 동적 렌더 고정. 레거시 `/day/[num]`는 홈으로 리다이렉트.
+
 ## [2.3.1] - 2026-04-18
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trip-planner-mcp"
-version = "2.3.1"
+version = "2.3.2"
 description = "여행 숙소, 항공편, 관광지 검색 + 구조화 활동 관리 MCP 서버 (20개 도구)"
 requires-python = ">=3.10"
 license = "MIT"

--- a/src/app/day/[num]/page.tsx
+++ b/src/app/day/[num]/page.tsx
@@ -1,30 +1,8 @@
 import { redirect } from "next/navigation";
-import { getAllTripSlugs, getAllDays } from "@/lib/trips";
 
-export async function generateStaticParams() {
-  const slugs = getAllTripSlugs();
-  const params: { num: string }[] = [];
+// 레거시 마크다운 경로 (#239로 소스 제거). 남은 외부 링크는 홈으로 리다이렉트.
+export const dynamic = "force-dynamic";
 
-  for (const slug of slugs) {
-    const days = await getAllDays(slug);
-    for (const day of days) {
-      params.push({ num: day.slug });
-    }
-  }
-  return params;
-}
-
-export default async function LegacyDayPage({
-  params,
-}: {
-  params: Promise<{ num: string }>;
-}) {
-  const { num } = await params;
-  const slugs = getAllTripSlugs();
-
-  if (slugs.length > 0) {
-    redirect(`/trips/${slugs[0]}/day/${num}`);
-  }
-
+export default async function LegacyDayPage() {
   redirect("/");
 }

--- a/src/app/trips/[id]/day/[dayId]/page.tsx
+++ b/src/app/trips/[id]/day/[dayId]/page.tsx
@@ -28,17 +28,10 @@ async function markdownToHtml(md: string): Promise<string> {
   return result.toString();
 }
 
-export async function generateStaticParams() {
-  const slugs = getAllTripSlugs();
-  const params: { id: string; dayId: string }[] = [];
-  for (const slug of slugs) {
-    const days = await getAllDays(slug);
-    for (const day of days) {
-      params.push({ id: slug, dayId: day.slug });
-    }
-  }
-  return params;
-}
+// DB-정본 전환(#239) 후 이 페이지는 항상 세션 기반 동적 렌더. generateStaticParams
+// 제거 + force-dynamic. 남은 MarkdownDayPage 브랜치는 trips/ 파일 부재로 항상
+// notFound()로 귀결된다.
+export const dynamic = "force-dynamic";
 
 export default async function DayDetailPage({
   params,

--- a/src/app/trips/[id]/page.tsx
+++ b/src/app/trips/[id]/page.tsx
@@ -27,10 +27,8 @@ async function markdownToHtml(md: string): Promise<string> {
   return result.toString();
 }
 
-export async function generateStaticParams() {
-  const slugs = getAllTripSlugs();
-  return slugs.map((slug) => ({ id: slug }));
-}
+// DB-정본 전환(#239) 후 이 페이지는 항상 세션 기반 동적 렌더. (#255+ 핫픽스)
+export const dynamic = "force-dynamic";
 
 export default async function TripDetailPage({
   params,


### PR DESCRIPTION
## 🚨 Hotfix release

v2.3.1 릴리즈 후 프로덕션 `/trips/[id]/day/[dayId]` 런타임 500 발생 (DYNAMIC_SERVER_USAGE). 즉시 해소.

## Root cause

v2.3.1에서 `trips/` 디렉토리를 제거(#239)한 결과 `generateStaticParams`가 빈 배열을 반환. 페이지가 `auth()`·`prisma.*`를 호출하는 구조와 SSG 플래그가 충돌 → Next.js 15 런타임 500.

## Fix

- `generateStaticParams` 제거 (마크다운 소스 없음)
- `export const dynamic = "force-dynamic"` 명시
- 레거시 `/day/[num]` 홈으로 리다이렉트로 단순화
- v2.3.2 버전 범프 + CHANGELOG

## PR

- #256 hotfix → develop (머지됨)

## 검증

- dev.trip.idean.me/trips/5/day/58 — 500 해소 확인 필요
- prod trip.idean.me/trips/5/day/58 — 머지·배포 후 재확인

## Follow-up

- `src/lib/trips.ts` 마크다운 fallback 완전 제거 (현재 dead code)
- MarkdownTripPage / MarkdownDayPage 브랜치 제거
- 별건 chore 이슈로 다룸

🤖 Generated with [Claude Code](https://claude.com/claude-code)