### PR TITLE
release: v2.4.2 버전 범프 + CHANGELOG 고정

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## [2.4.2] - 2026-04-19
+
+### Chore
+
+- **Next.js 15 → 16 업그레이드**: 프레임워크 메이저 버전업. 현재 프로젝트가 App Router 기본 패턴만 사용하여 breaking change 대응 코드 변경 없음. `next-auth@5.0.0-beta.31` peer(`next: ^14 || ^15 || ^16`)와 호환. `npx tsc --noEmit`·테스트 152개 전부 통과. `dependabot.yml` next ignore 블록 제거. **런타임 검증은 Vercel Preview 빌드 결과로 확인 필요**. ([#249](https://github.com/idean3885/trip-planner/issues/249))
+- **TypeScript 5.9 → 6.0 업그레이드**: 컴파일러 메이저 버전업. TS 6의 엄격한 side-effect import 검사(TS2882)에 대응해 `src/types/assets.d.ts`를 추가하여 `*.css` 임포트 선언 제공. 타입체크·테스트 전부 통과, `@typescript-eslint/*`와도 peer 호환(`<6.1.0`). `dependabot.yml` typescript ignore 블록 제거. ([#251](https://github.com/idean3885/trip-planner/issues/251))
+- **Vitest 3 → 4 업그레이드**: 테스트 러너와 `@vitest/coverage-v8` 메이저 버전 동반 업그레이드. 기존 테스트 152개 전부 통과, 기능 회귀 없음. `dependabot.yml` vitest ignore 블록 제거. ([#252](https://github.com/idean3885/trip-planner/issues/252))
+
+
 ## [2.4.1] - 2026-04-19
 
 ### Chore

--- a/changes/249.chore.md
+++ b/changes/249.chore.md
@@ -1,1 +1,0 @@
-**Next.js 15 → 16 업그레이드**: 프레임워크 메이저 버전업. 현재 프로젝트가 App Router 기본 패턴만 사용하여 breaking change 대응 코드 변경 없음. `next-auth@5.0.0-beta.31` peer(`next: ^14 || ^15 || ^16`)와 호환. `npx tsc --noEmit`·테스트 152개 전부 통과. `dependabot.yml` next ignore 블록 제거. **런타임 검증은 Vercel Preview 빌드 결과로 확인 필요**.

--- a/changes/251.chore.md
+++ b/changes/251.chore.md
@@ -1,1 +1,0 @@
-**TypeScript 5.9 → 6.0 업그레이드**: 컴파일러 메이저 버전업. TS 6의 엄격한 side-effect import 검사(TS2882)에 대응해 `src/types/assets.d.ts`를 추가하여 `*.css` 임포트 선언 제공. 타입체크·테스트 전부 통과, `@typescript-eslint/*`와도 peer 호환(`<6.1.0`). `dependabot.yml` typescript ignore 블록 제거.

--- a/changes/252.chore.md
+++ b/changes/252.chore.md
@@ -1,1 +1,0 @@
-**Vitest 3 → 4 업그레이드**: 테스트 러너와 `@vitest/coverage-v8` 메이저 버전 동반 업그레이드. 기존 테스트 152개 전부 통과, 기능 회귀 없음. `dependabot.yml` vitest ignore 블록 제거.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trip-planner-mcp"
-version = "2.4.1"
+version = "2.4.2"
 description = "여행 숙소, 항공편, 관광지 검색 + 구조화 활동 관리 MCP 서버 (20개 도구)"
 requires-python = ">=3.10"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1015,7 +1015,7 @@ wheels = [
 
 [[package]]
 name = "trip-planner-mcp"
-version = "2.4.0"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

v2.4.2 릴리즈 준비. 마일스톤 "v2.4.2: 메이저 의존성 정리 3건" 완료에 따른 버전 범프 + CHANGELOG 집계.

## 변경

- `CHANGELOG.md` [2.4.2] 섹션 자동 집계 (towncrier)
  - chore(#249) next 15 → 16
  - chore(#251) typescript 5.9 → 6.0
  - chore(#252) vitest 3 → 4
- `pyproject.toml` version 2.4.1 → 2.4.2
- `changes/*.chore.md` 단편 3건 삭제 (towncrier가 CHANGELOG로 이관)

## 마일스톤 상태

| # | PR | 상태 |
|---|---|---|
| #252 vitest | #279 | MERGED |
| #251 typescript | #280 | MERGED |
| #249 next | #281 | MERGED |

## 후속

1. 본 PR(release/v2.4.2 → develop) 머지
2. develop → main PR 머지 → auto-tag.yml이 v2.4.2 태그 생성 → pypi-publish.yml이 자동 배포
3. 추적 이슈 #282 (coverage threshold 100/95 복원) 별도 PR로 진행

🤖 Generated with [Claude Code](https://claude.com/claude-code)