### PR TITLE
chore: dependabot에 추적 메이저 7건 ignore 추가

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,23 @@ updates:
           - "patch"
     # major는 그룹화하지 않는다. 패키지별 개별 PR로 breaking change 영향을
     # 독립 평가·머지할 수 있도록 유지. (#248 참조)
+    # 아래는 codemod·마이그레이션이 필요한 메이저 버전업이다. 각 추적 이슈에서
+    # 개별 업그레이드 작업을 진행하고, 완료 후 해당 ignore 블록을 제거한다.
+    ignore:
+      - dependency-name: "next"
+        update-types: ["version-update:semver-major"]  # #249
+      - dependency-name: "tailwindcss"
+        update-types: ["version-update:semver-major"]  # #250
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]  # #251
+      - dependency-name: "vitest"
+        update-types: ["version-update:semver-major"]  # #252
+      - dependency-name: "@vitest/coverage-v8"
+        update-types: ["version-update:semver-major"]  # #252
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]  # #253
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]  # #254
 
   - package-ecosystem: "pip"
     directory: "/"


### PR DESCRIPTION
## Summary

#248로 메이저 그룹 해제 후 다음 dependabot 스캔에서 7개 메이저가 개별 PR(#261~#267)로 생성됐다. 모두 codemod·마이그레이션이 필요해 나이브 버전범프로 머지 불가 → 이미 닫고 추적 이슈로 흡수. 동일 PR 재생성 억제를 위해 ignore 규칙 추가.

## Ignored (각각 추적 이슈에서 업그레이드 작업)

- next → #249
- tailwindcss → #250
- typescript → #251
- vitest, @vitest/coverage-v8 → #252
- eslint → #253
- @types/node → #254

## 해제 절차

각 업그레이드 PR 머지 시 해당 ignore 블록 제거.

🤖 Generated with [Claude Code](https://claude.com/claude-code)