### PR TITLE
chore(#251): typescript 5.9 → 6.0 업그레이드

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,8 +20,6 @@ updates:
         update-types: ["version-update:semver-major"]  # #249
       - dependency-name: "tailwindcss"
         update-types: ["version-update:semver-major"]  # #250
-      - dependency-name: "typescript"
-        update-types: ["version-update:semver-major"]  # #251
       - dependency-name: "eslint"
         update-types: ["version-update:semver-major"]  # #253
       - dependency-name: "@types/node"

--- a/changes/251.chore.md
+++ b/changes/251.chore.md
@@ -1,0 +1,1 @@
+**TypeScript 5.9 → 6.0 업그레이드**: 컴파일러 메이저 버전업. TS 6의 엄격한 side-effect import 검사(TS2882)에 대응해 `src/types/assets.d.ts`를 추가하여 `*.css` 임포트 선언 제공. 타입체크·테스트 전부 통과, `@typescript-eslint/*`와도 peer 호환(`<6.1.0`). `dependabot.yml` typescript ignore 블록 제거.

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "eslint-config-next": "^16.2.4",
         "jsdom": "^29.0.2",
         "tsx": "^4.21.0",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.4"
       }
     },
@@ -11386,9 +11386,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-config-next": "^16.2.4",
     "jsdom": "^29.0.2",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.4"
   }
 }

--- a/src/types/assets.d.ts
+++ b/src/types/assets.d.ts
@@ -1,0 +1,5 @@
+// TypeScript 6부터 임의 확장자(.css, .svg 등) side-effect import에 대한
+// 모듈 선언을 명시적으로 요구. Next.js는 이를 webpack/turbopack에서
+// 처리하지만 TS 6는 선언 없으면 TS2882로 차단한다.
+
+declare module "*.css";


### PR DESCRIPTION
## Summary

v2.4.2 마일스톤 2/3. #251 해결.

- `typescript` 5.9.3 → 6.0.3 (메이저)
- `src/types/assets.d.ts` 신규 — TS 6의 side-effect import 엄격 검사 대응
- `.github/dependabot.yml` typescript ignore 블록 제거
- `changes/251.chore.md` 단편

## TS 6 주요 변경 대응

**TS2882 — side-effect import 엄격 검사**

TypeScript 6부터 `import './globals.css';` 같은 임의 확장자 side-effect import에 대해 모듈 선언을 명시적으로 요구. Next.js는 webpack/turbopack에서 CSS를 처리하지만 TS 컴파일 단계에서는 별도 선언 필요.

대응: `src/types/assets.d.ts`에 `declare module "*.css";` 추가.

```
src/app/layout.tsx(8,8): error TS2882:
  Cannot find module or type declarations for side-effect import of './globals.css'.
```
→ 해결.

## 호환성 확인

- `@typescript-eslint/eslint-plugin@8.58.2` peer typescript: `>=4.8.4 <6.1.0` → 6.0.3 호환
- `eslint-config-next@16.2.4` peer typescript: `>=3.3.1` → 호환
- Next 15 (현재): typescript 6 정식 peer 명시 없음 — dev/build 동작 확인 필요(Vercel preview)

## 검증

- `npx tsc --noEmit`: 에러 없음
- `npm test`: 13 files / 152 tests 통과
- `npm run lint`: baseline과 동일 (tailwind.config.ts require error는 기존 이슈, 별도 맥락)

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)