### PR TITLE
fix(speckit): create-new-feature.sh가 기존 NNN-* 브랜치 재사용하도록

### DIFF
--- a/.specify/scripts/bash/create-new-feature.sh
+++ b/.specify/scripts/bash/create-new-feature.sh
@@ -116,8 +116,9 @@ get_highest_from_branches() {
     
     if [ -n "$branches" ]; then
         while IFS= read -r branch; do
-            # Clean branch name: remove leading markers and remote prefixes
-            clean_branch=$(echo "$branch" | sed 's/^[* ]*//; s|^remotes/[^/]*/||')
+            # Clean branch name: remove leading markers (* current, + worktree-checked-out)
+            # and remote prefixes
+            clean_branch=$(echo "$branch" | sed 's/^[+* ]*//; s|^remotes/[^/]*/||')
             
             # Extract feature number if branch matches pattern ###-*
             if echo "$clean_branch" | grep -q '^[0-9]\{3\}-'; then
@@ -185,6 +186,21 @@ cd "$REPO_ROOT"
 SPECS_DIR="$REPO_ROOT/specs"
 mkdir -p "$SPECS_DIR"
 
+# Reuse current branch if caller (e.g. devex:flow) already set one up.
+# Conditions: on a NNN-<suffix> branch AND no spec directory exists for it yet.
+# This prevents collisions when the caller creates the worktree/branch before
+# invoking /speckit.specify.
+REUSE_CURRENT_BRANCH=false
+if [ "$HAS_GIT" = true ]; then
+    CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+    if [[ "$CURRENT_BRANCH" =~ ^[0-9]{3}-.+ ]] && [ ! -d "$SPECS_DIR/$CURRENT_BRANCH" ]; then
+        REUSE_CURRENT_BRANCH=true
+        BRANCH_NAME="$CURRENT_BRANCH"
+        FEATURE_NUM=$(printf "%03d" "$((10#$(echo "$CURRENT_BRANCH" | grep -oE '^[0-9]{3}')))")
+        >&2 echo "[specify] Reusing current branch: $BRANCH_NAME (caller-provided)"
+    fi
+fi
+
 # Function to generate branch name with stop word filtering and length filtering
 generate_branch_name() {
     local description="$1"
@@ -233,65 +249,67 @@ generate_branch_name() {
     fi
 }
 
-# Generate branch name
-if [ -n "$SHORT_NAME" ]; then
-    # Use provided short name, just clean it up
-    BRANCH_SUFFIX=$(clean_branch_name "$SHORT_NAME")
-else
-    # Generate from description with smart filtering
-    BRANCH_SUFFIX=$(generate_branch_name "$FEATURE_DESCRIPTION")
-fi
-
-# Determine branch number
-if [ -z "$BRANCH_NUMBER" ]; then
-    if [ "$HAS_GIT" = true ]; then
-        # Check existing branches on remotes
-        BRANCH_NUMBER=$(check_existing_branches "$SPECS_DIR")
+if [ "$REUSE_CURRENT_BRANCH" = false ]; then
+    # Generate branch name
+    if [ -n "$SHORT_NAME" ]; then
+        # Use provided short name, just clean it up
+        BRANCH_SUFFIX=$(clean_branch_name "$SHORT_NAME")
     else
-        # Fall back to local directory check
-        HIGHEST=$(get_highest_from_specs "$SPECS_DIR")
-        BRANCH_NUMBER=$((HIGHEST + 1))
+        # Generate from description with smart filtering
+        BRANCH_SUFFIX=$(generate_branch_name "$FEATURE_DESCRIPTION")
     fi
-fi
 
-# Force base-10 interpretation to prevent octal conversion (e.g., 010 → 8 in octal, but should be 10 in decimal)
-FEATURE_NUM=$(printf "%03d" "$((10#$BRANCH_NUMBER))")
-BRANCH_NAME="${FEATURE_NUM}-${BRANCH_SUFFIX}"
-
-# GitHub enforces a 244-byte limit on branch names
-# Validate and truncate if necessary
-MAX_BRANCH_LENGTH=244
-if [ ${#BRANCH_NAME} -gt $MAX_BRANCH_LENGTH ]; then
-    # Calculate how much we need to trim from suffix
-    # Account for: feature number (3) + hyphen (1) = 4 chars
-    MAX_SUFFIX_LENGTH=$((MAX_BRANCH_LENGTH - 4))
-    
-    # Truncate suffix at word boundary if possible
-    TRUNCATED_SUFFIX=$(echo "$BRANCH_SUFFIX" | cut -c1-$MAX_SUFFIX_LENGTH)
-    # Remove trailing hyphen if truncation created one
-    TRUNCATED_SUFFIX=$(echo "$TRUNCATED_SUFFIX" | sed 's/-$//')
-    
-    ORIGINAL_BRANCH_NAME="$BRANCH_NAME"
-    BRANCH_NAME="${FEATURE_NUM}-${TRUNCATED_SUFFIX}"
-    
-    >&2 echo "[specify] Warning: Branch name exceeded GitHub's 244-byte limit"
-    >&2 echo "[specify] Original: $ORIGINAL_BRANCH_NAME (${#ORIGINAL_BRANCH_NAME} bytes)"
-    >&2 echo "[specify] Truncated to: $BRANCH_NAME (${#BRANCH_NAME} bytes)"
-fi
-
-if [ "$HAS_GIT" = true ]; then
-    if ! git checkout -b "$BRANCH_NAME" 2>/dev/null; then
-        # Check if branch already exists
-        if git branch --list "$BRANCH_NAME" | grep -q .; then
-            >&2 echo "Error: Branch '$BRANCH_NAME' already exists. Please use a different feature name or specify a different number with --number."
-            exit 1
+    # Determine branch number
+    if [ -z "$BRANCH_NUMBER" ]; then
+        if [ "$HAS_GIT" = true ]; then
+            # Check existing branches on remotes
+            BRANCH_NUMBER=$(check_existing_branches "$SPECS_DIR")
         else
-            >&2 echo "Error: Failed to create git branch '$BRANCH_NAME'. Please check your git configuration and try again."
-            exit 1
+            # Fall back to local directory check
+            HIGHEST=$(get_highest_from_specs "$SPECS_DIR")
+            BRANCH_NUMBER=$((HIGHEST + 1))
         fi
     fi
-else
-    >&2 echo "[specify] Warning: Git repository not detected; skipped branch creation for $BRANCH_NAME"
+
+    # Force base-10 interpretation to prevent octal conversion (e.g., 010 → 8 in octal, but should be 10 in decimal)
+    FEATURE_NUM=$(printf "%03d" "$((10#$BRANCH_NUMBER))")
+    BRANCH_NAME="${FEATURE_NUM}-${BRANCH_SUFFIX}"
+
+    # GitHub enforces a 244-byte limit on branch names
+    # Validate and truncate if necessary
+    MAX_BRANCH_LENGTH=244
+    if [ ${#BRANCH_NAME} -gt $MAX_BRANCH_LENGTH ]; then
+        # Calculate how much we need to trim from suffix
+        # Account for: feature number (3) + hyphen (1) = 4 chars
+        MAX_SUFFIX_LENGTH=$((MAX_BRANCH_LENGTH - 4))
+
+        # Truncate suffix at word boundary if possible
+        TRUNCATED_SUFFIX=$(echo "$BRANCH_SUFFIX" | cut -c1-$MAX_SUFFIX_LENGTH)
+        # Remove trailing hyphen if truncation created one
+        TRUNCATED_SUFFIX=$(echo "$TRUNCATED_SUFFIX" | sed 's/-$//')
+
+        ORIGINAL_BRANCH_NAME="$BRANCH_NAME"
+        BRANCH_NAME="${FEATURE_NUM}-${TRUNCATED_SUFFIX}"
+
+        >&2 echo "[specify] Warning: Branch name exceeded GitHub's 244-byte limit"
+        >&2 echo "[specify] Original: $ORIGINAL_BRANCH_NAME (${#ORIGINAL_BRANCH_NAME} bytes)"
+        >&2 echo "[specify] Truncated to: $BRANCH_NAME (${#BRANCH_NAME} bytes)"
+    fi
+
+    if [ "$HAS_GIT" = true ]; then
+        if ! git checkout -b "$BRANCH_NAME" 2>/dev/null; then
+            # Check if branch already exists
+            if git branch --list "$BRANCH_NAME" | grep -q .; then
+                >&2 echo "Error: Branch '$BRANCH_NAME' already exists. Please use a different feature name or specify a different number with --number."
+                exit 1
+            else
+                >&2 echo "Error: Failed to create git branch '$BRANCH_NAME'. Please check your git configuration and try again."
+                exit 1
+            fi
+        fi
+    else
+        >&2 echo "[specify] Warning: Git repository not detected; skipped branch creation for $BRANCH_NAME"
+    fi
 fi
 
 FEATURE_DIR="$SPECS_DIR/$BRANCH_NAME"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.4] - 2026-04-19
+
+### Fixed
+- **speckit `create-new-feature.sh` 워크트리 분기 충돌**: 호출자(devex:flow 등)가 `NNN-*` 브랜치를 선행 생성한 상태에서 `/speckit.specify` 호출 시 스크립트가 `git checkout -b`를 다시 시도하며 충돌. 현재 브랜치가 `NNN-<suffix>` 패턴이고 `specs/<branch>/`가 아직 없으면 해당 브랜치를 재사용하도록 감지 블록 추가. 동시에 `git branch -a` 파싱 시 워크트리 체크아웃 마커(`+`)를 sed 필터에 반영하여 타 워크트리에서 체크아웃된 브랜치가 자동 채번에서 누락되던 부수 버그도 수정.
+
 ## [2.3.3] - 2026-04-19
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trip-planner-mcp"
-version = "2.3.3"
+version = "2.3.4"
 description = "여행 숙소, 항공편, 관광지 검색 + 구조화 활동 관리 MCP 서버 (20개 도구)"
 requires-python = ">=3.10"
 license = "MIT"


### PR DESCRIPTION
## 작업 내용

devex:flow 등 외부 호출자가 워크트리 + NNN-* 브랜치를 선행 생성한 상태에서 `/speckit.specify` 호출 시 `create-new-feature.sh`가 `git checkout -b`를 재시도하면서 충돌하던 문제 해결.

## 변경 사항

### 주 패치: 현재 브랜치 재사용 감지
- 현재 브랜치가 `^[0-9]{3}-.+` 패턴이고 `specs/<branch>/`가 아직 없으면 해당 브랜치를 재사용
- 재사용 시 `git checkout -b` 스킵, FEATURE_NUM은 브랜치 prefix에서 추출
- `>&2 echo "[specify] Reusing current branch: ..."` 로그 출력

### 부수 버그: `+` 마커 필터 누락
- `git branch -a` 출력에서 타 워크트리 체크아웃 브랜치는 `+` 마커가 붙음
- 기존 sed는 `[* ]*`만 벗겨서 `+ 010-foo` → 번호 추출 실패
- `[+* ]*`로 확장해 워크트리 브랜치도 정상 집계

## 자가 검증

| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ⬜ 해당없음 | bash 스크립트만 변경 |
| 테스트 | ✅ 통과 | 워크트리에서 재사용 감지 + 메인에서 자동 채번 011 확인 |
| 문서 동기화 | ✅ 완료 | CHANGELOG v2.3.4 섹션 추가 |

### 동작 확인

1. `010-project-identity-surface` 워크트리에서 스크립트 실행 → `Reusing current branch: 010-project-identity-surface` 출력, 번호/브랜치 그대로 재사용
2. develop에서 실행 → 자동 채번으로 `011-*` 할당 (이전엔 `010-*` 중복 할당 버그 있었음)

## 배경

devex(범용 플러그인)와 speckit 하네스(프로젝트 종속)가 모두 브랜치 생성 책임을 주장해 충돌. 본 패치는 speckit 측이 caller의 브랜치를 존중하도록 계약을 바꾼다. 플러그인 외부화 구조는 유지.