### PR TITLE
release: v2.4.0 버전 범프 + CHANGELOG 고정

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] - 2026-04-19
+
+### Added
+- **프로젝트 아이덴티티 표면 구축**: 앱을 공유받은 방문자가 프로젝트 출처·API 접근 경로를 즉시 파악할 수 있도록 3종 표면 추가. (#200)
+  - **전역 풋터** — 모든 페이지 하단에 `Made by idean3885`, `GitHub ↗`, `About`, `API Docs ↗` 노출. flex-wrap 단일 레이아웃(브레이크포인트 분기 없음), sticky footer(짧은 콘텐츠 페이지에서도 뷰포트 하단 고정).
+  - **About 페이지** — `/about` 공개 라우트 신설. 프로젝트 배경·저작자·라이선스·기술 스택 요약 표시. 로그인 없이 접근 가능.
+  - **설정 페이지 API 문서 진입점** — 설정 페이지 제목 옆에 "API 문서 →" 링크 추가.
+  - **단일 메타 소스** — `src/lib/project-meta.ts`에 `ProjectMeta` 타입과 `projectMeta` 상수를 `as const satisfies`로 정의. 풋터·About 모두 동일 소스 참조로 drift 구조적 방지.
+  - **공개 라우트 확장** — 미들웨어에 `/about`과 `/docs`를 공개 경로로 추가. 비로그인 방문자도 프로젝트 정체성·API 문서에 도달 가능.
+  - 신규 npm 의존성 0건(아이콘은 유니코드 `↗` 인라인).
+
 ## [2.3.4] - 2026-04-19
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trip-planner-mcp"
-version = "2.3.4"
+version = "2.4.0"
 description = "여행 숙소, 항공편, 관광지 검색 + 구조화 활동 관리 MCP 서버 (20개 도구)"
 requires-python = ">=3.10"
 license = "MIT"


### PR DESCRIPTION
## 작업 내용

v2.4.0 릴리즈를 위한 버전 범프와 CHANGELOG 고정. 본 PR 머지 후 develop → main PR을 통해 프로덕션 태그·PyPI 배포가 자동 트리거된다.

## 변경 사항

- `pyproject.toml`: `version = "2.3.4"` → `"2.4.0"` (MINOR — 기능 추가)
- `CHANGELOG.md`: `## [2.4.0] - 2026-04-19` 섹션 추가

## 포함 기능 (v2.4.0)

- **프로젝트 아이덴티티 표면** (#200, PR #273)
  - 전역 풋터 — Made by idean3885 / GitHub / About / API Docs
  - `/about` 공개 페이지
  - 설정 페이지 API 문서 진입점
  - `src/lib/project-meta.ts` 단일 메타 소스
  - `/about`, `/docs` 공개 라우트 확장

## 버전 기준

SemVer 기준 **MINOR**:
- 새 페이지(`/about`) 추가
- 새 컴포넌트(Footer) 전역 배치
- 기존 API/MCP 도구 변경 없음

## 자가 검증

| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ⬜ 해당없음 | 파일 2건 문서 성격 변경 |
| 테스트 | ⬜ 해당없음 | 릴리즈 메타만 변경 |
| 문서 동기화 | ✅ 완료 | CHANGELOG + pyproject.toml 일치 |
| dev 환경 검증 | ✅ 완료 | PR #273 머지 후 dev.trip.idean.me 배포 Ready 확인 |

## 후속 작업

본 PR 머지 후:
1. `develop → main` PR 생성 (별도)
2. main 머지 → `auto-tag.yml`이 v2.4.0 annotated 태그 생성
3. `auto-release.yml` + `pypi-publish.yml` 연쇄 실행으로 GitHub Release + PyPI 배포

Refs #200