### PR TITLE
chore: dependabot 타겟 브랜치를 develop으로 고정

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 10
@@ -15,6 +16,7 @@ updates:
 
   - package-ecosystem: "pip"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 10
@@ -27,6 +29,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

dependabot PR이 기본값으로 \`main\`을 타겟하면서 Git Flow Lite(feature → develop PR) 정책을 우회했다. #245(actions), #246(npm-minor-patch)가 main 직접 타겟으로 생성됨.

## Fix

- \`.github/dependabot.yml\`에 세 생태계(npm, pip, github-actions) 모두 \`target-branch: "develop"\` 추가
- 기존 PR(#245, #246)은 \`gh pr edit --base develop\`으로 수동 변경 완료

## Why

- develop → main 릴리즈 경로로 dev 환경 검증 경유
- dependabot 자동 PR도 정규 플로우에 속해야 main 보호 규칙을 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)