### PR TITLE
release: v2.3.3 버전 범프 + CHANGELOG 고정

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.3] - 2026-04-19
+
+### Changed
+- **dependabot 플로우 정규화**: `target-branch: develop` 추가(npm, pip, github-actions). dependabot PR이 기본값으로 `main`을 타겟하면서 Git Flow Lite(feature/hotfix → develop PR) 정책을 우회하던 문제 해소. (#258)
+
+### Chore (deps)
+- **GitHub Actions**: `actions/checkout` 4 → 6, `astral-sh/setup-uv` 업데이트. (#245)
+- **npm**: `postcss` 8.5.9 → 8.5.10, `eslint-config-next` 업데이트. (#246)
+
 ## [2.3.2] - 2026-04-19
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trip-planner-mcp"
-version = "2.3.2"
+version = "2.3.3"
 description = "여행 숙소, 항공편, 관광지 검색 + 구조화 활동 관리 MCP 서버 (20개 도구)"
 requires-python = ">=3.10"
 license = "MIT"


### PR DESCRIPTION
## Summary

v2.3.3 패치 릴리즈용 버전 범프 + CHANGELOG 추가.

## Milestone

v2.3.3

## 포함 PR

- #258 chore: dependabot target-branch develop로 고정
- #245 chore(deps): github-actions 그룹 업데이트 (checkout 4→6, setup-uv)
- #246 chore(deps): npm-minor-patch 그룹 업데이트 (postcss, eslint-config-next)

본 PR 머지 후 develop → main 릴리즈 PR 별도 생성.

🤖 Generated with [Claude Code](https://claude.com/claude-code)