### PR TITLE
feat(#306): About 페이지 카피·구성 재작성 — 일반 사용자 중심

### DIFF
--- a/changes/306.feat.md
+++ b/changes/306.feat.md
@@ -1,0 +1,1 @@
+About 페이지(`/about`)를 일반 사용자 관점으로 재작성. 앱 이름을 **우리의 여행**으로 통일(레포 이름 `trip-planner`는 부차 정보), 문장 톤은 합쇼체로 정합. 기술 스택 나열 섹션은 제거하고, 아키텍처·개발 가이드는 GitHub `docs/` 허브와 `ARCHITECTURE.md`로 분리해 내부 카드 링크로 연결. 유니코드 화살표(↗·→)를 lucide 아이콘(`ExternalLink`, `ArrowRight`, `BookOpen`, `Layers`)으로 교체하고, 전체 레이아웃을 shadcn `<Card>` 기반 semantic 토큰 체계에 맞춰 재구성.

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,72 +1,150 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { ExternalLink, ArrowRight, BookOpen, Layers } from "lucide-react";
 import { projectMeta } from "@/lib/project-meta";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 
 export const metadata: Metadata = {
-  title: `About — ${projectMeta.name}`,
+  title: `소개 — ${projectMeta.name}`,
   description: projectMeta.description,
 };
 
 export default function AboutPage() {
   return (
-    <article className="max-w-2xl mx-auto space-y-8">
+    <article className="mx-auto max-w-2xl space-y-8">
       <header className="space-y-3">
-        <div className="flex items-center gap-2 text-body-sm text-surface-500">
-          <Link href="/" className="hover:text-surface-700">홈</Link>
-          <span>/</span>
-          <span className="text-surface-700">About</span>
-        </div>
-        <h1 className="text-2xl font-bold">{projectMeta.name}</h1>
-        <p className="text-body text-surface-700">{projectMeta.description}</p>
+        <nav className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Link href="/" className="hover:text-foreground">
+            홈
+          </Link>
+          <span aria-hidden>·</span>
+          <span className="text-foreground">소개</span>
+        </nav>
+        <h1 className="text-2xl font-semibold tracking-tight">
+          {projectMeta.name}
+        </h1>
+        <p className="text-base leading-relaxed text-foreground">
+          {projectMeta.tagline}
+        </p>
       </header>
 
       <section className="space-y-3">
-        <h2 className="text-lg font-semibold">프로젝트 배경</h2>
-        <p className="text-body-sm text-surface-700 leading-relaxed">
-          1인 개발자가 동행자와 함께 사용하기 위해 만든 여행 계획 도구입니다.
-          AI 에이전트(Claude Code)가 자연어로 일정·숙소·항공편을 편성하고,
-          웹앱은 결과를 열람·수정·공유하는 창구 역할을 합니다. 마크다운 시절의
-          수작업 프로세스를 벗어나 DB 정본 + AX 중심 워크플로우로 전환 중입니다.
+        <h2 className="text-base font-semibold tracking-tight">
+          이렇게 쓰게 됩니다
+        </h2>
+        <p className="text-sm leading-relaxed text-muted-foreground">
+          여행 주인이 &quot;이번 주말 제주 2박 3일, 바다가 보이는 숙소로&quot;처럼 말을
+          건네면 일정이 자동으로 짜입니다. 초대받은 동행자는 웹에서 바로 일정을
+          열어보고, 가고 싶은 곳을 덧붙이거나 시간을 조정합니다. 모든 변경은
+          즉시 서로에게 공유되어 따로 정리할 필요가 없습니다.
         </p>
       </section>
 
       <section className="space-y-3">
-        <h2 className="text-lg font-semibold">정보</h2>
-        <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-body-sm">
-          <dt className="text-surface-500">저작자</dt>
-          <dd className="text-surface-900">{projectMeta.author}</dd>
+        <h2 className="text-base font-semibold tracking-tight">
+          좀 더 자세히 보기
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          아키텍처·개발 가이드·MCP 도구 설명 등 기술 문서는 GitHub에서 확인할 수
+          있습니다.
+        </p>
+        <div className="grid gap-2 sm:grid-cols-2">
+          <a
+            href={projectMeta.docsUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group block"
+          >
+            <Card
+              size="sm"
+              className="h-full transition-all group-hover:ring-foreground/20 group-hover:-translate-y-px"
+            >
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-sm">
+                  <BookOpen className="size-4" aria-hidden />
+                  기술 문서 허브
+                </CardTitle>
+                <CardDescription className="text-xs">
+                  docs/ 디렉토리 전체 — 아키텍처·운영·협업 프로세스 목차
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <span className="inline-flex items-center gap-1 text-xs font-medium text-foreground">
+                  GitHub에서 열기
+                  <ExternalLink className="size-3" aria-hidden />
+                </span>
+              </CardContent>
+            </Card>
+          </a>
+          <a
+            href={projectMeta.architectureUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group block"
+          >
+            <Card
+              size="sm"
+              className="h-full transition-all group-hover:ring-foreground/20 group-hover:-translate-y-px"
+            >
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-sm">
+                  <Layers className="size-4" aria-hidden />
+                  아키텍처 문서
+                </CardTitle>
+                <CardDescription className="text-xs">
+                  시스템 구조·인증 흐름·데이터 접근 패턴·도메인 결합도
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <span className="inline-flex items-center gap-1 text-xs font-medium text-foreground">
+                  ARCHITECTURE.md 열기
+                  <ExternalLink className="size-3" aria-hidden />
+                </span>
+              </CardContent>
+            </Card>
+          </a>
+        </div>
+      </section>
 
-          <dt className="text-surface-500">라이선스</dt>
-          <dd className="text-surface-900">{projectMeta.license}</dd>
+      <section className="space-y-3">
+        <h2 className="text-base font-semibold tracking-tight">정보</h2>
+        <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+          <dt className="text-muted-foreground">저작자</dt>
+          <dd className="text-foreground">{projectMeta.author}</dd>
 
-          <dt className="text-surface-500">저장소</dt>
+          <dt className="text-muted-foreground">라이선스</dt>
+          <dd className="text-foreground">{projectMeta.license}</dd>
+
+          <dt className="text-muted-foreground">저장소</dt>
           <dd>
             <a
               href={projectMeta.githubUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-primary-600 hover:underline"
+              className="inline-flex items-center gap-1 text-foreground underline-offset-4 hover:underline"
             >
-              GitHub ↗
+              {projectMeta.repoName}
+              <ExternalLink className="size-3" aria-hidden />
             </a>
           </dd>
 
-          <dt className="text-surface-500">API</dt>
+          <dt className="text-muted-foreground">API 문서</dt>
           <dd>
-            <Link href="/docs" className="text-primary-600 hover:underline">
-              /docs →
+            <Link
+              href="/docs"
+              className="inline-flex items-center gap-1 text-foreground underline-offset-4 hover:underline"
+            >
+              앱 안에서 열기
+              <ArrowRight className="size-3" aria-hidden />
             </Link>
           </dd>
         </dl>
-      </section>
-
-      <section className="space-y-3">
-        <h2 className="text-lg font-semibold">기술 스택</h2>
-        <ul className="list-disc list-inside space-y-1 text-body-sm text-surface-700">
-          {projectMeta.techStack.map((tech) => (
-            <li key={tech}>{tech}</li>
-          ))}
-        </ul>
       </section>
     </article>
   );

--- a/src/lib/project-meta.ts
+++ b/src/lib/project-meta.ts
@@ -1,25 +1,26 @@
 export type ProjectMeta = {
   readonly name: string;
+  readonly repoName: string;
   readonly author: string;
   readonly githubUrl: string;
+  readonly docsUrl: string;
+  readonly architectureUrl: string;
   readonly license: string;
+  readonly tagline: string;
   readonly description: string;
-  readonly techStack: readonly string[];
 };
 
 export const projectMeta = {
-  name: "Trip Planner",
+  name: "우리의 여행",
+  repoName: "trip-planner",
   author: "idean3885",
   githubUrl: "https://github.com/idean3885/trip-planner",
+  docsUrl: "https://github.com/idean3885/trip-planner/tree/main/docs",
+  architectureUrl:
+    "https://github.com/idean3885/trip-planner/blob/main/docs/ARCHITECTURE.md",
   license: "MIT",
+  tagline:
+    "여행 계획을 대화로 만들고 동행자와 함께 다듬는 플래너입니다. 일정·숙소·활동을 한곳에 모아 두고, 모바일에서 바로 열어 씁니다.",
   description:
-    "AI 기반 여행 계획 및 동행 협업 플래너. Claude Code·MCP 서버와 Next.js 웹앱을 통합해 일정·숙소·항공편을 자연어로 편성한다.",
-  techStack: [
-    "Next.js 15 (App Router)",
-    "TypeScript",
-    "Prisma + Neon Postgres",
-    "Auth.js v5",
-    "Tailwind CSS",
-    "MCP (Python / FastMCP)",
-  ],
+    "여행 계획을 대화로 만들고 동행자와 함께 다듬는 플래너. 일정·숙소·활동을 한곳에 모아 모바일에서 바로 확인합니다.",
 } as const satisfies ProjectMeta;


### PR DESCRIPTION
## 요약

About 페이지를 오가닉 유입 일반 사용자 관점으로 재작성. 기술 키워드를 걷어내고 앱 이름(우리의 여행)·합쇼체·카드형 IA로 정리했습니다. 개발자용 설명은 GitHub `docs/`(허브·ARCHITECTURE.md)로 외부화합니다.

- 제목: "Trip Planner"(레포명) → **"우리의 여행"**(앱명)
- 톤: 합쇼체 통일
- 본문: "이렇게 쓰게 됩니다" 섹션으로 일반 사용자 사용 예 추가
- 기술 스택 나열 섹션 **제거**
- 유니코드 화살표(↗·→) → lucide 아이콘(ExternalLink·ArrowRight·BookOpen·Layers)
- 전체 레이아웃 shadcn `<Card>` + semantic 토큰으로 재구성
- `projectMeta`에 `repoName`·`docsUrl`·`architectureUrl`·`tagline` 필드 추가, `techStack` 제거

Closes #306.

## 의존성

- #307(문서 허브 정비) PR #308 머지 완료. 본 PR에서 링크하는 `docs/`·`ARCHITECTURE.md` 경로가 안정화됨.

## 변경 파일

- `src/app/about/page.tsx` — 전면 재작성
- `src/lib/project-meta.ts` — 스키마 재정의(필드 교체)
- `changes/306.feat.md` — towncrier 단편

## Test plan

- [x] `npx tsc --noEmit` 통과
- [x] About 페이지 로컬 렌더 확인(카드 레이아웃·아이콘·링크 동작)
- [x] Footer가 `projectMeta.author`·`projectMeta.githubUrl`만 참조하므로 영향 없음 확인
- [x] OG 메타 `description` 유지(문구만 일반 사용자 기준으로 교체)

🤖 Generated with [Claude Code](https://claude.com/claude-code)