### PR TITLE
release: v2.4.1 버전 범프 + CHANGELOG 고정

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## [2.4.1] - 2026-04-19
+
+### Chore
+
+- **towncrier 도입으로 CHANGELOG 충돌 해소**: PR마다 `changes/<이슈>.<타입>.md` 단편 파일 1개를 추가하고, 릴리즈 PR에서 `towncrier build`로 자동 집계해 `CHANGELOG.md`에 합친다. 단일 파일 동시 편집 충돌이 구조적으로 차단되어 워크트리 분기 + AI 보조 병렬 작업이 안전해진다. 기존 `auto-tag.yml` / `auto-release.yml` / `pypi-publish.yml` 자동화 체인은 그대로 유지. ([#272](https://github.com/idean3885/trip-planner/issues/272))
+
+
 ## [2.4.0] - 2026-04-19
 
 ### Added

--- a/changes/272.chore.md
+++ b/changes/272.chore.md
@@ -1,1 +1,0 @@
-**towncrier 도입으로 CHANGELOG 충돌 해소**: PR마다 `changes/<이슈>.<타입>.md` 단편 파일 1개를 추가하고, 릴리즈 PR에서 `towncrier build`로 자동 집계해 `CHANGELOG.md`에 합친다. 단일 파일 동시 편집 충돌이 구조적으로 차단되어 워크트리 분기 + AI 보조 병렬 작업이 안전해진다. 기존 `auto-tag.yml` / `auto-release.yml` / `pypi-publish.yml` 자동화 체인은 그대로 유지.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trip-planner-mcp"
-version = "2.4.0"
+version = "2.4.1"
 description = "여행 숙소, 항공편, 관광지 검색 + 구조화 활동 관리 MCP 서버 (20개 도구)"
 requires-python = ">=3.10"
 license = "MIT"


### PR DESCRIPTION
## 작업 내용

v2.4.1 릴리즈 준비. towncrier 단편(`changes/272.chore.md`)을 `CHANGELOG.md`로 통합하고 `pyproject.toml` 버전을 2.4.1로 범프.

## 마일스톤

[v2.4.1: CHANGELOG 충돌 해소 (분산 방식 도입)](https://github.com/idean3885/trip-planner/milestone/16) — closed

## 포함 PR

- #276 chore(#272): towncrier 도입으로 CHANGELOG 단일 파일 충돌 해소

## 변경 사항

- `CHANGELOG.md`: towncrier가 `changes/272.chore.md` 단편을 `## [2.4.1] - 2026-04-19` 섹션으로 통합
- `pyproject.toml`: `version = "2.4.0"` → `"2.4.1"`
- `changes/272.chore.md`: 삭제 (towncrier 소비)

## 자가 검증

| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ⬜ 해당없음 | 버전·문서 변경만 |
| 테스트 | ⬜ 해당없음 | 동일 |
| 문서 동기화 | ✅ 완료 | CHANGELOG.md 자동 생성 |
| towncrier 동작 | ✅ end-to-end | `towncrier build --version 2.4.1 --yes` 정상 실행, 단편 자동 삭제 확인 |

## changes/ 단편

- [x] `chore-no-news` 면제 — 본 PR은 release 작업으로 단편 불필요

## 의미

towncrier 도입(#272) 후 첫 자체 검증 — 새 분산 방식이 end-to-end 동작함을 자기 참조 단편으로 증명.

본 PR 머지 후 별도 develop → main 릴리즈 PR 생성 → 자동 v2.4.1 tag → GitHub Release → PyPI 배포.

🤖 Generated with [Claude Code](https://claude.com/claude-code)