### PR TITLE
release(v2.4.0): 프로젝트 아이덴티티 표면 + speckit 하네스 개선

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,23 @@ updates:
           - "patch"
     # major는 그룹화하지 않는다. 패키지별 개별 PR로 breaking change 영향을
     # 독립 평가·머지할 수 있도록 유지. (#248 참조)
+    # 아래는 codemod·마이그레이션이 필요한 메이저 버전업이다. 각 추적 이슈에서
+    # 개별 업그레이드 작업을 진행하고, 완료 후 해당 ignore 블록을 제거한다.
+    ignore:
+      - dependency-name: "next"
+        update-types: ["version-update:semver-major"]  # #249
+      - dependency-name: "tailwindcss"
+        update-types: ["version-update:semver-major"]  # #250
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]  # #251
+      - dependency-name: "vitest"
+        update-types: ["version-update:semver-major"]  # #252
+      - dependency-name: "@vitest/coverage-v8"
+        update-types: ["version-update:semver-major"]  # #252
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]  # #253
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]  # #254
 
   - package-ecosystem: "pip"
     directory: "/"

--- a/.specify/scripts/bash/create-new-feature.sh
+++ b/.specify/scripts/bash/create-new-feature.sh
@@ -116,8 +116,9 @@ get_highest_from_branches() {
     
     if [ -n "$branches" ]; then
         while IFS= read -r branch; do
-            # Clean branch name: remove leading markers and remote prefixes
-            clean_branch=$(echo "$branch" | sed 's/^[* ]*//; s|^remotes/[^/]*/||')
+            # Clean branch name: remove leading markers (* current, + worktree-checked-out)
+            # and remote prefixes
+            clean_branch=$(echo "$branch" | sed 's/^[+* ]*//; s|^remotes/[^/]*/||')
             
             # Extract feature number if branch matches pattern ###-*
             if echo "$clean_branch" | grep -q '^[0-9]\{3\}-'; then
@@ -185,6 +186,21 @@ cd "$REPO_ROOT"
 SPECS_DIR="$REPO_ROOT/specs"
 mkdir -p "$SPECS_DIR"
 
+# Reuse current branch if caller (e.g. devex:flow) already set one up.
+# Conditions: on a NNN-<suffix> branch AND no spec directory exists for it yet.
+# This prevents collisions when the caller creates the worktree/branch before
+# invoking /speckit.specify.
+REUSE_CURRENT_BRANCH=false
+if [ "$HAS_GIT" = true ]; then
+    CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+    if [[ "$CURRENT_BRANCH" =~ ^[0-9]{3}-.+ ]] && [ ! -d "$SPECS_DIR/$CURRENT_BRANCH" ]; then
+        REUSE_CURRENT_BRANCH=true
+        BRANCH_NAME="$CURRENT_BRANCH"
+        FEATURE_NUM=$(printf "%03d" "$((10#$(echo "$CURRENT_BRANCH" | grep -oE '^[0-9]{3}')))")
+        >&2 echo "[specify] Reusing current branch: $BRANCH_NAME (caller-provided)"
+    fi
+fi
+
 # Function to generate branch name with stop word filtering and length filtering
 generate_branch_name() {
     local description="$1"
@@ -233,65 +249,67 @@ generate_branch_name() {
     fi
 }
 
-# Generate branch name
-if [ -n "$SHORT_NAME" ]; then
-    # Use provided short name, just clean it up
-    BRANCH_SUFFIX=$(clean_branch_name "$SHORT_NAME")
-else
-    # Generate from description with smart filtering
-    BRANCH_SUFFIX=$(generate_branch_name "$FEATURE_DESCRIPTION")
-fi
-
-# Determine branch number
-if [ -z "$BRANCH_NUMBER" ]; then
-    if [ "$HAS_GIT" = true ]; then
-        # Check existing branches on remotes
-        BRANCH_NUMBER=$(check_existing_branches "$SPECS_DIR")
+if [ "$REUSE_CURRENT_BRANCH" = false ]; then
+    # Generate branch name
+    if [ -n "$SHORT_NAME" ]; then
+        # Use provided short name, just clean it up
+        BRANCH_SUFFIX=$(clean_branch_name "$SHORT_NAME")
     else
-        # Fall back to local directory check
-        HIGHEST=$(get_highest_from_specs "$SPECS_DIR")
-        BRANCH_NUMBER=$((HIGHEST + 1))
+        # Generate from description with smart filtering
+        BRANCH_SUFFIX=$(generate_branch_name "$FEATURE_DESCRIPTION")
     fi
-fi
 
-# Force base-10 interpretation to prevent octal conversion (e.g., 010 → 8 in octal, but should be 10 in decimal)
-FEATURE_NUM=$(printf "%03d" "$((10#$BRANCH_NUMBER))")
-BRANCH_NAME="${FEATURE_NUM}-${BRANCH_SUFFIX}"
-
-# GitHub enforces a 244-byte limit on branch names
-# Validate and truncate if necessary
-MAX_BRANCH_LENGTH=244
-if [ ${#BRANCH_NAME} -gt $MAX_BRANCH_LENGTH ]; then
-    # Calculate how much we need to trim from suffix
-    # Account for: feature number (3) + hyphen (1) = 4 chars
-    MAX_SUFFIX_LENGTH=$((MAX_BRANCH_LENGTH - 4))
-    
-    # Truncate suffix at word boundary if possible
-    TRUNCATED_SUFFIX=$(echo "$BRANCH_SUFFIX" | cut -c1-$MAX_SUFFIX_LENGTH)
-    # Remove trailing hyphen if truncation created one
-    TRUNCATED_SUFFIX=$(echo "$TRUNCATED_SUFFIX" | sed 's/-$//')
-    
-    ORIGINAL_BRANCH_NAME="$BRANCH_NAME"
-    BRANCH_NAME="${FEATURE_NUM}-${TRUNCATED_SUFFIX}"
-    
-    >&2 echo "[specify] Warning: Branch name exceeded GitHub's 244-byte limit"
-    >&2 echo "[specify] Original: $ORIGINAL_BRANCH_NAME (${#ORIGINAL_BRANCH_NAME} bytes)"
-    >&2 echo "[specify] Truncated to: $BRANCH_NAME (${#BRANCH_NAME} bytes)"
-fi
-
-if [ "$HAS_GIT" = true ]; then
-    if ! git checkout -b "$BRANCH_NAME" 2>/dev/null; then
-        # Check if branch already exists
-        if git branch --list "$BRANCH_NAME" | grep -q .; then
-            >&2 echo "Error: Branch '$BRANCH_NAME' already exists. Please use a different feature name or specify a different number with --number."
-            exit 1
+    # Determine branch number
+    if [ -z "$BRANCH_NUMBER" ]; then
+        if [ "$HAS_GIT" = true ]; then
+            # Check existing branches on remotes
+            BRANCH_NUMBER=$(check_existing_branches "$SPECS_DIR")
         else
-            >&2 echo "Error: Failed to create git branch '$BRANCH_NAME'. Please check your git configuration and try again."
-            exit 1
+            # Fall back to local directory check
+            HIGHEST=$(get_highest_from_specs "$SPECS_DIR")
+            BRANCH_NUMBER=$((HIGHEST + 1))
         fi
     fi
-else
-    >&2 echo "[specify] Warning: Git repository not detected; skipped branch creation for $BRANCH_NAME"
+
+    # Force base-10 interpretation to prevent octal conversion (e.g., 010 → 8 in octal, but should be 10 in decimal)
+    FEATURE_NUM=$(printf "%03d" "$((10#$BRANCH_NUMBER))")
+    BRANCH_NAME="${FEATURE_NUM}-${BRANCH_SUFFIX}"
+
+    # GitHub enforces a 244-byte limit on branch names
+    # Validate and truncate if necessary
+    MAX_BRANCH_LENGTH=244
+    if [ ${#BRANCH_NAME} -gt $MAX_BRANCH_LENGTH ]; then
+        # Calculate how much we need to trim from suffix
+        # Account for: feature number (3) + hyphen (1) = 4 chars
+        MAX_SUFFIX_LENGTH=$((MAX_BRANCH_LENGTH - 4))
+
+        # Truncate suffix at word boundary if possible
+        TRUNCATED_SUFFIX=$(echo "$BRANCH_SUFFIX" | cut -c1-$MAX_SUFFIX_LENGTH)
+        # Remove trailing hyphen if truncation created one
+        TRUNCATED_SUFFIX=$(echo "$TRUNCATED_SUFFIX" | sed 's/-$//')
+
+        ORIGINAL_BRANCH_NAME="$BRANCH_NAME"
+        BRANCH_NAME="${FEATURE_NUM}-${TRUNCATED_SUFFIX}"
+
+        >&2 echo "[specify] Warning: Branch name exceeded GitHub's 244-byte limit"
+        >&2 echo "[specify] Original: $ORIGINAL_BRANCH_NAME (${#ORIGINAL_BRANCH_NAME} bytes)"
+        >&2 echo "[specify] Truncated to: $BRANCH_NAME (${#BRANCH_NAME} bytes)"
+    fi
+
+    if [ "$HAS_GIT" = true ]; then
+        if ! git checkout -b "$BRANCH_NAME" 2>/dev/null; then
+            # Check if branch already exists
+            if git branch --list "$BRANCH_NAME" | grep -q .; then
+                >&2 echo "Error: Branch '$BRANCH_NAME' already exists. Please use a different feature name or specify a different number with --number."
+                exit 1
+            else
+                >&2 echo "Error: Failed to create git branch '$BRANCH_NAME'. Please check your git configuration and try again."
+                exit 1
+            fi
+        fi
+    else
+        >&2 echo "[specify] Warning: Git repository not detected; skipped branch creation for $BRANCH_NAME"
+    fi
 fi
 
 FEATURE_DIR="$SPECS_DIR/$BRANCH_NAME"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.4] - 2026-04-19
+
+### Fixed
+- **speckit `create-new-feature.sh` 워크트리 분기 충돌**: 호출자(devex:flow 등)가 `NNN-*` 브랜치를 선행 생성한 상태에서 `/speckit.specify` 호출 시 스크립트가 `git checkout -b`를 다시 시도하며 충돌. 현재 브랜치가 `NNN-<suffix>` 패턴이고 `specs/<branch>/`가 아직 없으면 해당 브랜치를 재사용하도록 감지 블록 추가. 동시에 `git branch -a` 파싱 시 워크트리 체크아웃 마커(`+`)를 sed 필터에 반영하여 타 워크트리에서 체크아웃된 브랜치가 자동 채번에서 누락되던 부수 버그도 수정.
+
 ## [2.3.3] - 2026-04-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] - 2026-04-19
+
+### Added
+- **프로젝트 아이덴티티 표면 구축**: 앱을 공유받은 방문자가 프로젝트 출처·API 접근 경로를 즉시 파악할 수 있도록 3종 표면 추가. (#200)
+  - **전역 풋터** — 모든 페이지 하단에 `Made by idean3885`, `GitHub ↗`, `About`, `API Docs ↗` 노출. flex-wrap 단일 레이아웃(브레이크포인트 분기 없음), sticky footer(짧은 콘텐츠 페이지에서도 뷰포트 하단 고정).
+  - **About 페이지** — `/about` 공개 라우트 신설. 프로젝트 배경·저작자·라이선스·기술 스택 요약 표시. 로그인 없이 접근 가능.
+  - **설정 페이지 API 문서 진입점** — 설정 페이지 제목 옆에 "API 문서 →" 링크 추가.
+  - **단일 메타 소스** — `src/lib/project-meta.ts`에 `ProjectMeta` 타입과 `projectMeta` 상수를 `as const satisfies`로 정의. 풋터·About 모두 동일 소스 참조로 drift 구조적 방지.
+  - **공개 라우트 확장** — 미들웨어에 `/about`과 `/docs`를 공개 경로로 추가. 비로그인 방문자도 프로젝트 정체성·API 문서에 도달 가능.
+  - 신규 npm 의존성 0건(아이콘은 유니코드 `↗` 인라인).
+
 ## [2.3.4] - 2026-04-19
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,7 @@ develop ──●──●──●───●──●──●──●──
 - Neon Postgres (Vercel Marketplace, Prisma ORM) (005-ax-api-mcp)
 - TypeScript 5.x (Next.js 15), Python 3.10+ (MCP 서버) + Next.js App Router, Auth.js v5, Prisma 7.x, FastMCP, httpx (007-oauth-cli-reauth)
 - Neon Postgres (Prisma ORM), macOS Keychain (로컬 토큰 저장) (007-oauth-cli-reauth)
+- TypeScript 5.x, Node.js 20+ + Next.js 15 (App Router), React 19, Tailwind CSS. 신규 의존성 없음. (011-project-identity-surface)
 
 ## Recent Changes
 - 001-ax-travel-planning: Added Python 3.14 + FastMCP, httpx, python-dotenv, pytes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trip-planner-mcp"
-version = "2.3.3"
+version = "2.3.4"
 description = "여행 숙소, 항공편, 관광지 검색 + 구조화 활동 관리 MCP 서버 (20개 도구)"
 requires-python = ">=3.10"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trip-planner-mcp"
-version = "2.3.4"
+version = "2.4.0"
 description = "여행 숙소, 항공편, 관광지 검색 + 구조화 활동 관리 MCP 서버 (20개 도구)"
 requires-python = ">=3.10"
 license = "MIT"

--- a/specs/011-project-identity-surface/checklists/requirements.md
+++ b/specs/011-project-identity-surface/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: 프로젝트 아이덴티티 표면 구축
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-19
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- spec.md Assumptions 섹션에 Next.js App Router 구조 가정이 들어가 있으나, 이는 프로젝트 환경의 기술 전제이지 본 피처의 구현 지시가 아니므로 "implementation details"로 분류하지 않음.
+- Clarifications 4종(단일 데이터 소스 범위, About 우선순위, API 문서 진입점, 반응형 전략)은 드래프트 중 봉합된 결정이며 FR·SC에 반영됨.
+- 본 체크리스트 통과 이후 `/speckit.plan`으로 진행 가능.

--- a/specs/011-project-identity-surface/contracts/ui-surface.md
+++ b/specs/011-project-identity-surface/contracts/ui-surface.md
@@ -1,0 +1,106 @@
+# UI Surface Contract — 011-project-identity-surface
+
+본 피처는 외부 API·네트워크 계약이 없다. 대신 앱이 사용자에게 노출하는 **UI 표면**이 계약이다. 구현 변경 시 본 계약을 깨면 spec의 FR·SC가 무너진다.
+
+## 1. 전역 풋터 (`<Footer />`)
+
+**Location**: `src/components/Footer.tsx`
+**Rendered by**: `src/app/layout.tsx`의 루트 `<body>` 말미
+
+### DOM 표면
+
+```html
+<footer class="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 py-6 text-sm text-surface-600">
+  <span>Made by {projectMeta.author}</span>
+  <span aria-hidden="true">·</span>
+  <a href="{projectMeta.githubUrl}" target="_blank" rel="noopener noreferrer">GitHub ↗</a>
+  <span aria-hidden="true">·</span>
+  <a href="/docs">API Docs ↗</a>
+  <!-- About 링크는 US2 배포 이후 추가 -->
+</footer>
+```
+
+### 계약 조건
+
+- 모든 공개 페이지의 하단에 렌더될 것(spec FR-001, SC-001).
+- 3개(US2 이후 4개) 링크/텍스트 요소를 포함할 것.
+- 외부 링크는 `target="_blank" rel="noopener noreferrer"` 필수(spec FR-005).
+- 구분자 `·`는 `aria-hidden="true"`로 스크린 리더에서 무시되게 함.
+- 가로 폭 축소 시 flex-wrap으로 자동 줄바꿈. 레이아웃 깨짐 금지(spec SC-004).
+- 짧은 콘텐츠 페이지에서도 뷰포트 하단에 고정(sticky footer via flex column min-h-screen, spec FR-011).
+
+## 2. About 페이지 (`/about`)
+
+**Location**: `src/app/about/page.tsx`
+**Access**: 공개(로그인 불요, spec SC-005)
+
+### DOM 표면 (구조 계약)
+
+```html
+<main class="max-w-2xl mx-auto px-4 py-10 space-y-6">
+  <header class="space-y-2">
+    <h1>{projectMeta.name}</h1>
+    <p>{projectMeta.description}</p>
+  </header>
+
+  <section>
+    <h2>프로젝트 배경</h2>
+    <p>…{배경 설명 하드코딩 또는 projectMeta 확장 필드}…</p>
+  </section>
+
+  <section>
+    <h2>정보</h2>
+    <dl>
+      <dt>저작자</dt><dd>{projectMeta.author}</dd>
+      <dt>라이선스</dt><dd>{projectMeta.license}</dd>
+      <dt>저장소</dt><dd><a href="{projectMeta.githubUrl}" target="_blank" rel="noopener noreferrer">GitHub ↗</a></dd>
+    </dl>
+  </section>
+
+  <section>
+    <h2>기술 스택</h2>
+    <ul>
+      {projectMeta.techStack.map((tech) => (<li key={tech}>{tech}</li>))}
+    </ul>
+  </section>
+</main>
+```
+
+### 계약 조건
+
+- `/about` 경로는 인증 미들웨어 대상 제외(공개 라우트).
+- 모든 표시 값은 `projectMeta`에서 읽음. 하드코딩 금지(spec FR-003).
+- 외부 링크는 풋터와 동일 규약 적용(`target="_blank" rel="noopener noreferrer"`).
+- 단일 컬럼 `max-w-2xl`로 모바일·데스크톱 모두 가로 스크롤 없음(spec SC-004).
+
+## 3. 설정 페이지 API 문서 링크
+
+**Location**: `src/app/settings/page.tsx` (기존 파일 편집)
+
+### DOM 표면
+
+설정 페이지 제목 영역 하단 또는 옆에 추가:
+
+```html
+<Link href="/docs" class="text-sm text-blue-600 hover:underline">API 문서 →</Link>
+```
+
+### 계약 조건
+
+- 위치는 페이지 상단 식별 가능한 영역(제목 아래/옆).
+- 내부 이동이므로 `target="_blank"` 붙이지 않음(풋터와 동일 경로로 이동).
+- 새 컴포넌트 추출 금지(spec US3는 최소 변경).
+
+## 4. 메타 소스 Import 계약
+
+- **단일 경로**: `import { projectMeta } from "@/lib/project-meta";`
+- 다른 경로에서 `projectMeta`를 재정의하거나 mirror 금지.
+- About·Footer·설정 페이지·미래 확장 모두 동일 경로를 참조해야 구조적 일관성 확보(spec SC-003).
+
+## Breakage 기준 (계약 위반 = 회귀)
+
+- 풋터가 일부 라우트에서 누락 → SC-001 실패
+- 외부 링크에 `rel` 누락 → FR-005 실패, 보안 감사 실패
+- 브레이크포인트 분기(`md:flex-row` 등) 도입 → FR-009 실패, 헌법 III 위배
+- `projectMeta` 필드가 빈 문자열로 배포 → SC-006 실패(타입 경유 우회 시도는 리뷰에서 차단)
+- About 페이지 레이아웃이 모바일에서 가로 스크롤 발생 → SC-004 실패, 헌법 III 위배

--- a/specs/011-project-identity-surface/data-model.md
+++ b/specs/011-project-identity-surface/data-model.md
@@ -1,0 +1,68 @@
+# Phase 1: Data Model — 프로젝트 아이덴티티 표면
+
+**Feature**: 011-project-identity-surface
+**Date**: 2026-04-19
+
+본 피처는 DB 스키마·마이그레이션을 수반하지 않는다. 정적 상수 하나를 정의할 뿐이다.
+
+## ProjectMeta (정적 상수)
+
+**Location**: `src/lib/project-meta.ts`
+**Shape**: `readonly` 객체, 타입으로 강제. 런타임 가변 없음.
+
+### Fields
+
+| 필드 | 타입 | 필수 | 설명 | 예시 값 |
+|------|------|------|------|---------|
+| `name` | `string` | ✓ | 사용자에게 표시되는 프로젝트 이름 | `"Trip Planner"` |
+| `author` | `string` | ✓ | 풋터·About에 표시되는 저작자 식별자 | `"idean3885"` |
+| `githubUrl` | `string` (https URL) | ✓ | 공식 저장소 URL. `https://`로 시작 | `"https://github.com/idean3885/trip-planner"` |
+| `license` | `string` | ✓ | 라이선스 식별자(SPDX 또는 축약) | `"MIT"` |
+| `description` | `string` | ✓ | About 페이지 상단 1문단 설명 | `"AI 기반 여행 계획 및 동행 협업 플래너"` |
+| `techStack` | `readonly string[]` | ✓ | About 페이지에 표시할 기술 스택 요약. 순서대로 나열 | `["Next.js 15", "TypeScript", "Prisma", "Neon Postgres", "MCP (Python)"]` |
+
+### Type Definition
+
+```ts
+export type ProjectMeta = {
+  readonly name: string;
+  readonly author: string;
+  readonly githubUrl: string;
+  readonly license: string;
+  readonly description: string;
+  readonly techStack: readonly string[];
+};
+
+export const projectMeta = {
+  name: "Trip Planner",
+  author: "idean3885",
+  githubUrl: "https://github.com/idean3885/trip-planner",
+  license: "MIT",
+  description: "AI 기반 여행 계획 및 동행 협업 플래너. MCP 서버와 Next.js 웹앱 통합.",
+  techStack: [
+    "Next.js 15 (App Router)",
+    "TypeScript",
+    "Prisma",
+    "Neon Postgres",
+    "MCP (Python)",
+  ],
+} as const satisfies ProjectMeta;
+```
+
+### Validation Rules
+
+- **모든 필드 필수**: 타입에서 `?` 없이 선언 → `tsc`가 누락을 컴파일 에러로 감지(spec FR-010, SC-006 충족).
+- **빈 문자열 방지**: 타입 시스템만으로는 빈 문자열을 막지 못하므로 **린트 규칙 또는 CI 검증** 대신 코드 리뷰 규약으로 커버. 별도 런타임 검증 코드 추가 금지(과잉).
+- **`githubUrl` 프로토콜**: 외부 링크 규약상 `https://`로 시작해야 안전. 인라인 주석으로 명시하되 런타임 검증 추가 금지.
+
+### State Transitions
+
+없음. 빌드 시점 고정 상수.
+
+## Relationships
+
+없음. `ProjectMeta`는 단일 모듈 내부에 닫힌 값. 외부 테이블·도메인과 조인 없음.
+
+## 도메인 분류
+
+본 피처의 메타 상수는 **앱 아이덴티티 도메인**(신규)에 속한다. 헌법 V(Cross-Domain Integrity)의 기존 도메인(일정 편성·여행 탐색·동행 협업·예산 관리·일정 활용)과 교차 참조 없음. 따라서 신규 도메인 등록만으로 경계 위배 없음.

--- a/specs/011-project-identity-surface/plan.md
+++ b/specs/011-project-identity-surface/plan.md
@@ -1,0 +1,88 @@
+# Implementation Plan: 프로젝트 아이덴티티 표면 구축
+
+**Branch**: `011-project-identity-surface` | **Date**: 2026-04-19 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/011-project-identity-surface/spec.md`
+
+## Summary
+
+전역 풋터(모든 페이지 하단)·About 페이지(`/about`)·설정 페이지 API 문서 링크 3종을 추가해 프로젝트 아이덴티티 표면을 구축한다. 프로젝트 메타(이름·저작자·GitHub URL·라이선스·기술 스택)는 `src/lib/project-meta.ts` 단일 상수 모듈에서 노출하고 풋터·About 모두 이 소스만 참조한다. 반응형 분기 없이 모바일 우선 단일 레이아웃으로 구현. US1(풋터)와 US2(About)는 별도 PR로 분할 가능.
+
+## Coverage Targets
+
+- 프로젝트 메타 단일 소스 모듈 정의 [why: meta-source]
+- 전역 풋터 컴포넌트 + 루트 레이아웃 통합 [why: footer] [multi-step: 2]
+- About 페이지 `/about` 라우트 신설 [why: about-page]
+- 설정 페이지 상단에 API 문서 진입 링크 추가 [why: settings-link]
+- 풋터·About 모바일/데스크톱 시각 증거 수집 [why: visual-evidence]
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, Node.js 20+
+**Primary Dependencies**: Next.js 15 (App Router), React 19, Tailwind CSS (프로젝트 기존 채택). 추가 npm 의존성 없음 — 아이콘은 유니코드 ↗ 인라인 사용(research R-4 참조).
+**Storage**: N/A (정적 상수)
+**Testing**: 빌드 단계 타입 검사(`tsc`), 시각 검증은 quickstart의 수동 Evidence + 스크린샷
+**Target Platform**: 브라우저(Next.js SSR/RSC) — 모바일 375px, 데스크톱 1280px 기준
+**Project Type**: web-application (Next.js 웹앱 + Python MCP 서버 공존)
+**Performance Goals**: 추가 런타임 JS 0바이트 수준(순수 서버 컴포넌트), CLS 0에 가까운 sticky footer
+**Constraints**: 브레이크포인트 분기 금지(flex-wrap 또는 세로 정렬만), 외부 링크 `rel="noopener noreferrer"` 필수, 메타 필수 필드 누락 시 빌드 실패(런타임 fallback 금지)
+**Scale/Scope**: 전 페이지 영향(루트 레이아웃 변경) + 신규 라우트 1개(`/about`) + 기존 설정 페이지 1곳 링크 추가
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| 원칙 | 준수 여부 | 검토 |
+|------|----------|------|
+| I. AX-First | ✅ 해당 없음 | 아이덴티티 표면은 정보성 UI. AI 워크플로우 개입 없음. |
+| II. Minimum Cost | ✅ 준수 | 정적 상수 + 기존 Next.js 라우팅. 외부 의존성 추가 없음. |
+| III. Mobile-First Delivery | ✅ 핵심 | spec FR-009 "브레이크포인트 분기 금지" — flex-wrap/세로 정렬 단일 레이아웃. |
+| IV. Incremental Release | ✅ 준수 | US1(풋터) 단독 배포 가능, US2(About) 별도 PR로 분할. 기존 기능 영향 없음. |
+| V. Cross-Domain Integrity | ✅ 준수 | 메타 소스는 앱 아이덴티티 도메인(독립). Trip/Activity/Member 등 기존 도메인에 참조·변경 없음. |
+| VI. Role-Based Access Control | ✅ 준수 | 풋터·About은 공개 페이지(인증 불요). 설정 페이지 링크는 모든 로그인 역할(OWNER/HOST/GUEST)에 동일 노출되며 클릭 시 이동만 수행(읽기 전용). 새 권한 행위 추가 없음. |
+
+추가 고려: spec.md FR-010의 "메타 필수 필드 빌드 감지"는 `project-meta.ts`의 타입을 `readonly` + 명시적 타입으로 강제하여 구현한다. 런타임 fallback은 작성하지 않는다.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/011-project-identity-surface/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output (ProjectMeta shape)
+├── quickstart.md        # Phase 1 output (Evidence 포함)
+├── contracts/           # Phase 1 output (UI 계약 — 라우트·컴포넌트 공개 인터페이스)
+│   └── ui-surface.md
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── app/
+│   ├── layout.tsx                 # 루트 레이아웃 — Footer 삽입 위치
+│   ├── about/
+│   │   └── page.tsx               # /about 페이지 (신규)
+│   └── settings/                  # 기존 경로 — API 문서 링크 추가 위치 (파일 경로는 현행 유지)
+├── components/
+│   └── footer/
+│       ├── Footer.tsx             # 서버 컴포넌트 (신규)
+│       └── Footer.module.css      # 또는 Tailwind 클래스 직접 사용
+└── lib/
+    └── project-meta.ts            # 단일 메타 상수 (신규)
+
+mcp/                               # 본 피처 범위 외
+prisma/                            # 본 피처 범위 외 (마이그레이션 없음)
+```
+
+**Structure Decision**: Next.js App Router 단일 앱 구조를 유지. 풋터는 `src/components/footer/Footer.tsx` 서버 컴포넌트로 작성해 루트 `src/app/layout.tsx`에서 `<body>` 말미에 삽입. About 페이지는 `src/app/about/page.tsx` 단일 파일(서버 컴포넌트). 메타 상수는 `src/lib/project-meta.ts`에 타입 명시된 `as const` 객체로 배치. 설정 페이지는 기존 파일의 상단 섹션에 링크만 추가(새 파일 생성 없음). 스타일은 프로젝트의 기존 Tailwind 클래스 규약을 그대로 사용하며 별도 CSS 모듈 도입은 피한다.
+
+## Complexity Tracking
+
+본 피처는 추가 의존성·새 아키텍처 패턴·크로스 도메인 접근 없음. 헌법 위배 없음. 표는 비움.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| (해당 없음) | | |

--- a/specs/011-project-identity-surface/quickstart.md
+++ b/specs/011-project-identity-surface/quickstart.md
@@ -1,0 +1,91 @@
+# Quickstart: 프로젝트 아이덴티티 표면 구축
+
+**Feature**: `011-project-identity-surface` | **Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+본 문서는 각 User Story의 수동/자동 회귀 케이스를 정의한다. PR 머지 게이트가 `validate-quickstart-ev.sh`로 자동 검증한다.
+
+## US1: 전역 풋터
+
+### Scenario US1-1: 모든 공개 페이지 하단 렌더
+
+- `/`, `/about`(배포 후), `/docs`, `/settings`(로그인 상태), `/trips/<id>`(로그인+소유 여행)에 접속해 하단 스크롤 시 동일 풋터 렌더.
+- 각 풋터에서 `Made by idean3885`, `GitHub ↗`, `API Docs ↗` 노출 확인.
+
+### Scenario US1-2: 외부 링크 동작
+
+- `GitHub ↗` 클릭 → 새 탭으로 `https://github.com/idean3885/trip-planner` 열림.
+- `API Docs ↗` 클릭 → 같은 탭 `/docs` 이동, Scalar UI 렌더.
+
+### Scenario US1-3: 모바일 375px 레이아웃
+
+- Chrome DevTools Device Mode로 iPhone SE(375px) 설정.
+- 풋터 항목이 wrap되어 잘리지 않고 모두 읽힘.
+
+### Scenario US1-4: 짧은 콘텐츠 페이지 sticky 동작
+
+- 여행 0건 상태(`/` 또는 `/trips`) 등 콘텐츠 높이가 뷰포트보다 짧은 페이지에서 풋터가 뷰포트 하단에 붙어 보임(페이지 중간에 뜨지 않음).
+
+### Evidence
+
+- 자동 테스트: `pnpm tsc --noEmit` — `src/lib/project-meta.ts`의 필수 필드 누락 시 타입 에러로 차단(spec SC-006).
+- 수동 체크리스트:
+  - [ ] US1-1: 5개 경로 풋터 노출 확인
+  - [ ] US1-2: GitHub/API Docs 링크 목적지 200 응답
+  - [ ] US1-3: 375px 뷰 스크린샷 `docs/evidence/011-project-identity-surface/us1-3-mobile.png`
+  - [ ] US1-4: 짧은 콘텐츠 페이지 sticky 스크린샷 `docs/evidence/011-project-identity-surface/us1-4-sticky.png`
+- 스크린샷: `docs/evidence/011-project-identity-surface/us1-*.png`
+
+## US2: About 페이지
+
+### Scenario US2-1: `/about` 공개 접근
+
+- 로그아웃 상태에서 `/about` 직접 접속 → 200 응답, 인증 리다이렉트 없음(spec SC-005).
+
+### Scenario US2-2: 모든 필드 노출
+
+- 프로젝트 이름, 배경 1-2문단, 저작자, 라이선스, GitHub 링크, 기술 스택 목록 모두 화면에 보임.
+- 저작자·GitHub URL·라이선스 값이 풋터와 문자열 레벨 동일(spec SC-003).
+
+### Scenario US2-3: 모바일 가독성
+
+- 375px 뷰에서 About 페이지 가로 스크롤 없음, 모든 섹션 읽힘.
+
+### Scenario US2-4: 단일 소스 일관성
+
+- `projectMeta.author`를 임의 변경 → About·풋터 양쪽이 동일하게 바뀜(같은 상수 참조).
+
+### Evidence
+
+- 자동 테스트: `pnpm tsc --noEmit` (타입 일관성), `pnpm lint`(외부 링크 `rel` 규약은 eslint-plugin-react 기본 규칙으로 감지되면 활용, 아니면 수동).
+- 수동 체크리스트:
+  - [ ] US2-1: 로그아웃 상태 `/about` 200 응답 curl 또는 브라우저 확인
+  - [ ] US2-2: 모든 필드 노출 스크린샷
+  - [ ] US2-3: 375px 스크린샷 `docs/evidence/011-project-identity-surface/us2-3-mobile.png`
+  - [ ] US2-4: `projectMeta.author` 임시 변경 후 풋터·About 동일 갱신 확인(커밋 금지, 로컬 확인만)
+- 스크린샷: `docs/evidence/011-project-identity-surface/us2-*.png`
+
+## US3: 설정 페이지 API 문서 진입점
+
+### Scenario US3-1: 링크 노출
+
+- 로그인 상태 `/settings` 접속 → 페이지 상단에 `API 문서 →` 링크 노출.
+
+### Scenario US3-2: 이동 경로
+
+- 링크 클릭 → 같은 탭으로 `/docs` 이동, Scalar UI 렌더.
+
+### Evidence
+
+- 수동 체크리스트:
+  - [ ] US3-1: 설정 페이지 상단 링크 스크린샷 `docs/evidence/011-project-identity-surface/us3-1-settings.png`
+  - [ ] US3-2: 링크 클릭 → `/docs` 도달
+- 자동 테스트: 해당없음 (UI 링크 배치는 타입 시스템 밖). 수동 체크리스트로 대체.
+- 스크린샷: `docs/evidence/011-project-identity-surface/us3-*.png`
+
+## Rollout 순서
+
+1. **PR #1 (US1 + 메타 소스)**: `src/lib/project-meta.ts` + `src/components/Footer.tsx` + `src/app/layout.tsx` 편집. dev 환경 검증 후 develop 머지.
+2. **PR #2 (US2)**: `src/app/about/page.tsx` + 풋터에 About 링크 추가. PR #1 머지 후 진행.
+3. **PR #3 (US3)**: `src/app/settings/page.tsx` API 문서 링크 1줄 추가. PR #1과 독립적으로 진행 가능.
+
+PR #1 단독 배포 시 About 링크는 풋터에 포함하지 않는다(깨진 링크 방지, spec Edge Cases).

--- a/specs/011-project-identity-surface/research.md
+++ b/specs/011-project-identity-surface/research.md
@@ -1,0 +1,100 @@
+# Phase 0: Research — 프로젝트 아이덴티티 표면
+
+**Feature**: 011-project-identity-surface
+**Date**: 2026-04-19
+
+Spec의 Clarifications·Assumptions로 대부분의 모호점은 이미 봉합됐다. 본 문서는 구현 수단 선택과 그 근거를 기록한다. `NEEDS CLARIFICATION`은 없다.
+
+## R-1. 메타 소스 형식: TypeScript 상수 모듈 (`as const`)
+
+**Decision**: `src/lib/project-meta.ts`에 `export const projectMeta = { ... } as const satisfies ProjectMeta;` 형태로 정의. 타입은 동일 파일에서 `export type ProjectMeta = { name: string; author: string; githubUrl: string; license: string; description: string; techStack: readonly string[]; }`로 명시.
+
+**Rationale**:
+- 빌드 시점 정적 검사. 필수 필드 누락 시 `tsc`가 바로 실패(spec SC-006 충족).
+- JSON 또는 env 변수 대비 import 경로가 명확하고 IDE 자동완성·go-to-definition 지원.
+- `as const` + `satisfies`로 리터럴 타입 좁히기 + 스키마 검증 동시 획득.
+
+**Alternatives considered**:
+- `project-meta.json` + zod 검증: 런타임 검증 레이어가 추가돼 IV(점진적 릴리즈)·비용 원칙에 비해 과잉.
+- `package.json` 필드 재활용: 다른 팀원·도구가 `package.json`을 수정할 때 UI까지 함께 바뀌는 부작용. 앱 아이덴티티와 패키지 메타는 목적이 다르므로 분리.
+- `.env` 변수: 런타임 의존성 생성, 타입 안전성 약함, 빌드 시점 감지 어려움.
+
+## R-2. 풋터 배치 전략: 서버 컴포넌트 + 루트 레이아웃 flex column
+
+**Decision**: `src/components/Footer.tsx`를 기본 서버 컴포넌트로 작성. `src/app/layout.tsx`의 `<body>`를 `className="... min-h-screen flex flex-col"`로 변경, 기존 메인 콘텐츠 래퍼에 `flex-1`을 적용한 뒤 `<Footer />`를 그 아래에 둔다.
+
+**Rationale**:
+- 서버 컴포넌트로 작성하면 클라이언트 번들에 추가되는 JS 0바이트(spec Performance Goals 충족).
+- flex column + flex-1 패턴은 브레이크포인트 분기 없이 모든 뷰포트에서 콘텐츠가 짧아도 풋터가 하단에 고정(spec FR-011).
+- 추가 CSS 파일 불요. 프로젝트의 Tailwind 규약과 정합.
+
+**Alternatives considered**:
+- `position: sticky`/`fixed`: 짧은 콘텐츠에서 빈 여백 또는 겹침 발생. flex column이 문법·시각 모두 깔끔.
+- 클라이언트 컴포넌트로 작성: Link 컴포넌트만 쓸 예정이므로 "use client" 불필요. 서버 컴포넌트가 기본값이어야 함.
+
+## R-3. 반응형 단일 레이아웃: flex-wrap
+
+**Decision**: 풋터는 `flex flex-wrap items-center justify-center gap-x-4 gap-y-2 py-6 text-sm`로 항목을 가로 배치. 가로 폭이 줄면 자동 wrap. About 페이지는 `max-w-2xl mx-auto px-4 py-10`의 세로 단일 컬럼.
+
+**Rationale**:
+- spec FR-009 "브레이크포인트 분기 금지"를 충족. flex-wrap은 viewport meta queries 없이 가로 공간에 따라 자동 조정.
+- 375px(모바일)에서는 3~4개 항목이 2줄로, 1280px(데스크톱)에서는 한 줄로 자연 배치.
+
+**Alternatives considered**:
+- `md:flex-row`, `sm:block` 같은 Tailwind 브레이크포인트 사용: 원칙 위배.
+- CSS Grid `grid-template-columns: repeat(auto-fit, ...)`: 유효하지만 flex-wrap이 더 간결하고 디자인 의도 명확.
+
+## R-4. 외부 링크 아이콘: 인라인 유니코드 "↗"
+
+**Decision**: "GitHub ↗", "API Docs ↗"처럼 텍스트 뒤에 유니코드 `↗` (U+2197) 직접 포함. `aria-label` 또는 시각적 보조 없이 링크 자체의 텍스트로 의미 전달.
+
+**Rationale**:
+- `lucide-react` 같은 아이콘 라이브러리가 프로젝트에 미채택 상태. 추가 의존성은 II(비용) 원칙에 비춰 불필요.
+- 유니코드 화살표는 모든 폰트에서 렌더 가능, 시각 장애인 스크린 리더도 "위쪽 오른쪽 화살표"로 읽음(적절한 의미 전달).
+
+**Alternatives considered**:
+- SVG 인라인: 유지보수 대비 가독성 손해. 유니코드로 충분.
+- `lucide-react`: 패키지 크기 + 빌드 시간 증가. 한 아이콘을 위해 도입할 가치 없음.
+
+## R-5. About 페이지 콘텐츠 구조
+
+**Decision**: `/about` 페이지는 세로 단일 컬럼으로 4개 섹션 구성:
+
+1. 프로젝트 이름 + 한 줄 설명 (h1 + p)
+2. 배경 설명 (1-2문단)
+3. 저작자·라이선스·GitHub 링크 (dl 또는 키-값 리스트)
+4. 기술 스택 요약 (ul)
+
+모든 값은 `projectMeta`에서 읽어온다. 하드코딩 금지(spec FR-003).
+
+**Rationale**:
+- 단일 컬럼 = 모바일에서 가로 스크롤 불필요(spec SC-004).
+- 섹션 헤더 없이도 의미 전달 가능한 최소 구조. 추후 확장 여지만 두고 현재는 심플.
+
+**Alternatives considered**:
+- 다단 그리드(저작자·라이선스·GitHub를 카드로 나열): 모바일에서 세로 쌓이는 반응형 필요 → 원칙 위배.
+
+## R-6. 설정 페이지 API 문서 링크 위치
+
+**Decision**: `src/app/settings/page.tsx` 상단(페이지 제목 바로 아래 또는 옆)에 `<Link href="/docs">API 문서 →</Link>` 1개 요소 추가. 새 섹션·새 컴포넌트 도입 없이 현행 파일만 편집.
+
+**Rationale**:
+- spec US3(P3)는 "진입점 강화"이지 새 UX 흐름 도입이 아니다. 최소 코드 변경.
+- 기존 페이지 구조 존중. 새 파일 생성은 IV(점진적)·복잡도 억제 원칙에 비춰 과잉.
+
+**Alternatives considered**:
+- 별도 `SettingsHeader` 컴포넌트 추출: 현재는 설정 페이지 하나뿐, YAGNI.
+
+## R-7. 단일 소스 일관성 검증 방법
+
+**Decision**: `projectMeta` 필드 중 UI에 노출되는 값은 About·풋터 양쪽이 "import 경로가 동일한 상수"라는 것을 코드 리뷰에서 확인. 별도 테스트 없이도 타입 시스템이 drift를 막는다(동일 상수 참조이므로 값 차이 발생 불가능).
+
+**Rationale**:
+- 단일 import이므로 SC-003(풋터·About 필드 100% 일치)는 구조적으로 보장됨. 추가 테스트는 중복.
+
+**Alternatives considered**:
+- 컨트랙트 테스트 추가: 상수 참조 구조상 불필요한 과잉 검증.
+
+---
+
+모든 결정은 spec의 FR·SC·Clarifications와 정합한다. Phase 1 산출물(data-model, contracts, quickstart)은 본 연구 기반으로 작성한다.

--- a/specs/011-project-identity-surface/spec.md
+++ b/specs/011-project-identity-surface/spec.md
@@ -1,0 +1,123 @@
+# Feature Specification: 프로젝트 아이덴티티 표면 구축
+
+**Feature Branch**: `011-project-identity-surface`
+**Created**: 2026-04-19
+**Status**: Draft
+**Input**: User description: "전역 풋터(모든 페이지 하단, Made by idean3885 / GitHub / API Docs), About 페이지(/about, 프로젝트 배경·저작자·기술스택·라이선스·GitHub 링크), API 문서 진입점 연결(/docs Scalar 활용). 단일 데이터 소스(프로젝트 메타 상수)에서 읽어 1인 개발 유지보수성 확보. 반응형 분기 최소화. Issue #200 참조."
+
+## Clarifications *(optional, add when drafting raises ambiguity)*
+
+1. **단일 데이터 소스 범위** — 프로젝트 메타(이름·저작자·GitHub URL·라이선스·현재 버전·기술 스택 요약)는 `src/`에서 import 가능한 단일 모듈에 상수로 노출된다. 풋터와 About 페이지는 이 소스만 참조한다. 외부(mcp/, docs/) 메타와의 동기화는 범위 외.
+2. **About 페이지 우선순위** — 풋터(P1)와 About(P2)는 같은 PR로 묶지 않는다. 풋터는 선행 배포 가능한 독립 슬라이스. About 페이지는 풋터의 링크 대상이 존재한다는 전제로 뒤에 배포.
+3. **API 문서 진입점** — 기존 `/docs`(Scalar) 페이지를 그대로 활용한다. 본 피처는 진입 링크만 추가(풋터·About). `/docs` 자체 개편은 범위 외.
+4. **반응형 전략** — 풋터·About 모두 단일 레이아웃(모바일 우선 세로 정렬, 가로 폭이 충분하면 flex-wrap으로 자연 배치)으로 구현한다. 브레이크포인트 분기 금지.
+
+## Metatag Conventions *(normative, inherited from PR #204)*
+
+본 피처의 tasks.md·plan.md는 네 종 메타태그를 통해 후속 자동 검증과 연결된다:
+
+- `[artifact: <path>|<path>::<symbol>]` — 산출 파일 식별자(drift 감사 기준)
+- `[why: <short-tag>]` — 추적 그룹 키(plan↔tasks 커버리지·이슈 합산)
+- `[multi-step: N]` — plan bullet이 다단 작업일 때 최소 매핑 태스크 수(N ≥ 2)
+- `[migration-type: schema-only | data-migration]` — 마이그레이션 산출물 구분
+
+형식 검증은 `.specify/scripts/bash/validate-metatag-format.sh`가 수행한다. 의미 검증은 각 US의 validator가 담당한다.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - 전역 풋터로 프로젝트 출처 즉시 인지 (Priority: P1)
+
+앱을 공유받은 방문자가 어느 페이지에서든 화면 하단에서 "이 앱은 누가 만들었고, 소스코드는 어디에서 볼 수 있고, API는 어떻게 쓰는가"를 확인한다. 별도 페이지로 이동하지 않고도 프로젝트의 기본 정체성을 즉시 인지한다.
+
+**Why this priority**: 현재 앱은 제작자·출처 표시가 없어 공유받은 사람이 "신뢰할 만한 프로젝트인가"를 판단할 근거가 없다. 풋터 한 줄만으로도 이 질문이 해소된다. 가장 적은 UI 비용으로 가장 큰 신뢰 효과를 얻는 슬라이스다. About 페이지가 없어도 풋터만으로 최소한의 아이덴티티 표면이 성립하므로 단독 MVP로 배포 가능.
+
+**Independent Test**: 풋터만 구현·배포하고 About 페이지를 만들지 않은 상태에서도, 모든 페이지 하단에 제작자 이름·GitHub 링크·API Docs 링크가 노출되고 각 링크가 정상 목적지로 이동하면 본 스토리는 완료다. About 링크는 이 시점에 404/미구현이어도 무방(풋터에는 포함하지 않거나 비활성화).
+
+**Acceptance Scenarios**:
+
+1. **Given** 로그인하지 않은 방문자가 랜딩 페이지(`/`)에 접속했을 때, **When** 페이지 하단까지 스크롤하면, **Then** "Made by idean3885", "GitHub ↗", "API Docs ↗" 세 항목이 보이고 각각이 링크로 동작한다.
+2. **Given** 방문자가 여행 상세 페이지(`/trips/[id]`) 등 임의의 내부 페이지에 있을 때, **When** 화면 하단을 확인하면, **Then** 동일한 풋터가 같은 항목으로 렌더된다(페이지별 편차 없음).
+3. **Given** 방문자가 모바일 뷰(가로 375px)로 접속했을 때, **When** 풋터를 확인하면, **Then** 항목이 세로로 쌓이거나 wrap되어 잘리지 않고 모든 텍스트가 읽힌다(브레이크포인트 분기 없이 자연 정렬).
+4. **Given** 방문자가 풋터의 "GitHub ↗"를 클릭했을 때, **When** 새 탭이 열리면, **Then** 프로젝트 저장소(`https://github.com/idean3885/trip-planner`)가 로드된다.
+5. **Given** 방문자가 풋터의 "API Docs ↗"를 클릭했을 때, **When** 이동하면, **Then** 기존 `/docs` Scalar 페이지가 렌더된다.
+
+---
+
+### User Story 2 - About 페이지에서 프로젝트 맥락 확인 (Priority: P2)
+
+풋터의 제작자 이름을 본 방문자가 "더 자세히 알고 싶다"고 느꼈을 때 클릭할 수 있는 단일 공식 페이지를 제공한다. 여기서 프로젝트 배경, 저작자, 기술 스택 개요, 라이선스, GitHub 링크를 한 화면에서 확인한다.
+
+**Why this priority**: 풋터로 최소 신뢰는 확보된 뒤의 심화 단계. 풋터 없이 About만 있으면 발견 경로가 없어 의미가 반감된다. 반대로 풋터만 있고 About이 없더라도 기본 목적은 달성되므로 P2. 별도 PR로 분리 가능.
+
+**Independent Test**: `/about` 경로로 직접 접속했을 때 프로젝트 배경·저작자·기술 스택 요약·라이선스·GitHub 링크가 한 화면에 보이고, 모바일 뷰에서도 정상 렌더되면 완료. 풋터의 "About" 진입 여부는 US1/US2 간 인접 관심사이지만, 본 스토리의 완료 조건은 `/about` 페이지 자체의 표시·접근성이다.
+
+**Acceptance Scenarios**:
+
+1. **Given** 방문자가 `/about` URL로 직접 접속했을 때, **When** 페이지가 로드되면, **Then** 프로젝트 이름, 배경 설명(1-2문단), 저작자 이름, 라이선스, 기술 스택 요약, GitHub 링크가 모두 노출된다.
+2. **Given** `/about` 페이지가 렌더됐을 때, **When** 표시된 프로젝트 이름·저작자·GitHub URL·라이선스를 확인하면, **Then** 풋터의 동일 필드와 100% 일치한다(단일 소스 기반).
+3. **Given** 방문자가 모바일 뷰로 `/about`에 접속했을 때, **When** 페이지를 스크롤하면, **Then** 모든 섹션이 가로 스크롤 없이 읽히고 레이아웃이 깨지지 않는다.
+4. **Given** 방문자가 About 페이지의 GitHub 링크를 클릭했을 때, **When** 새 탭이 열리면, **Then** 풋터의 GitHub 링크와 같은 URL로 이동한다.
+
+---
+
+### User Story 3 - API 문서 접근성 강화 (Priority: P3)
+
+API를 사용하려는 이용자(1인 개발자 본인 포함)가 설정 페이지 상단에서도 API 문서로 즉시 이동할 수 있도록, 풋터의 링크 외에 설정 페이지 내부에서도 "API 문서 →" 진입점을 제공한다.
+
+**Why this priority**: 풋터 링크만으로도 도달 가능하므로 중복성 있는 강화 작업. 하지만 PAT/토큰 관리와 API 문서는 맥락상 인접하므로, 설정 페이지 이용자에게는 추가 진입점이 체감 편의성을 높인다. 본 피처의 핵심 가치와 독립적이므로 P3.
+
+**Independent Test**: 설정 페이지(`/settings` 등 기존 경로) 상단에 "API 문서 →" 링크가 노출되고 `/docs`로 이동하면 완료. 풋터·About과 무관하게 단독 검증 가능.
+
+**Acceptance Scenarios**:
+
+1. **Given** 로그인한 사용자가 설정 페이지에 접속했을 때, **When** 상단 영역을 확인하면, **Then** "API 문서 →" 링크가 보인다.
+2. **Given** 사용자가 설정 페이지의 "API 문서 →" 링크를 클릭했을 때, **When** 이동하면, **Then** 풋터의 "API Docs" 링크와 동일한 `/docs` 페이지가 렌더된다.
+
+---
+
+### Edge Cases
+
+- **About 페이지 미배포 시 풋터 "About" 링크 상태**: US1 단독 MVP 상황에서 풋터에 About 링크를 넣지 않는다(비노출). About 배포 PR에서 풋터 링크를 함께 추가한다. 이유: 깨진 링크 노출 금지.
+- **프로젝트 메타 소스 누락 필드**: 단일 상수에서 읽는 필드(이름·GitHub URL·라이선스 등) 중 하나라도 빈 문자열이면 해당 UI 요소를 렌더하지 않고 빌드 에러로 조기 감지한다(런타임 fallback 금지).
+- **외부 링크 보안**: GitHub·API Docs 등 외부 링크는 `target="_blank"` + `rel="noopener noreferrer"`를 강제한다.
+- **다크 모드/테마 대응**: 현재 앱이 단일 테마라면 풋터도 단일 테마. 추후 테마 추가 시 풋터가 자동 대응하도록 디자인 토큰(시스템 색상)만 사용, 하드코딩 색상 금지.
+- **풋터 위치 vs 짧은 콘텐츠 페이지**: 콘텐츠가 화면보다 짧은 페이지(예: 빈 여행 목록)에서도 풋터가 하단에 고정되어 보이도록 레이아웃이 뷰포트 최소 높이를 채운다.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: 시스템은 모든 라우트(랜딩·여행 목록·여행 상세·설정 등)의 하단에 동일한 풋터를 렌더해야 한다.
+- **FR-002**: 풋터는 최소 세 항목 — "Made by {저작자}", GitHub 링크, API Docs 링크 — 을 포함해야 한다.
+- **FR-003**: 풋터와 About 페이지의 메타 정보(저작자·GitHub URL·라이선스·프로젝트 이름)는 동일한 단일 모듈에서 읽어야 한다.
+- **FR-004**: 프로젝트 메타 소스는 최소한 다음 필드를 노출해야 한다 — 프로젝트 이름, 저작자 표시명, GitHub 저장소 URL, 라이선스 식별자, 기술 스택 요약.
+- **FR-005**: 외부 링크(GitHub·API Docs)는 새 탭으로 열리며 `rel="noopener noreferrer"`가 적용되어야 한다.
+- **FR-006**: 시스템은 `/about` 경로에서 About 페이지를 공개 접근 가능하게 제공해야 한다(로그인 불요).
+- **FR-007**: About 페이지는 프로젝트 배경 설명, 저작자, 기술 스택 요약, 라이선스, GitHub 링크를 한 화면에 포함해야 한다.
+- **FR-008**: 설정 페이지 상단에 API 문서로 이동하는 링크를 제공해야 한다.
+- **FR-009**: 풋터·About의 레이아웃은 단일 스타일 선언으로 모바일·데스크톱 모두 가독 상태를 유지해야 한다(별도 브레이크포인트 분기 없이 flex-wrap 또는 자연 세로 정렬).
+- **FR-010**: 메타 소스의 필수 필드가 비어있거나 정의되지 않은 경우 빌드 단계에서 감지되어야 하며 런타임 fallback을 사용해선 안 된다.
+- **FR-011**: 풋터는 콘텐츠 높이가 뷰포트보다 짧은 페이지에서도 하단에 고정되어 보여야 한다(sticky footer 패턴).
+
+### Key Entities *(include if feature involves data)*
+
+- **ProjectMeta**: 프로젝트의 공개 메타데이터. 단일 모듈 내 상수로 정의되며 빌드 시점에 고정. 필드 — 이름, 저작자 표시명, GitHub URL, 라이선스, 기술 스택 요약(문자열 또는 배열), 설명(About 본문용). 외부 API 호출 없음, DB 저장 없음.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 앱의 모든 공개 페이지에서 풋터가 노출된다(수동 감사 기준 100% 페이지 적중).
+- **SC-002**: 풋터의 GitHub·API Docs 링크는 한 번의 클릭으로 목적지에 도달하며, 404·깨진 링크·잘못된 도메인이 없다(각 링크 목적지 200 응답 확인).
+- **SC-003**: 풋터의 저작자·GitHub URL·라이선스 값과 About 페이지의 동일 필드 값이 문자열 레벨에서 100% 일치한다(단일 소스 기반 검증).
+- **SC-004**: 모바일 뷰(가로 375px)와 데스크톱 뷰(가로 1280px) 모두에서 풋터·About이 가로 스크롤 없이 전체 내용이 보인다.
+- **SC-005**: `/about` 페이지는 로그인하지 않은 방문자가 직접 URL로 접속해도 정상 렌더된다(인증 리다이렉트 없음).
+- **SC-006**: 메타 소스의 필수 필드가 누락된 상태로 빌드 시도하면 타입 또는 정적 검사에서 실패한다(런타임 빈값 노출 0건).
+
+## Assumptions *(informative)*
+
+- 앱은 Next.js App Router 구조이며 전역 풋터는 최상위 레이아웃(`src/app/layout.tsx` 또는 그룹 레이아웃)에서 선언 가능하다.
+- 라이선스는 이미 `pyproject.toml`·`package.json` 등에서 정의되어 있으며 본 피처는 그 값을 참조하지 않고 별도 메타 상수로 명시한다(소스 정본 차이로 인한 drift 방지는 별건).
+- API 문서 경로 `/docs`는 이미 Scalar로 렌더되며 본 피처는 링크만 추가한다(Scalar 자체 개편 제외).
+- 저작자 이름·GitHub URL은 CLAUDE.md와 devex provider 정의에서 `idean3885` / `https://github.com/idean3885/trip-planner`로 확정된 값을 그대로 사용한다.
+- 본 피처의 모든 UI는 단일 색상 테마를 가정한다. 다크 모드 분기는 범위 외.

--- a/specs/011-project-identity-surface/tasks.md
+++ b/specs/011-project-identity-surface/tasks.md
@@ -1,0 +1,171 @@
+---
+
+description: "Task list for 011-project-identity-surface"
+---
+
+# Tasks: 프로젝트 아이덴티티 표면 구축
+
+**Input**: Design documents from `/specs/011-project-identity-surface/`
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/ui-surface.md](./contracts/ui-surface.md), [quickstart.md](./quickstart.md)
+
+**Tests**: spec·plan에서 자동 테스트 명시 요구 없음. `tsc --noEmit`이 타입 기반 계약을 검증하고 나머지는 quickstart 수동 증거로 커버한다. TDD·단위 테스트 태스크는 포함하지 않는다.
+
+**Organization**: 태스크는 User Story 단위로 묶여 독립 구현·독립 배포가 가능하다. PR 분할은 quickstart의 Rollout 순서를 따른다.
+
+## Format: `[ID] [P?] [Story] Description [artifact: ...] [why: ...]`
+
+- **[P]**: 다른 파일, 선행 태스크와 충돌 없어 병렬 가능
+- **[Story]**: 해당 태스크가 소속된 User Story (US1/US2/US3)
+- **[artifact]**: 산출 파일 상대 경로 또는 `path::symbol`
+- **[why]**: plan의 Coverage Target과 일치하는 그룹 태그
+
+## Path Conventions
+
+Next.js App Router 단일 앱 구조. 소스 경로는 `src/` 기준, 저장소 루트 경로는 본 워크트리(`/Users/nhn/git-project/idean3885/trip-planner-200/`) 기준.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: 본 피처 전용 공유 인프라. 신규 npm 의존성 없음.
+
+- [ ] T001 스크린샷 수집용 디렉토리 생성 `docs/evidence/011-project-identity-surface/` (빈 `.gitkeep`) [artifact: docs/evidence/011-project-identity-surface/.gitkeep] [why: visual-evidence]
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: US1·US2가 공통으로 참조하는 프로젝트 메타 소스. US3는 참조하지 않으므로 미선행 가능이나, 동일 피처 스코프이므로 순서상 먼저 둔다.
+
+**⚠️ CRITICAL**: US1(풋터)·US2(About) 모두 이 모듈을 import하므로 선행 필수.
+
+- [ ] T002 프로젝트 메타 타입·상수 작성 `src/lib/project-meta.ts` — `ProjectMeta` 타입 + `projectMeta` `as const satisfies ProjectMeta` 객체. 필드는 data-model.md 정의 그대로. [artifact: src/lib/project-meta.ts::projectMeta] [why: meta-source]
+- [ ] T003 `tsc --noEmit` 실행으로 T002의 타입 정합성 확인. 실패 시 T002 수정 후 재실행. [artifact: src/lib/project-meta.ts] [why: meta-source]
+
+**Checkpoint**: `projectMeta`가 타입 안전하게 export되면 US1·US2 진입 가능.
+
+---
+
+## Phase 3: User Story 1 - 전역 풋터 (Priority: P1) 🎯 MVP
+
+**Goal**: 모든 공개 페이지 하단에 프로젝트 출처·GitHub·API Docs 링크를 노출.
+
+**Independent Test**: 5개 경로(`/`, `/docs`, `/settings`, `/trips/<id>`, 짧은 콘텐츠 페이지)에 접속해 풋터 렌더·링크 동작·모바일 wrap·sticky 동작 확인 (quickstart US1-1~US1-4).
+
+### Implementation for User Story 1
+
+- [ ] T004 [US1] `Footer` 서버 컴포넌트 작성 `src/components/Footer.tsx` — `projectMeta` import, contracts/ui-surface.md §1 DOM 표면 준수, 외부 링크 `target="_blank" rel="noopener noreferrer"`, flex-wrap 레이아웃, About 링크 미포함(US2 배포 시 추가). [artifact: src/components/Footer.tsx] [why: footer] [multi-step: 2]
+- [ ] T005 [US1] 루트 레이아웃 수정 `src/app/layout.tsx` — `<body>`에 `flex flex-col` 추가, 기존 메인 콘텐츠 래퍼에 `flex-1` 적용, 말미에 `<Footer />` 삽입. 기존 SessionProvider/AuthButton 구조 보존. [artifact: src/app/layout.tsx] [why: footer] [multi-step: 2]
+- [ ] T006 [US1] 로컬 dev 서버 기동 후 quickstart US1-1~US1-4 수동 체크리스트 실행. 스크린샷 `docs/evidence/011-project-identity-surface/us1-3-mobile.png`, `us1-4-sticky.png` 수집. quickstart.md 체크박스 업데이트. [artifact: specs/011-project-identity-surface/quickstart.md] [why: visual-evidence]
+
+**Checkpoint**: US1 단독 머지 가능(PR #1). About 페이지 없이도 풋터만으로 MVP 성립.
+
+---
+
+## Phase 4: User Story 2 - About 페이지 (Priority: P2)
+
+**Goal**: `/about` 공개 페이지에서 프로젝트 배경·저작자·기술 스택·라이선스·GitHub 링크 확인.
+
+**Independent Test**: `/about` 직접 접속 → 200 응답, 모든 필드 노출, 모바일 가독성, `projectMeta` 참조 일관성 확인 (quickstart US2-1~US2-4).
+
+### Implementation for User Story 2
+
+- [ ] T007 [US2] About 페이지 작성 `src/app/about/page.tsx` — contracts/ui-surface.md §2 DOM 구조 준수, 모든 표시 값을 `projectMeta`에서 import, `max-w-2xl mx-auto` 단일 컬럼, 외부 링크 `rel` 규약 적용. [artifact: src/app/about/page.tsx] [why: about-page]
+- [ ] T008 [US2] 풋터에 About 링크 추가 `src/components/Footer.tsx` — 기존 링크들 사이에 `<Link href="/about">About</Link>` 삽입. US1의 "About 미노출" 규약은 본 태스크에서 해제. [artifact: src/components/Footer.tsx::Footer] [why: footer]
+- [ ] T009 [US2] 로컬 dev 서버에서 quickstart US2-1~US2-4 실행. 스크린샷 `us2-3-mobile.png` 수집. quickstart.md 체크박스 업데이트. [artifact: specs/011-project-identity-surface/quickstart.md] [why: visual-evidence]
+
+**Checkpoint**: US2 머지 시점 PR #2(PR #1 선행 전제). About 페이지와 풋터 "About" 링크 동시 배포로 깨진 링크 방지.
+
+---
+
+## Phase 5: User Story 3 - 설정 페이지 API 문서 진입점 (Priority: P3)
+
+**Goal**: 설정 페이지 상단에 `/docs`로 이동하는 API 문서 링크 추가.
+
+**Independent Test**: 로그인 상태 `/settings` 접속 → 상단에 "API 문서 →" 노출, 클릭 시 `/docs` 이동 (quickstart US3-1~US3-2).
+
+### Implementation for User Story 3
+
+- [ ] T010 [US3] 설정 페이지 상단에 API 문서 링크 추가 `src/app/settings/page.tsx` — 페이지 제목 근처 `<Link href="/docs" className="text-sm text-blue-600 hover:underline">API 문서 →</Link>` 1줄 삽입. 새 컴포넌트 추출 금지. [artifact: src/app/settings/page.tsx] [why: settings-link]
+- [ ] T011 [US3] quickstart US3-1~US3-2 수동 실행, 스크린샷 `us3-1-settings.png` 수집. quickstart.md 체크박스 업데이트. [artifact: specs/011-project-identity-surface/quickstart.md] [why: visual-evidence]
+
+**Checkpoint**: US3 머지 시점 PR #3(US1에 의존하지 않음, US1 이후 언제든 가능).
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: 배포·릴리즈 준비. US1·US2·US3가 모두 머지된 뒤 수행.
+
+- [ ] T012 CHANGELOG.md에 v2.4.0 섹션 추가 — 풋터/About/설정 링크 3건을 Added로 기재, 이슈 #200 참조. [artifact: CHANGELOG.md] [why: release-notes]
+- [ ] T013 pyproject.toml 버전 2.3.x → 2.4.0 범프. [artifact: pyproject.toml] [why: release-notes]
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: 의존 없음. T001 즉시 가능.
+- **Phase 2 (Foundational)**: T001 후. T002→T003 순차.
+- **Phase 3 (US1)**: Phase 2 완료 후. T004·T005는 동일 참조 관계(T005가 T004 import)이므로 T004 → T005 순차. T006은 T004·T005 이후 수동 검증.
+- **Phase 4 (US2)**: Phase 2 완료 후. US1 머지(PR #1)와 무관하게 구현 시작 가능하나, 풋터 About 링크(T008)는 US1의 T004를 수정하므로 PR #1 머지 후에 진행(merge conflict 회피).
+- **Phase 5 (US3)**: Phase 2 불요(메타 소스 미참조). T001만 선행. 실질적으로 Phase 2 이후 언제든 시작 가능.
+- **Phase 6 (Polish)**: US1·US2·US3 PR이 모두 develop에 머지된 뒤 develop→main 릴리즈 PR 단계에서 수행.
+
+### User Story Dependencies
+
+- **US1**: Phase 2(메타 소스)에만 의존.
+- **US2**: Phase 2 + US1(풋터에 About 링크 추가 지점). 구현은 독립 병렬 가능하나 머지 순서는 US1 → US2.
+- **US3**: 독립. US1·US2와 무관.
+
+### Parallel Opportunities
+
+- T002와 T001은 다른 파일 → 이론상 병렬이나 T001이 먼저 끝나도 T002 차단 없음. 순차 수행으로도 충분.
+- US1의 T004·T005는 T005가 T004 import하므로 순차.
+- US2의 T007은 T002(메타 소스)와 contracts 문서만 참조 → Phase 2 직후 US1 완료 전이라도 작성 가능(로컬 테스트는 US1 머지 후).
+- US3의 T010은 완전 독립. Phase 2와 병렬도 가능(`projectMeta` 미참조).
+- T006·T009·T011의 수동 검증(quickstart 실행)은 각각 해당 US 구현 직후에만.
+
+---
+
+## Parallel Example: User Story들 간 병렬 워크
+
+```bash
+# Phase 2 완료 후, 서로 다른 터치포인트를 가진 US들을 병렬 워크트리로 진행 가능:
+# - 워크트리 A: US1 (src/components/Footer.tsx, src/app/layout.tsx)
+# - 워크트리 B: US3 (src/app/settings/page.tsx)   ← US1과 파일 독립
+# US2는 US1의 Footer.tsx를 수정하므로 머지 충돌 회피 위해 US1 이후 진행
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 only — PR #1)
+
+1. Phase 1 T001 완료
+2. Phase 2 T002·T003 완료 → 메타 소스 안정
+3. Phase 3 T004·T005·T006 완료 → 풋터 렌더 확인
+4. **STOP and VALIDATE**: quickstart US1 수동 증거 수집
+5. develop PR → dev.trip.idean.me 확인 → 머지
+
+### Incremental Delivery
+
+1. PR #1 (US1) 머지 → dev 확인
+2. PR #2 (US2) 생성 → dev 확인 → 머지
+3. PR #3 (US3) 생성 → dev 확인 → 머지 (순서 무관)
+4. 3개 PR 모두 머지 후 Phase 6 T012·T013 수행 → develop → main 릴리즈 PR (v2.4.0)
+
+### Parallel Team Strategy
+
+본 프로젝트는 1인 개발이므로 실질 병렬은 워크트리 분기로 수행. US1과 US3는 파일 독립이므로 두 워크트리에서 동시 진행 가능.
+
+---
+
+## Notes
+
+- [P] 마커는 다른 파일 + 선행 없음을 뜻한다. 본 피처는 파일 의존 관계가 명확해 [P] 태스크가 많지 않다.
+- 모든 태스크에 [artifact]와 [why]가 부착되어 drift·커버리지 검증 대상이다.
+- `tsc --noEmit`은 Phase 2·6의 묵시적 검증 단계. 별도 태스크 번호를 부여하지 않고 T003·T013 진행 중 실행한다.
+- 커밋은 태스크 묶음(US 단위) 또는 논리 묶음(Phase 2 전체, Phase 6 전체) 단위로 분할한다.

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,73 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { projectMeta } from "@/lib/project-meta";
+
+export const metadata: Metadata = {
+  title: `About — ${projectMeta.name}`,
+  description: projectMeta.description,
+};
+
+export default function AboutPage() {
+  return (
+    <article className="max-w-2xl mx-auto space-y-8">
+      <header className="space-y-3">
+        <div className="flex items-center gap-2 text-body-sm text-surface-500">
+          <Link href="/" className="hover:text-surface-700">홈</Link>
+          <span>/</span>
+          <span className="text-surface-700">About</span>
+        </div>
+        <h1 className="text-2xl font-bold">{projectMeta.name}</h1>
+        <p className="text-body text-surface-700">{projectMeta.description}</p>
+      </header>
+
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold">프로젝트 배경</h2>
+        <p className="text-body-sm text-surface-700 leading-relaxed">
+          1인 개발자가 동행자와 함께 사용하기 위해 만든 여행 계획 도구입니다.
+          AI 에이전트(Claude Code)가 자연어로 일정·숙소·항공편을 편성하고,
+          웹앱은 결과를 열람·수정·공유하는 창구 역할을 합니다. 마크다운 시절의
+          수작업 프로세스를 벗어나 DB 정본 + AX 중심 워크플로우로 전환 중입니다.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold">정보</h2>
+        <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-body-sm">
+          <dt className="text-surface-500">저작자</dt>
+          <dd className="text-surface-900">{projectMeta.author}</dd>
+
+          <dt className="text-surface-500">라이선스</dt>
+          <dd className="text-surface-900">{projectMeta.license}</dd>
+
+          <dt className="text-surface-500">저장소</dt>
+          <dd>
+            <a
+              href={projectMeta.githubUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary-600 hover:underline"
+            >
+              GitHub ↗
+            </a>
+          </dd>
+
+          <dt className="text-surface-500">API</dt>
+          <dd>
+            <Link href="/docs" className="text-primary-600 hover:underline">
+              /docs →
+            </Link>
+          </dd>
+        </dl>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold">기술 스택</h2>
+        <ul className="list-disc list-inside space-y-1 text-body-sm text-surface-700">
+          {projectMeta.techStack.map((tech) => (
+            <li key={tech}>{tech}</li>
+          ))}
+        </ul>
+      </section>
+    </article>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import ScrollToTop from "@/components/ScrollToTop";
 import SessionProvider from "@/components/SessionProvider";
 import AuthButton from "@/components/AuthButton";
+import Footer from "@/components/Footer";
 import "./globals.css";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -26,7 +27,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
-      <body className={`${inter.className} bg-white text-surface-900 min-h-screen`}>
+      <body className={`${inter.className} bg-white text-surface-900 min-h-screen flex flex-col`}>
         <SessionProvider>
           <header className="max-w-content mx-auto w-full px-4 pt-4 flex items-center justify-between">
             <Link href="/" className="text-body-sm font-semibold text-surface-700 hover:text-surface-900">
@@ -34,10 +35,11 @@ export default function RootLayout({
             </Link>
             <AuthButton />
           </header>
-          <main className="max-w-content mx-auto w-full px-4 py-6 pb-16">
+          <main className="max-w-content mx-auto w-full px-4 py-6 pb-16 flex-1">
             {children}
           </main>
           <ScrollToTop />
+          <Footer />
         </SessionProvider>
       </body>
     </html>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -85,7 +85,15 @@ export default function SettingsPage() {
         <span>/</span>
         <span className="text-surface-700">설정</span>
       </div>
-      <h1 className="text-2xl font-bold">설정</h1>
+      <div className="flex items-baseline justify-between gap-4 flex-wrap">
+        <h1 className="text-2xl font-bold">설정</h1>
+        <Link
+          href="/docs"
+          className="text-body-sm text-primary-600 hover:underline"
+        >
+          API 문서 →
+        </Link>
+      </div>
 
       <section className="space-y-4">
         <h2 className="text-lg font-semibold">API 토큰</h2>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+import { projectMeta } from "@/lib/project-meta";
+
+export default function Footer() {
+  return (
+    <footer className="border-t border-surface-100 mt-auto">
+      <div className="max-w-content mx-auto w-full px-4 py-6 flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-body-sm text-surface-500">
+        <span>Made by {projectMeta.author}</span>
+        <span aria-hidden="true" className="text-surface-300">·</span>
+        <a
+          href={projectMeta.githubUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:text-surface-700"
+        >
+          GitHub ↗
+        </a>
+        <span aria-hidden="true" className="text-surface-300">·</span>
+        <Link href="/about" className="hover:text-surface-700">
+          About
+        </Link>
+        <span aria-hidden="true" className="text-surface-300">·</span>
+        <Link href="/docs" className="hover:text-surface-700">
+          API Docs ↗
+        </Link>
+      </div>
+    </footer>
+  );
+}

--- a/src/lib/project-meta.ts
+++ b/src/lib/project-meta.ts
@@ -1,0 +1,25 @@
+export type ProjectMeta = {
+  readonly name: string;
+  readonly author: string;
+  readonly githubUrl: string;
+  readonly license: string;
+  readonly description: string;
+  readonly techStack: readonly string[];
+};
+
+export const projectMeta = {
+  name: "Trip Planner",
+  author: "idean3885",
+  githubUrl: "https://github.com/idean3885/trip-planner",
+  license: "MIT",
+  description:
+    "AI 기반 여행 계획 및 동행 협업 플래너. Claude Code·MCP 서버와 Next.js 웹앱을 통합해 일정·숙소·항공편을 자연어로 편성한다.",
+  techStack: [
+    "Next.js 15 (App Router)",
+    "TypeScript",
+    "Prisma + Neon Postgres",
+    "Auth.js v5",
+    "Tailwind CSS",
+    "MCP (Python / FastMCP)",
+  ],
+} as const satisfies ProjectMeta;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,11 +5,16 @@ const { auth } = NextAuth(authConfig);
 
 export default auth((req) => {
   const isLoggedIn = !!req.auth;
-  const isAuthRoute = req.nextUrl.pathname.startsWith("/auth");
-  const isApiRoute = req.nextUrl.pathname.startsWith("/api/");
+  const pathname = req.nextUrl.pathname;
+  const isAuthRoute = pathname.startsWith("/auth");
+  const isApiRoute = pathname.startsWith("/api/");
+  const isPublicRoute = pathname === "/about" || pathname.startsWith("/docs");
 
   // API 라우트는 자체 인증 처리 (PAT Bearer 토큰 + 세션 병행, auth-helpers.ts)
   if (isApiRoute) return;
+
+  // 공개 라우트(About, API 문서)는 인증 불요
+  if (isPublicRoute) return;
 
   // 로그인 상태에서 auth 페이지 접근 → 홈으로
   if (isAuthRoute && isLoggedIn) {


### PR DESCRIPTION
## 작업 내용

v2.4.0 릴리즈를 main에 반영한다. 머지 시 CI가 자동으로 annotated 태그 생성 → GitHub Release → PyPI 배포 파이프라인을 연쇄 실행.

## 포함 이력 (main 기준 차이)

| 커밋 | 설명 |
|------|------|
| `bd3bfa8` | release: v2.4.0 버전 범프 + CHANGELOG 고정 (#274) |
| `4726f4c` | feat(#200): 프로젝트 아이덴티티 표면 (풋터/About/설정 링크) (#273) |
| `e9d1f55` | fix(speckit): create-new-feature.sh가 기존 NNN-* 브랜치 재사용하도록 (#271) |
| `9f9b4b9` | chore: dependabot에 추적 메이저 7건 ignore 추가 (#268) |

## 변경 요약 (v2.4.0 CHANGELOG)

### Added (#200)
- 전역 풋터(Made by / GitHub / About / API Docs) — flex-wrap 단일 레이아웃, sticky footer
- `/about` 공개 페이지 — 프로젝트 배경·저작자·라이선스·기술 스택
- 설정 페이지 제목 옆 "API 문서 →" 진입점
- `src/lib/project-meta.ts` 단일 메타 소스 (`as const satisfies`)
- `/about`, `/docs` 공개 라우트 확장 (미들웨어)
- 신규 npm 의존성 0건 (아이콘 유니코드 `↗`)

### Fixed (#271, v2.3.4에서 선반영)
- speckit `create-new-feature.sh` 워크트리 분기 충돌 해소 (현재 브랜치 재사용 감지 + `+` 마커 파싱 수정)

## 자가 검증

| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ✅ 통과 | PR #273/#274 CI에서 확인 (Vercel Ready) |
| 테스트 | ✅ 통과 | `tsc --noEmit` clean, `next lint` clean |
| 문서 동기화 | ✅ 완료 | CHANGELOG v2.4.0 / pyproject.toml 2.4.0 일치 |
| dev 환경 검증 | ✅ 완료 | dev.trip.idean.me 배포 Ready, alias 갱신 확인 |

## 후속 자동화 (main 머지 후)

1. `auto-tag.yml` — pyproject.toml 변경 감지 → `v2.4.0` annotated 태그 push
2. `auto-release.yml` — 태그 push → CHANGELOG v2.4.0 섹션 추출 → GitHub Release 생성
3. `pypi-publish.yml` — 태그 push → 테스트 → PyPI 배포

## 머지 전략

CLAUDE.md 정책에 따라 **Create a merge commit**. Squash 금지.

Refs #200