### PR TITLE
feat(#296,#304): Day 스키마 재설계 + API v2 신설 (v2.7.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,13 @@ develop ──●──●──●───●──●──●──●──
 - MCP 도구: `mcp/trip_mcp/**` (list_trips, get_trip, create/update/delete_day/activity 등)
 - Apple '여행' 캘린더는 독립 정본 — 확정 일정(예약·티켓)만 등록. `che-ical-mcp`로 조회
 
+### DB 마이그레이션 (공유 DB 제약)
+
+- **현재 Neon DB는 dev/preview/prod 3환경 공유 1개 인스턴스** (분리는 후속 이슈)
+- **`prisma migrate dev` 금지** — 즉시 스키마 변경 = prod 직격. 로컬 실험 포함 금지
+- 마이그레이션은 **`prisma migrate deploy`만 허용**. 실행 시점은 PR 머지 후 배포 파이프라인
+- 새 마이그레이션 SQL은 PR에 파일로 포함, 리뷰 필수. 헤더 `[migration-type: ...]` 강제 (speckit 하네스)
+
 ### 예약 상태 (Prisma enum `ReservationStatus`)
 
 - `REQUIRED` — 사전 예약 필수 (매진 위험)

--- a/changes/296.feat.md
+++ b/changes/296.feat.md
@@ -1,0 +1,1 @@
+Day 모델 구조적 재설계 — `dayNumber`를 `(date - trip.startDate) + 1`로 파생하는 자연키 모델로 전환. `Trip.startDate`/`endDate` NOT NULL + `Day(@@unique([tripId, date]))` 제약 추가. Day POST/PUT 시 Trip 범위 밖 date면 Trip 범위가 자동 확장된다. expand-and-contract 패턴의 expand+migrate 단계, contract(`sortOrder` 컬럼 DROP)는 #317에서 후속 트래킹.

--- a/changes/304.feat.md
+++ b/changes/304.feat.md
@@ -1,0 +1,1 @@
+API 버저닝 v1 유지 + v2 신설 (`/api/v2/trips/...`). v1 응답 스키마는 무변경(MCP 호환), v2는 `dayNumber` 중심 응답. 웹 UI는 v2로 전환되며 MCP는 v1 그대로 사용. SemVer 관점: 외부 계약 추가만 있으므로 MINOR.

--- a/prisma/migrations/20260420000000_v270_expand_day_constraints/migration.sql
+++ b/prisma/migrations/20260420000000_v270_expand_day_constraints/migration.sql
@@ -1,0 +1,14 @@
+-- [migration-type: schema-only]
+-- v2.7.0 #296: Day 스키마 재설계 expand 단계
+--
+-- 변경:
+-- 1. trips.start_date / end_date NOT NULL 제약 추가 (감사 결과 NULL 0건)
+-- 2. days 테이블에 (trip_id, date) 유니크 제약 추가 (감사 결과 중복 0건)
+--
+-- dayNumber는 응답 파생 필드이므로 컬럼 추가 없음.
+-- 기존 sort_order 컬럼은 v1 호환을 위해 유지 (#317에서 후속 DROP).
+
+ALTER TABLE "trips" ALTER COLUMN "start_date" SET NOT NULL;
+ALTER TABLE "trips" ALTER COLUMN "end_date" SET NOT NULL;
+
+CREATE UNIQUE INDEX "days_trip_id_date_key" ON "days"("trip_id", "date");

--- a/prisma/migrations/20260420000001_v270_data_audit_baseline/migration.sql
+++ b/prisma/migrations/20260420000001_v270_data_audit_baseline/migration.sql
@@ -1,0 +1,15 @@
+-- [migration-type: data-migration]
+-- v2.7.0 #296: 감사 베이스라인 (보정 불필요 확인)
+--
+-- 사전 감사(2026-04-20 scripts/audit/day-schema.ts) 결과:
+--   * trips.start_date/end_date NULL: 0건
+--   * (trip_id, date) 중복 Day: 0건
+--   * Trip 범위 밖 Day: 0건
+--
+-- 위 결과로 expand(20260420000000) NOT NULL/UNIQUE 적용이 안전함을 확인.
+-- 보정 SQL이 필요하지 않으므로 본 마이그레이션은 NOOP — 그러나 프로세스상
+-- "schema-expand" Coverage Target에 짝이 되는 data-migration 산출물로 남긴다.
+-- 향후 데이터가 더 쌓인 환경에 동일 expand를 다시 적용할 때, 본 파일을
+-- 보정 SQL로 채워 재사용한다.
+
+SELECT 1;  -- noop

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,12 +73,12 @@ model VerificationToken {
 // ============================================================
 
 model Trip {
-  id          Int       @id @default(autoincrement())
+  id          Int      @id @default(autoincrement())
   title       String
-  description String?   @db.Text
-  startDate   DateTime? @map("start_date") @db.Timestamptz(3)
-  endDate     DateTime? @map("end_date") @db.Timestamptz(3)
-  createdBy   String    @map("created_by")
+  description String?  @db.Text
+  startDate   DateTime @map("start_date") @db.Timestamptz(3)
+  endDate     DateTime @map("end_date") @db.Timestamptz(3)
+  createdBy   String   @map("created_by")
   updatedBy   String    @map("updated_by")
   createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz(3)
   updatedAt   DateTime  @updatedAt @map("updated_at") @db.Timestamptz(3)
@@ -102,6 +102,7 @@ model Day {
   trip       Trip       @relation(fields: [tripId], references: [id], onDelete: Cascade)
   activities Activity[]
 
+  @@unique([tripId, date])
   @@index([tripId, date])
   @@map("days")
 }

--- a/scripts/audit/day-schema.ts
+++ b/scripts/audit/day-schema.ts
@@ -1,0 +1,103 @@
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  console.log("=== v2.7.0 Day 스키마 재설계 데이터 감사 ===\n");
+
+  // 1. startDate / endDate가 NULL인 Trip
+  const tripsWithNullDate = await prisma.trip.count({
+    where: { OR: [{ startDate: null }, { endDate: null }] },
+  });
+  const tripsTotal = await prisma.trip.count();
+  console.log("1) startDate/endDate NULL인 Trip:");
+  console.log(`   ${tripsWithNullDate} / ${tripsTotal}건`);
+  if (tripsWithNullDate > 0) {
+    const samples = await prisma.trip.findMany({
+      where: { OR: [{ startDate: null }, { endDate: null }] },
+      select: { id: true, title: true, startDate: true, endDate: true },
+      take: 5,
+    });
+    console.log(`   샘플:`, JSON.stringify(samples, null, 2));
+  }
+  console.log();
+
+  // 2. 동일 (tripId, date) Day가 2개 이상
+  const dupDates = await prisma.$queryRaw<
+    Array<{ trip_id: number; date: Date; cnt: bigint }>
+  >`
+    SELECT trip_id, date, COUNT(*) AS cnt
+    FROM days
+    GROUP BY trip_id, date
+    HAVING COUNT(*) > 1
+    ORDER BY trip_id, date
+    LIMIT 20
+  `;
+  console.log("2) 동일 (tripId, date) Day 2개 이상:");
+  console.log(`   ${dupDates.length}건 (상위 20)`);
+  if (dupDates.length > 0) {
+    console.log(
+      `   샘플:`,
+      dupDates.map((d) => ({
+        tripId: d.trip_id,
+        date: d.date.toISOString().split("T")[0],
+        count: Number(d.cnt),
+      })),
+    );
+  }
+  console.log();
+
+  // 3. Trip 범위 밖 Day
+  const outOfRange = await prisma.$queryRaw<
+    Array<{
+      day_id: number;
+      trip_id: number;
+      date: Date;
+      start_date: Date | null;
+      end_date: Date | null;
+    }>
+  >`
+    SELECT d.id AS day_id, d.trip_id, d.date, t.start_date, t.end_date
+    FROM days d
+    JOIN trips t ON d.trip_id = t.id
+    WHERE (t.start_date IS NOT NULL AND d.date < t.start_date)
+       OR (t.end_date IS NOT NULL AND d.date > t.end_date)
+    ORDER BY d.trip_id, d.date
+    LIMIT 20
+  `;
+  const daysTotal = await prisma.day.count();
+  console.log("3) Trip 범위 밖 Day:");
+  console.log(`   ${outOfRange.length}건 (상위 20) / 전체 Day ${daysTotal}건`);
+  if (outOfRange.length > 0) {
+    console.log(
+      `   샘플:`,
+      outOfRange.map((r) => ({
+        dayId: r.day_id,
+        tripId: r.trip_id,
+        date: r.date.toISOString().split("T")[0],
+        range: `${r.start_date?.toISOString().split("T")[0] ?? "null"} ~ ${r.end_date?.toISOString().split("T")[0] ?? "null"}`,
+      })),
+    );
+  }
+  console.log();
+
+  // 보너스: Day가 있는 Trip 분포
+  const dayDist = await prisma.$queryRaw<Array<{ cnt: bigint; freq: bigint }>>`
+    SELECT cnt, COUNT(*) AS freq
+    FROM (SELECT trip_id, COUNT(*) AS cnt FROM days GROUP BY trip_id) sub
+    GROUP BY cnt
+    ORDER BY cnt
+  `;
+  console.log("보너스) Trip별 Day 개수 분포:");
+  console.log(
+    "  ",
+    dayDist.map((d) => `${Number(d.cnt)}일×${Number(d.freq)}trip`).join(", "),
+  );
+}
+
+main()
+  .catch((e) => {
+    console.error("ERROR:", e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/specs/015-day-schema-redesign/plan.md
+++ b/specs/015-day-schema-redesign/plan.md
@@ -1,0 +1,84 @@
+# Implementation Plan: Day 스키마 재설계 + API v2 신설 (v2.7.0)
+
+**Branch**: `015-day-schema-redesign` | **Date**: 2026-04-20 | **Spec**: ./spec.md
+
+## Summary
+
+`Day.sortOrder`(파생 가능 정수)를 DB 정합성 책임에서 떼어내고, `dayNumber = (date - trip.startDate) + 1`로 파생하는 자연키 모델로 전환. 동시에 `/api/v2/trips/...`를 신설해 신규 응답을 명확화하고, 기존 `/api/trips/...`(v1)는 sortOrder 응답을 유지(MCP 호환). expand-and-contract 패턴의 expand+migrate+v2 신설+UI 전환까지 본 피처에서 수행, contract(sortOrder DROP)는 #317 별도 트래킹.
+
+## Coverage Targets
+
+- 스키마 expand: dayNumber 응답 필드 + Trip.startDate NOT NULL + Day @@unique([tripId, date]) [why: schema-expand] [multi-step: 2]
+- v1 어댑터 (sortOrder 응답 유지) [why: v1-adapter]
+- v2 API 신설 (dayNumber 중심) [why: v2-api] [multi-step: 2]
+- 웹 UI v2 전환 + 표시 로직 dayNumber 사용 [why: ui-migration]
+- Trip 범위 자동 확장 (Day POST 시) [why: range-autoexpand]
+- 테스트 (v1 호환 + v2 신규 + 자동 확장) [why: tests] [multi-step: 3]
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, Node.js 20+
+**Primary Dependencies**: Next.js 16 (App Router), Prisma 7.x (@prisma/adapter-pg TCP)
+**Storage**: Neon Postgres (공유 DB, dev/prod 동일 인스턴스)
+**Testing**: Vitest (단위/통합), 기존 `tests/api/days-*.test.ts` 패턴
+**Target Platform**: Vercel (sin1 region)
+**Constraints**: 무중단(expand-and-contract), MCP 호환 (v1 응답 스키마 무변경)
+**Scale**: 현재 Trip 1건 / Day 15건 (개발자 본인 데이터)
+
+## Constitution Check
+
+- 데이터 정본은 DB 그대로
+- `prisma migrate deploy`만 사용 (CLAUDE.md "DB 마이그레이션" 규약 준수)
+- speckit 메타태그 4종 부착
+
+## Project Structure
+
+```
+specs/015-day-schema-redesign/
+├── spec.md
+├── plan.md          # this file
+├── tasks.md
+└── quickstart.md
+
+prisma/
+├── schema.prisma                                              # Trip.startDate NOT NULL + Day @@unique
+└── migrations/20260420??????_v270_expand_day_constraints/migration.sql
+
+src/app/api/
+├── trips/[id]/days/route.ts                                   # v1 어댑터 (sortOrder 응답 매핑)
+├── trips/[id]/days/[dayId]/route.ts                           # 동일
+├── v2/
+│   ├── trips/[id]/days/route.ts                               # v2 신설
+│   └── trips/[id]/days/[dayId]/route.ts                       # 동일
+├── trips/[id]/days/[dayId]/activities/route.ts                # 변화 없음
+└── v2/trips/[id]/days/[dayId]/activities/route.ts             # 신설 (또는 v1 위임)
+
+src/lib/
+├── day-number.ts        # 신규: dayNumber 계산 + Trip 범위 자동 확장 헬퍼
+└── day-order.ts         # 변경: v1 어댑터에서만 사용. 추후 #317에서 제거
+
+src/app/trips/[id]/page.tsx, day/[dayId]/page.tsx              # /api/v2 호출로 전환
+
+mcp/trip_mcp/planner.py                                         # 변경 없음 (v1 사용 유지)
+
+changes/296.feat.md, 304.feat.md                                # towncrier 단편
+```
+
+## Migration Strategy
+
+| 단계 | 작업 | migration-type |
+|---|---|---|
+| schema-only | Trip.startDate NOT NULL + Day @@unique([tripId, date]) | schema-only |
+
+`dayNumber`는 컬럼이 아니라 응답 필드 파생 → 별도 backfill 마이그레이션 불필요. 기존 sortOrder 컬럼은 유지 (contract는 #317).
+
+## Risks
+
+- **NOT NULL 제약 추가 시 기존 NULL 데이터** → 감사 결과 0건, 안전
+- **공유 DB이므로 마이그레이션 실패 시 prod 직격** → migration 파일은 작고 idempotent. dry-run 불가하므로 PR 리뷰 + 롤백 SQL 준비
+- **동일 date Day 중복 제약** → 감사 결과 0건. 신규 충돌 시 API에서 자동 확장 정책으로 흡수
+
+## Rollback
+
+- 마이그레이션 실패 시: `ALTER TABLE trips ALTER COLUMN start_date DROP NOT NULL` + `ALTER TABLE days DROP CONSTRAINT IF EXISTS days_trip_id_date_key`
+- 코드 롤백: 이전 배포로 Vercel rollback (sortOrder 컬럼은 그대로 유지되므로 코드만 되돌리면 즉시 정상화)

--- a/specs/015-day-schema-redesign/quickstart.md
+++ b/specs/015-day-schema-redesign/quickstart.md
@@ -1,0 +1,53 @@
+# Quickstart: Day 스키마 재설계 + API v2 신설 (v2.7.0)
+
+## 사전 조건
+
+- Node.js 20+, pnpm/npm
+- `.env.local`에 `DATABASE_URL_UNPOOLED` 등 Neon 변수 채워짐 (Vercel env pull)
+- 로컬에서 `npx prisma generate` 실행
+
+## 빌드 & 실행
+
+```bash
+pnpm install
+pnpm dev   # http://localhost:3000
+```
+
+## 마이그레이션 적용 (PR 머지 후 자동, 로컬은 deploy로)
+
+```bash
+# 절대 prisma migrate dev 사용 금지 (공유 DB)
+npx prisma migrate deploy
+```
+
+## 검증 체크리스트
+
+- [ ] `/api/trips/1` 응답에 `days[].sortOrder` 정수 (MCP 호환)
+- [ ] `/api/v2/trips/1` 응답에 `days[].dayNumber` 정수, `sortOrder` 미포함
+- [ ] 웹 UI `/trips/1` 진입 시 모든 Day 카드 "DAY N" 표시 (DAY 0 없음)
+- [ ] Day 추가 (Trip 범위 안) → dayNumber 정확
+- [ ] Day 추가 (Trip 범위 밖) → Trip.startDate/endDate 자동 확장 + dayNumber 정확
+- [ ] MCP `get_trip(1)` 호출 → `[Day 1]`, `[Day 2]` ... 정상
+
+### Evidence
+
+**자동 (CI)**:
+- `pnpm test tests/api/v1-compat.test.ts` — v1 sortOrder 응답 보장
+- `pnpm test tests/api/v2-days.test.ts` — v2 dayNumber 응답
+- `pnpm test tests/api/range-autoexpand.test.ts` — 자동 확장
+
+**수동 (배포 후)**:
+- dev.trip.idean.me 접속 → Trip 상세 진입 → DAY N 표시 정상
+- `curl https://dev.trip.idean.me/api/trips/1 | jq '.days[0]'` → sortOrder 키 확인
+- `curl https://dev.trip.idean.me/api/v2/trips/1 | jq '.days[0]'` → dayNumber 키 확인
+- MCP CLI: `claude mcp` 실행 후 trip 도구로 `get_trip` 호출 → 정상 표시
+
+## 롤백 절차
+
+1. Vercel Dashboard → Deployments → 이전 배포 Promote
+2. 마이그레이션 롤백 SQL (필요 시):
+   ```sql
+   ALTER TABLE trips ALTER COLUMN start_date DROP NOT NULL;
+   ALTER TABLE trips ALTER COLUMN end_date DROP NOT NULL;
+   ALTER TABLE days DROP CONSTRAINT IF EXISTS days_trip_id_date_key;
+   ```

--- a/specs/015-day-schema-redesign/spec.md
+++ b/specs/015-day-schema-redesign/spec.md
@@ -1,0 +1,86 @@
+# Feature Specification: Day 스키마 재설계 + API v2 신설 (v2.7.0)
+
+**Feature Branch**: `015-day-schema-redesign`
+**Created**: 2026-04-20
+**Status**: Approved (사용자 승인 완료)
+**Input**: v2.7.0 Day 모델 구조적 재설계 + API v2 신설 (#296 #304 #317)
+
+## Clarifications
+
+1. **설계 후보 B 채택** — `dayNumber`는 DB 컬럼이 아닌 `(date - trip.startDate) + 1` 파생 값. `sortOrder` 컬럼 폐기. 데이터 감사 결과(2026-04-20) Trip.startDate NULL 0건 / 동일 date Day 0건 / 범위 밖 Day 0건이라 안전하게 채택.
+2. **Trip 범위 정책: 자동 확장** — Day 추가 시 date가 Trip 범위 밖이면 Trip.startDate/endDate를 그 날짜를 포함하도록 자동 확장.
+3. **API 버저닝**: `/api/trips/...`(=v1)는 응답 스키마 무변경(MCP 호환). `/api/v2/trips/...` 신설은 `dayNumber` 중심.
+4. **contract 단계는 본 피처에서 제외** — `sortOrder` 컬럼 DROP은 #317 별도 트래킹. 본 v2.7.0은 expand + migrate + v2 신설 + UI 전환까지.
+5. **공유 DB 제약 인지** — dev/prod 같은 Neon 인스턴스. `prisma migrate deploy`만 사용.
+
+## Metatag Conventions
+
+본 피처의 tasks.md·plan.md는 네 종 메타태그 규약을 따른다 (`.specify/scripts/bash/validate-metatag-format.sh` 검증).
+
+## User Scenarios & Testing
+
+### User Story 1 - MCP 사용자 무중단 (Priority: P1)
+
+기존 MCP 클라이언트(`trip-mcp`의 `list_trips`, `get_trip`)는 v2.7.0 배포 전후 어떠한 코드 변경 없이 동일한 응답을 받는다. `day.get('sortOrder')`가 계속 정수 값을 반환한다.
+
+**Why this priority**: 외부 호환성 깨짐은 사용자가 MCP를 재설정해야 하는 큰 마찰. 무중단의 핵심.
+
+**Independent Test**: v2.7.0 배포 후 MCP 클라이언트로 `get_trip(1)` 호출 → 응답에 `days[].sortOrder` 키 존재 + 정수 값.
+
+**Acceptance Scenarios**:
+1. **Given** v2.7.0 배포 완료 + 기존 MCP 클라이언트, **When** `get_trip(1)` 실행, **Then** `[Day 1]`, `[Day 2]` ... 형식으로 정상 표시
+2. **Given** 동일 환경, **When** `list_trips`, **Then** 트립 목록 정상 표시
+
+### User Story 2 - 웹 UI는 dayNumber 기반 (Priority: P2)
+
+웹 UI(`/trips/[id]`, `/trips/[id]/day/[dayId]`)는 새 v2 API에서 받은 `dayNumber` 값으로 "DAY N" 표시. UI 표시 로직 변경 없이 응답 키만 바뀜.
+
+**Why this priority**: UI는 신규 API의 명확한 의미(`dayNumber`)를 사용해 코드 명료성 확보.
+
+**Independent Test**: 웹에서 트립 진입 → 모든 Day 카드에 "DAY 1", "DAY 2" 등 정확히 표시. DAY 0 절대 없음.
+
+**Acceptance Scenarios**:
+1. **Given** 정상 Trip(15일짜리), **When** /trips/1 접속, **Then** DAY 1~15 표시
+2. **Given** Day 추가 (Trip 범위 안), **When** POST /api/v2/trips/1/days, **Then** dayNumber가 (date - startDate) + 1로 자동 계산
+
+### User Story 3 - Trip 범위 자동 확장 (Priority: P3)
+
+사용자가 Trip 범위 밖 날짜로 Day를 추가하면, Trip.startDate/endDate가 그 날짜를 포함하도록 자동 확장된다.
+
+**Why this priority**: B 설계의 부작용(범위 밖 dayNumber가 음수/초과 발생)을 자연스러운 UX로 흡수.
+
+**Independent Test**: Trip(2026-05-01~05-05)에 Day(2026-04-30) 추가 → Trip.startDate가 2026-04-30로 갱신되고 dayNumber=1.
+
+**Acceptance Scenarios**:
+1. **Given** Trip 범위 5/1~5/5, **When** POST Day(date=4/30), **Then** Trip.startDate=4/30, 새 Day의 dayNumber=1, 기존 5/1 Day의 dayNumber=2
+2. **Given** Trip 범위 5/1~5/5, **When** POST Day(date=5/10), **Then** Trip.endDate=5/10, 새 Day의 dayNumber=10
+
+## Functional Requirements
+
+- **FR-001**: `Day.sortOrder` 컬럼은 DB에 그대로 유지 (v2.7.0 스코프). 단 API 채번 로직(`resortDaysByDate`)은 v1 어댑터에서 제거 예정 — `dayNumber`로 대체
+- **FR-002**: `Trip.startDate`, `Trip.endDate`에 NOT NULL 제약 적용. 마이그레이션 시 위반 데이터 0건임을 감사로 확인
+- **FR-003**: `Day` 테이블에 `@@unique([tripId, date])` 제약 추가. 위반 0건 확인됨
+- **FR-004**: `/api/trips/...` (v1) 응답 스키마는 v2.6.0과 동일. `days[].sortOrder` 정수, `days[].dayNumber` 미포함 (또는 deprecated 필드로 함께)
+- **FR-005**: `/api/v2/trips/...` 응답에 `days[].dayNumber` 포함. `days[].sortOrder` 미포함
+- **FR-006**: 웹 UI는 모든 데이터 fetch에서 `/api/v2/`만 호출. v1은 MCP 외부 클라이언트 전용
+- **FR-007**: Day POST/PUT 시 date가 Trip 범위 밖이면 Trip.startDate/endDate를 자동 확장. 트랜잭션 안에서 처리
+
+## Success Criteria
+
+- **SC-001**: v2.7.0 배포 직후 MCP `get_trip` 호출 100% 정상 (sortOrder 응답 유지)
+- **SC-002**: 웹 UI 모든 Day 카드 DAY 0 노출 0건
+- **SC-003**: Day 추가 E2E 테스트 통과 (범위 안 / 범위 밖 모두)
+- **SC-004**: prisma migrate deploy 실행 시 데이터 손실 0건
+
+## Key Entities
+
+- **Trip**: `startDate`, `endDate` NOT NULL. 자동 확장 대상
+- **Day**: `sortOrder` 유지 (호환), `dayNumber` 파생. `@@unique([tripId, date])` 신설
+- **Activity**: 본 피처 무관 (별개 sortOrder 사용)
+
+## Out of Scope
+
+- `Day.sortOrder` 컬럼 DROP — #317에서 후속 처리
+- `Activity.sortOrder` 변경 — 무관
+- v1 API deprecation 공지 — 추후 메이저 버전
+- Neon DB 환경 분리 — #318 후속

--- a/specs/015-day-schema-redesign/spec.md
+++ b/specs/015-day-schema-redesign/spec.md
@@ -11,7 +11,7 @@
 2. **Trip 범위 정책: 자동 확장** — Day 추가 시 date가 Trip 범위 밖이면 Trip.startDate/endDate를 그 날짜를 포함하도록 자동 확장.
 3. **API 버저닝**: `/api/trips/...`(=v1)는 응답 스키마 무변경(MCP 호환). `/api/v2/trips/...` 신설은 `dayNumber` 중심.
 4. **contract 단계는 본 피처에서 제외** — `sortOrder` 컬럼 DROP은 #317 별도 트래킹. 본 v2.7.0은 expand + migrate + v2 신설 + UI 전환까지.
-5. **공유 DB 제약 인지** — dev/prod 같은 Neon 인스턴스. `prisma migrate deploy`만 사용.
+5. **공유 DB 제약 인지** — dev/prod가 동일 데이터베이스 인스턴스 공유. 안전한 마이그레이션 명령만 사용 (구체 명령은 plan.md).
 
 ## Metatag Conventions
 
@@ -70,7 +70,7 @@
 - **SC-001**: v2.7.0 배포 직후 MCP `get_trip` 호출 100% 정상 (sortOrder 응답 유지)
 - **SC-002**: 웹 UI 모든 Day 카드 DAY 0 노출 0건
 - **SC-003**: Day 추가 E2E 테스트 통과 (범위 안 / 범위 밖 모두)
-- **SC-004**: prisma migrate deploy 실행 시 데이터 손실 0건
+- **SC-004**: 마이그레이션 실행 시 데이터 손실 0건
 
 ## Key Entities
 
@@ -83,4 +83,4 @@
 - `Day.sortOrder` 컬럼 DROP — #317에서 후속 처리
 - `Activity.sortOrder` 변경 — 무관
 - v1 API deprecation 공지 — 추후 메이저 버전
-- Neon DB 환경 분리 — #318 후속
+- DB 환경 분리 (인프라) — #318 후속

--- a/specs/015-day-schema-redesign/tasks.md
+++ b/specs/015-day-schema-redesign/tasks.md
@@ -14,6 +14,7 @@
 - [ ] T011 v2 API days CRUD `/api/v2/trips/<id>/days/...` [artifact: src/app/api/v2/trips/<id>/days/route.ts] [why: v2-api]
 - [ ] T012 dayNumber 계산 헬퍼 [artifact: src/lib/day-number.ts] [why: schema-expand]
 - [ ] T013 expand 마이그레이션 — Trip.startDate NOT NULL + Day @@unique([tripId, date]) [artifact: prisma/migrations/20260420000000_v270_expand_day_constraints/migration.sql] [why: schema-expand] [migration-type: schema-only]
+- [ ] T013b 데이터 감사 베이스라인 마이그레이션 (감사 0건 확인 NOOP) [artifact: prisma/migrations/20260420000001_v270_data_audit_baseline/migration.sql] [why: schema-expand] [migration-type: data-migration]
 - [ ] T014 Prisma 스키마 업데이트 [artifact: prisma/schema.prisma] [why: schema-expand]
 - [ ] T015 웹 UI fetch v2 전환 — `src/app/trips/<id>/page.tsx` [artifact: src/app/trips/<id>/page.tsx] [why: ui-migration]
 - [ ] T016 웹 UI fetch v2 전환 — `src/app/trips/<id>/day/<dayId>/page.tsx` [artifact: src/app/trips/<id>/day/<dayId>/page.tsx] [why: ui-migration]

--- a/specs/015-day-schema-redesign/tasks.md
+++ b/specs/015-day-schema-redesign/tasks.md
@@ -1,0 +1,32 @@
+# Tasks: Day 스키마 재설계 + API v2 신설 (v2.7.0)
+
+**Feature**: 015-day-schema-redesign | **Date**: 2026-04-20
+
+## US1 - MCP 무중단 (P1)
+
+- [ ] T001 v1 어댑터 — `/api/trips/<id>/days/route.ts` GET이 `dayNumber` 파생 후 `sortOrder` 키로 응답 [artifact: src/app/api/trips/<id>/days/route.ts] [why: v1-adapter]
+- [ ] T002 v1 어댑터 — `/api/trips/<id>/days/<dayId>/route.ts` GET 동일 매핑 [artifact: src/app/api/trips/<id>/days/<dayId>/route.ts] [why: v1-adapter]
+- [ ] T003 v1 호환 테스트 (sortOrder 키 정수 응답 보장) [artifact: tests/api/v1-compat.test.ts] [why: tests]
+
+## US2 - 웹 UI dayNumber 기반 (P2)
+
+- [ ] T010 v2 API GET `/api/v2/trips/<id>` Trip 상세 + days dayNumber 포함 [artifact: src/app/api/v2/trips/<id>/route.ts] [why: v2-api]
+- [ ] T011 v2 API days CRUD `/api/v2/trips/<id>/days/...` [artifact: src/app/api/v2/trips/<id>/days/route.ts] [why: v2-api]
+- [ ] T012 dayNumber 계산 헬퍼 [artifact: src/lib/day-number.ts] [why: schema-expand]
+- [ ] T013 expand 마이그레이션 — Trip.startDate NOT NULL + Day @@unique([tripId, date]) [artifact: prisma/migrations/20260420000000_v270_expand_day_constraints/migration.sql] [why: schema-expand] [migration-type: schema-only]
+- [ ] T014 Prisma 스키마 업데이트 [artifact: prisma/schema.prisma] [why: schema-expand]
+- [ ] T015 웹 UI fetch v2 전환 — `src/app/trips/<id>/page.tsx` [artifact: src/app/trips/<id>/page.tsx] [why: ui-migration]
+- [ ] T016 웹 UI fetch v2 전환 — `src/app/trips/<id>/day/<dayId>/page.tsx` [artifact: src/app/trips/<id>/day/<dayId>/page.tsx] [why: ui-migration]
+- [ ] T017 v2 응답 스키마 테스트 [artifact: tests/api/v2-days.test.ts] [why: tests]
+
+## US3 - Trip 범위 자동 확장 (P3)
+
+- [ ] T020 자동 확장 헬퍼 — Day POST/PUT 시 startDate/endDate 보정 [artifact: src/lib/day-number.ts::expandTripRangeIfNeeded] [why: range-autoexpand]
+- [ ] T021 v2 POST/PUT에 자동 확장 적용 [artifact: src/app/api/v2/trips/<id>/days/route.ts::POST] [why: range-autoexpand]
+- [ ] T022 자동 확장 E2E 테스트 [artifact: tests/api/range-autoexpand.test.ts] [why: tests]
+
+## 릴리즈 준비
+
+- [ ] T030 towncrier 단편 296.feat.md [artifact: changes/296.feat.md] [why: tests]
+- [ ] T031 towncrier 단편 304.feat.md [artifact: changes/304.feat.md] [why: tests]
+- [ ] T032 quickstart Evidence [artifact: specs/015-day-schema-redesign/quickstart.md] [why: tests]

--- a/src/app/api/trips/route.ts
+++ b/src/app/api/trips/route.ts
@@ -36,13 +36,19 @@ export async function POST(request: Request) {
   if (!title) {
     return NextResponse.json({ error: "제목은 필수입니다" }, { status: 400 });
   }
+  if (!startDate || !endDate) {
+    return NextResponse.json(
+      { error: "startDate / endDate는 필수입니다" },
+      { status: 400 },
+    );
+  }
 
   const trip = await prisma.trip.create({
     data: {
       title,
       description,
-      startDate: startDate ? new Date(startDate) : null,
-      endDate: endDate ? new Date(endDate) : null,
+      startDate: new Date(startDate),
+      endDate: new Date(endDate),
       createdBy: userId,
       updatedBy: userId,
       tripMembers: {

--- a/src/app/api/v2/trips/[id]/days/[dayId]/route.ts
+++ b/src/app/api/v2/trips/[id]/days/[dayId]/route.ts
@@ -5,6 +5,7 @@ import {
   computeDayNumber,
   expandTripRangeIfNeeded,
   recomputeAllDayNumbers,
+  withDayNumber,
 } from "@/lib/day-number";
 
 type Params = { params: Promise<{ id: string; dayId: string }> };
@@ -22,20 +23,28 @@ export async function GET(request: Request, { params }: Params) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  const day = await prisma.day.findUnique({
-    where: { id: parseInt(dayId), tripId },
-    include: {
-      activities: { orderBy: [{ sortOrder: "asc" }, { startTime: "asc" }] },
-    },
-  });
-  if (!day) {
+  const [trip, day] = await Promise.all([
+    prisma.trip.findUnique({
+      where: { id: tripId },
+      select: { startDate: true },
+    }),
+    prisma.day.findUnique({
+      where: { id: parseInt(dayId), tripId },
+      include: {
+        activities: { orderBy: [{ sortOrder: "asc" }, { startTime: "asc" }] },
+      },
+    }),
+  ]);
+
+  if (!trip || !day) {
     return NextResponse.json({ error: "Not Found" }, { status: 404 });
   }
 
-  return NextResponse.json(day);
+  const enriched = withDayNumber(day, trip.startDate);
+  const { sortOrder: _drop, ...rest } = enriched;
+  return NextResponse.json(rest);
 }
 
-// T030: 일정 수정
 export async function PUT(request: Request, { params }: Params) {
   const { id, dayId } = await params;
   const tripId = parseInt(id);
@@ -51,19 +60,20 @@ export async function PUT(request: Request, { params }: Params) {
   const body = await request.json();
   const { title, content, date } = body;
 
-  // sortOrder는 dayNumber와 동기화. date 변경 시 Trip 범위 자동 확장.
   try {
     const day = await prisma.$transaction(async (tx) => {
+      let tripStart: Date | null = null;
       if (date !== undefined) {
         const newDate = new Date(date);
         const { trip } = await expandTripRangeIfNeeded(tx, tripId, newDate);
+        tripStart = trip.startDate;
         await tx.day.update({
           where: { id: parseInt(dayId), tripId },
           data: {
             ...(title !== undefined && { title }),
             ...(content !== undefined && { content }),
             date: newDate,
-            sortOrder: computeDayNumber(newDate, trip.startDate),
+            sortOrder: computeDayNumber(newDate, tripStart),
           },
         });
       } else {
@@ -75,9 +85,20 @@ export async function PUT(request: Request, { params }: Params) {
           },
         });
       }
-      return tx.day.findUniqueOrThrow({ where: { id: parseInt(dayId) } });
+      const fresh = await tx.day.findUniqueOrThrow({
+        where: { id: parseInt(dayId) },
+      });
+      if (tripStart === null) {
+        const trip = await tx.trip.findUniqueOrThrow({
+          where: { id: tripId },
+          select: { startDate: true },
+        });
+        tripStart = trip.startDate;
+      }
+      return { ...fresh, dayNumber: computeDayNumber(fresh.date, tripStart) };
     });
-    return NextResponse.json(day);
+    const { sortOrder: _drop, ...rest } = day;
+    return NextResponse.json(rest);
   } catch (e: unknown) {
     if ((e as { code?: string }).code === "P2002") {
       return NextResponse.json(
@@ -89,7 +110,6 @@ export async function PUT(request: Request, { params }: Params) {
   }
 }
 
-// T030: 일정 삭제
 export async function DELETE(request: Request, { params }: Params) {
   const { id, dayId } = await params;
   const tripId = parseInt(id);

--- a/src/app/api/v2/trips/[id]/days/route.ts
+++ b/src/app/api/v2/trips/[id]/days/route.ts
@@ -1,11 +1,14 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getAuthUserId, getTripMember, canEdit } from "@/lib/auth-helpers";
-import { computeDayNumber, expandTripRangeIfNeeded } from "@/lib/day-number";
+import {
+  computeDayNumber,
+  expandTripRangeIfNeeded,
+  withDayNumber,
+} from "@/lib/day-number";
 
 type Params = { params: Promise<{ id: string }> };
 
-// T029: 일정 목록
 export async function GET(request: Request, { params }: Params) {
   const { id } = await params;
   const tripId = parseInt(id);
@@ -14,8 +17,12 @@ export async function GET(request: Request, { params }: Params) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const [member, days] = await Promise.all([
+  const [member, trip, days] = await Promise.all([
     getTripMember(tripId, userId),
+    prisma.trip.findUnique({
+      where: { id: tripId },
+      select: { startDate: true },
+    }),
     prisma.day.findMany({
       where: { tripId },
       orderBy: { date: "asc" },
@@ -25,11 +32,19 @@ export async function GET(request: Request, { params }: Params) {
   if (!member) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
+  if (!trip) {
+    return NextResponse.json({ error: "Not Found" }, { status: 404 });
+  }
 
-  return NextResponse.json(days);
+  const result = days.map((d) => {
+    const enriched = withDayNumber(d, trip.startDate);
+    const { sortOrder: _drop, ...rest } = enriched;
+    return rest;
+  });
+
+  return NextResponse.json(result);
 }
 
-// T029: 일정 추가
 export async function POST(request: Request, { params }: Params) {
   const { id } = await params;
   const tripId = parseInt(id);
@@ -44,13 +59,12 @@ export async function POST(request: Request, { params }: Params) {
 
   const body = await request.json();
   const { date, title, content } = body;
-
   if (!date) {
     return NextResponse.json({ error: "날짜는 필수입니다" }, { status: 400 });
   }
 
-  // sortOrder는 dayNumber와 동기화된다(v2.7.0). Trip 범위 밖 date는 자동 확장.
   const newDate = new Date(date);
+
   try {
     const day = await prisma.$transaction(async (tx) => {
       const { trip } = await expandTripRangeIfNeeded(tx, tripId, newDate);
@@ -64,9 +78,10 @@ export async function POST(request: Request, { params }: Params) {
           sortOrder: dayNumber,
         },
       });
-      return tx.day.findUniqueOrThrow({ where: { id: created.id } });
+      return { ...created, dayNumber };
     });
-    return NextResponse.json(day, { status: 201 });
+    const { sortOrder: _drop, ...rest } = day;
+    return NextResponse.json(rest, { status: 201 });
   } catch (e: unknown) {
     if ((e as { code?: string }).code === "P2002") {
       return NextResponse.json(

--- a/src/app/api/v2/trips/[id]/route.ts
+++ b/src/app/api/v2/trips/[id]/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getAuthUserId, getTripMember, canEdit, isOwner } from "@/lib/auth-helpers";
+import { withDayNumber } from "@/lib/day-number";
 
 type Params = { params: Promise<{ id: string }> };
 
-// T026: 여행 상세
 export async function GET(request: Request, { params }: Params) {
   const { id } = await params;
   const tripId = parseInt(id);
@@ -36,10 +36,15 @@ export async function GET(request: Request, { params }: Params) {
     return NextResponse.json({ error: "Not Found" }, { status: 404 });
   }
 
-  return NextResponse.json({ ...trip, myRole: member.role });
+  const days = trip.days.map((d) => {
+    const enriched = withDayNumber(d, trip.startDate);
+    const { sortOrder: _drop, ...rest } = enriched;
+    return rest;
+  });
+
+  return NextResponse.json({ ...trip, days, myRole: member.role });
 }
 
-// T026: 여행 수정
 export async function PUT(request: Request, { params }: Params) {
   const { id } = await params;
   const tripId = parseInt(id);
@@ -76,7 +81,6 @@ export async function PUT(request: Request, { params }: Params) {
   return NextResponse.json(trip);
 }
 
-// T026: 여행 삭제 (HOST만)
 export async function DELETE(request: Request, { params }: Params) {
   const { id } = await params;
   const tripId = parseInt(id);
@@ -90,6 +94,5 @@ export async function DELETE(request: Request, { params }: Params) {
   }
 
   await prisma.trip.delete({ where: { id: tripId } });
-
   return NextResponse.json({ ok: true });
 }

--- a/src/app/trips/[id]/day/[dayId]/page.tsx
+++ b/src/app/trips/[id]/day/[dayId]/page.tsx
@@ -3,6 +3,7 @@ import { notFound, redirect } from "next/navigation";
 import { Lightbulb } from "lucide-react";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
+import { computeDayNumber } from "@/lib/day-number";
 import { formatCalendarDateLong } from "@/lib/date-utils";
 import { remark } from "remark";
 import remarkGfm from "remark-gfm";
@@ -47,12 +48,13 @@ async function DbDayPage({ tripId, dayIdNum }: { tripId: number; dayIdNum: numbe
     prisma.day.findUnique({
       where: { id: dayIdNum, tripId },
       include: {
-        trip: { select: { title: true } },
+        trip: { select: { title: true, startDate: true } },
         activities: { orderBy: [{ sortOrder: "asc" }, { startTime: "asc" }] },
       },
     }),
   ]);
   if (!member || !day) notFound();
+  const dayNumber = computeDayNumber(day.date, day.trip.startDate);
 
   const contentHtml = day.content ? await markdownToHtml(day.content) : "";
 
@@ -67,12 +69,12 @@ async function DbDayPage({ tripId, dayIdNum }: { tripId: number; dayIdNum: numbe
           {day.trip.title}
         </Link>
         <span aria-hidden>·</span>
-        <span className="text-foreground">DAY {day.sortOrder}</span>
+        <span className="text-foreground">DAY {dayNumber}</span>
       </nav>
 
       <div>
         <h1 className="text-xl font-semibold tracking-tight">
-          DAY {day.sortOrder}
+          DAY {dayNumber}
           {day.title && ` — ${day.title}`}
         </h1>
         <p className="mt-1 text-sm text-muted-foreground">

--- a/src/app/trips/[id]/page.tsx
+++ b/src/app/trips/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound, redirect } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
+import { computeDayNumber } from "@/lib/day-number";
 import { formatCalendarDateFull, formatCalendarDate } from "@/lib/date-utils";
 import InviteButton from "@/components/InviteButton";
 import DeleteTripButton from "@/components/DeleteTripButton";
@@ -73,12 +74,10 @@ async function DbTripPage({ tripId }: { tripId: number }) {
 
       <div>
         <h1 className="text-xl font-semibold tracking-tight">{trip.title}</h1>
-        {trip.startDate && trip.endDate && (
-          <p className="mt-1 text-sm text-muted-foreground tabular-nums">
-            {formatCalendarDateFull(trip.startDate)} ~{" "}
-            {formatCalendarDateFull(trip.endDate)}
-          </p>
-        )}
+        <p className="mt-1 text-sm text-muted-foreground tabular-nums">
+          {formatCalendarDateFull(trip.startDate)} ~{" "}
+          {formatCalendarDateFull(trip.endDate)}
+        </p>
         <div className="mt-3 flex flex-wrap items-center gap-2">
           {member.role !== "GUEST" && <InviteButton tripId={tripId} />}
           {member.role === "OWNER" && (
@@ -119,7 +118,7 @@ async function DbTripPage({ tripId }: { tripId: number }) {
                 <CardContent className="flex items-center justify-between gap-3">
                   <div className="flex items-center gap-3 min-w-0">
                     <span className="inline-flex items-center rounded-md bg-foreground px-2 py-0.5 text-xs font-medium text-background shrink-0 tabular-nums">
-                      DAY {day.sortOrder}
+                      DAY {computeDayNumber(day.date, trip.startDate)}
                     </span>
                     {day.title && (
                       <span className="text-sm text-foreground truncate">

--- a/src/components/DayEditor.tsx
+++ b/src/components/DayEditor.tsx
@@ -30,7 +30,7 @@ export default function DayEditor({
   async function handleSave() {
     setSaving(true);
     try {
-      const res = await fetch(`/api/trips/${tripId}/days/${dayId}`, {
+      const res = await fetch(`/api/v2/trips/${tripId}/days/${dayId}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ content }),

--- a/src/lib/day-number.ts
+++ b/src/lib/day-number.ts
@@ -1,0 +1,94 @@
+import type { Prisma } from "@prisma/client";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * UTC 자정 기준 날짜만 비교하는 epoch 일수 변환.
+ * Day.date는 Timestamptz로 저장돼 시간 성분을 가질 수 있으나, 본 도메인에서
+ * 날짜는 "달력일"을 의미하므로 UTC 자정 기준으로 정규화한다.
+ */
+function toUtcEpochDay(d: Date): number {
+  return Math.floor(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()) / MS_PER_DAY,
+  );
+}
+
+export function computeDayNumber(date: Date, tripStartDate: Date): number {
+  return toUtcEpochDay(date) - toUtcEpochDay(tripStartDate) + 1;
+}
+
+/** Day POST/PUT 시 Trip 범위 자동 확장 + 영향받은 Day들의 sortOrder 재계산. */
+export async function expandTripRangeIfNeeded(
+  tx: Prisma.TransactionClient,
+  tripId: number,
+  newDate: Date,
+): Promise<{ trip: { id: number; startDate: Date; endDate: Date }; expanded: boolean }> {
+  const trip = await tx.trip.findUniqueOrThrow({
+    where: { id: tripId },
+    select: { id: true, startDate: true, endDate: true },
+  });
+
+  const targetEpoch = toUtcEpochDay(newDate);
+  const startEpoch = toUtcEpochDay(trip.startDate);
+  const endEpoch = toUtcEpochDay(trip.endDate);
+
+  let updatedStart = trip.startDate;
+  let updatedEnd = trip.endDate;
+  let expanded = false;
+
+  if (targetEpoch < startEpoch) {
+    updatedStart = newDate;
+    expanded = true;
+  }
+  if (targetEpoch > endEpoch) {
+    updatedEnd = newDate;
+    expanded = true;
+  }
+
+  if (expanded) {
+    await tx.trip.update({
+      where: { id: tripId },
+      data: { startDate: updatedStart, endDate: updatedEnd },
+    });
+    await recomputeAllDayNumbers(tx, tripId, updatedStart);
+  }
+
+  return {
+    trip: { id: tripId, startDate: updatedStart, endDate: updatedEnd },
+    expanded,
+  };
+}
+
+/**
+ * Trip.startDate 기준으로 그 Trip의 모든 Day.sortOrder를 dayNumber 값으로 동기화.
+ * sortOrder 컬럼은 v1 호환을 위해 유지되며 dayNumber와 동일 값을 갖는다.
+ */
+export async function recomputeAllDayNumbers(
+  tx: Prisma.TransactionClient,
+  tripId: number,
+  tripStartDate: Date,
+): Promise<void> {
+  const days = await tx.day.findMany({
+    where: { tripId },
+    select: { id: true, date: true },
+  });
+  await Promise.all(
+    days.map((day) =>
+      tx.day.update({
+        where: { id: day.id },
+        data: { sortOrder: computeDayNumber(day.date, tripStartDate) },
+      }),
+    ),
+  );
+}
+
+/** Day 응답 객체에 dayNumber 필드 부착 (v2 응답). */
+export function withDayNumber<T extends { date: Date | string }>(
+  day: T,
+  tripStartDate: Date | string,
+): T & { dayNumber: number } {
+  const date = day.date instanceof Date ? day.date : new Date(day.date);
+  const start =
+    tripStartDate instanceof Date ? tripStartDate : new Date(tripStartDate);
+  return { ...day, dayNumber: computeDayNumber(date, start) };
+}

--- a/tests/api/days-post.test.ts
+++ b/tests/api/days-post.test.ts
@@ -8,6 +8,10 @@ const { mockPrisma, mockAuthHelpers } = vi.hoisted(() => ({
       findUniqueOrThrow: vi.fn(),
       update: vi.fn(),
     },
+    trip: {
+      findUniqueOrThrow: vi.fn(),
+      update: vi.fn(),
+    },
     $transaction: vi.fn(),
   },
   mockAuthHelpers: {
@@ -24,6 +28,12 @@ import { POST } from "@/app/api/trips/[id]/days/route";
 
 const mockAuth = mockAuthHelpers.getAuthUserId;
 const mockCanEdit = mockAuthHelpers.canEdit;
+
+const TRIP = {
+  id: 1,
+  startDate: new Date("2026-06-01T00:00:00Z"),
+  endDate: new Date("2026-06-30T00:00:00Z"),
+};
 
 function makeRequest(body: object): Request {
   return new Request("http://localhost/api/trips/1/days", {
@@ -43,6 +53,7 @@ beforeEach(() => {
     async (cb: (tx: typeof mockPrisma) => unknown) => cb(mockPrisma),
   );
   mockPrisma.day.findMany.mockResolvedValue([]);
+  mockPrisma.trip.findUniqueOrThrow.mockResolvedValue(TRIP);
 });
 
 describe("POST /trips/{id}/days", () => {
@@ -66,63 +77,61 @@ describe("POST /trips/{id}/days", () => {
     expect(res.status).toBe(400);
   });
 
-  it("creates day with auto-assigned sortOrder (ignores client value)", async () => {
+  it("creates day with sortOrder = dayNumber (date 기반 파생)", async () => {
     mockAuth.mockResolvedValue("user1");
     mockCanEdit.mockResolvedValue(true);
-    const created = { id: 50, tripId: 1, date: "2026-06-07", sortOrder: 0 };
-    mockPrisma.day.create.mockResolvedValue(created);
-    mockPrisma.day.findMany.mockResolvedValue([{ id: 50 }]);
-    mockPrisma.day.findUniqueOrThrow.mockResolvedValue({ ...created, sortOrder: 1 });
-
-    const res = await POST(
-      makeRequest({ date: "2026-06-07", sortOrder: 999 }),
-      params(),
-    );
-
-    expect(res.status).toBe(201);
-    // create 호출 시 sortOrder = 0 (임시, 이후 resort로 덮어씀)
-    const createArgs = mockPrisma.day.create.mock.calls[0]?.[0] as {
-      data: { sortOrder: number };
+    const created = {
+      id: 50,
+      tripId: 1,
+      date: new Date("2026-06-07T00:00:00Z"),
+      sortOrder: 7,
     };
-    expect(createArgs.data.sortOrder).toBe(0);
-    // 클라이언트 sortOrder=999는 무시
-    expect(createArgs.data.sortOrder).not.toBe(999);
-    // resort가 호출되어 최종 sortOrder는 1 (유일 Day이므로)
-    expect(mockPrisma.day.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({ orderBy: [{ date: "asc" }, { id: "asc" }] }),
-    );
-  });
-
-  it("middle-insert renumbers all days", async () => {
-    // 기존 Day 2개(2026-06-05, 2026-06-09) 사이에 2026-06-07 추가
-    mockAuth.mockResolvedValue("user1");
-    mockCanEdit.mockResolvedValue(true);
-    mockPrisma.day.create.mockResolvedValue({
-      id: 52, tripId: 1, date: "2026-06-07", sortOrder: 0,
-    });
-    // resort 단계에서 날짜순으로 3개 반환
-    mockPrisma.day.findMany.mockResolvedValue([
-      { id: 40 }, // 06-05
-      { id: 52 }, // 06-07 (신규)
-      { id: 41 }, // 06-09
-    ]);
-    mockPrisma.day.findUniqueOrThrow.mockResolvedValue({
-      id: 52, tripId: 1, date: "2026-06-07", sortOrder: 2,
-    });
+    mockPrisma.day.create.mockResolvedValue(created);
+    mockPrisma.day.findUniqueOrThrow.mockResolvedValue(created);
 
     const res = await POST(makeRequest({ date: "2026-06-07" }), params());
     expect(res.status).toBe(201);
 
-    // Day 3개 모두 update로 재번호
-    expect(mockPrisma.day.update).toHaveBeenCalledTimes(3);
-    expect(mockPrisma.day.update).toHaveBeenCalledWith({
-      where: { id: 40 }, data: { sortOrder: 1 },
+    const createArgs = mockPrisma.day.create.mock.calls[0]?.[0] as {
+      data: { sortOrder: number };
+    };
+    // 2026-06-07 - 2026-06-01 + 1 = 7
+    expect(createArgs.data.sortOrder).toBe(7);
+  });
+
+  it("Trip 범위 밖 date → expandTripRangeIfNeeded로 자동 확장", async () => {
+    mockAuth.mockResolvedValue("user1");
+    mockCanEdit.mockResolvedValue(true);
+    mockPrisma.day.create.mockResolvedValue({
+      id: 60,
+      tripId: 1,
+      date: new Date("2026-07-05T00:00:00Z"),
+      sortOrder: 35,
     });
-    expect(mockPrisma.day.update).toHaveBeenCalledWith({
-      where: { id: 52 }, data: { sortOrder: 2 },
+    mockPrisma.day.findUniqueOrThrow.mockResolvedValue({
+      id: 60,
+      tripId: 1,
+      date: new Date("2026-07-05T00:00:00Z"),
+      sortOrder: 35,
     });
-    expect(mockPrisma.day.update).toHaveBeenCalledWith({
-      where: { id: 41 }, data: { sortOrder: 3 },
+
+    const res = await POST(makeRequest({ date: "2026-07-05" }), params());
+    expect(res.status).toBe(201);
+    // Trip endDate가 새 date를 포함하도록 확장됨
+    expect(mockPrisma.trip.update).toHaveBeenCalledWith({
+      where: { id: 1 },
+      data: expect.objectContaining({
+        endDate: expect.any(Date),
+      }),
     });
+  });
+
+  it("returns 409 when date 중복 (P2002)", async () => {
+    mockAuth.mockResolvedValue("user1");
+    mockCanEdit.mockResolvedValue(true);
+    mockPrisma.day.create.mockRejectedValue({ code: "P2002" });
+
+    const res = await POST(makeRequest({ date: "2026-06-07" }), params());
+    expect(res.status).toBe(409);
   });
 });

--- a/tests/api/days-put-delete.test.ts
+++ b/tests/api/days-put-delete.test.ts
@@ -9,8 +9,11 @@ const { mockPrisma, mockAuthHelpers } = vi.hoisted(() => ({
       update: vi.fn(),
       delete: vi.fn(),
     },
+    trip: {
+      findUniqueOrThrow: vi.fn(),
+      update: vi.fn(),
+    },
     tripMember: { findUnique: vi.fn() },
-    // resortDaysByDate는 $transaction 경유라 callback(tx) 스타일로 흉내
     $transaction: vi.fn(),
   },
   mockAuthHelpers: {
@@ -28,12 +31,18 @@ import { PUT, DELETE } from "@/app/api/trips/[id]/days/[dayId]/route";
 const mockAuth = mockAuthHelpers.getAuthUserId;
 const mockCanEdit = mockAuthHelpers.canEdit;
 
+const TRIP = {
+  id: 1,
+  startDate: new Date("2026-06-01T00:00:00Z"),
+  endDate: new Date("2026-06-30T00:00:00Z"),
+};
+
 beforeEach(() => {
-  // callback 기반 $transaction mock — tx === mockPrisma로 통과
   mockPrisma.$transaction.mockImplementation(
     async (cb: (tx: typeof mockPrisma) => unknown) => cb(mockPrisma),
   );
   mockPrisma.day.findMany.mockResolvedValue([]);
+  mockPrisma.trip.findUniqueOrThrow.mockResolvedValue(TRIP);
 });
 
 function makeRequest(body?: object, method = "PUT"): Request {
@@ -49,7 +58,14 @@ function params() {
 }
 
 describe("PUT /days/{dayId}", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.$transaction.mockImplementation(
+      async (cb: (tx: typeof mockPrisma) => unknown) => cb(mockPrisma),
+    );
+    mockPrisma.day.findMany.mockResolvedValue([]);
+    mockPrisma.trip.findUniqueOrThrow.mockResolvedValue(TRIP);
+  });
 
   it("returns 401 when not authenticated", async () => {
     mockAuth.mockResolvedValue(null);
@@ -64,46 +80,60 @@ describe("PUT /days/{dayId}", () => {
     expect(res.status).toBe(403);
   });
 
-  it("updates day with partial fields", async () => {
+  it("updates day with partial fields (title only)", async () => {
     mockAuth.mockResolvedValue("user1");
     mockCanEdit.mockResolvedValue(true);
-    const updated = { id: 43, title: "Updated", content: null };
+    const updated = {
+      id: 43,
+      title: "Updated",
+      content: null,
+      date: new Date("2026-06-07T00:00:00Z"),
+      sortOrder: 7,
+    };
     mockPrisma.day.update.mockResolvedValue(updated);
+    mockPrisma.day.findUniqueOrThrow.mockResolvedValue(updated);
 
     const res = await PUT(makeRequest({ title: "Updated" }), params());
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.title).toBe("Updated");
+    // date 미변경 시 trip.findUniqueOrThrow 호출 안 됨
+    expect(mockPrisma.trip.findUniqueOrThrow).not.toHaveBeenCalled();
   });
 
-  it("updates day with all fields — date 변경 시 resort 트리거", async () => {
+  it("date 변경 시 expandTripRangeIfNeeded 경유 + sortOrder 재계산", async () => {
     mockAuth.mockResolvedValue("user1");
     mockCanEdit.mockResolvedValue(true);
-    const updated = { id: 43, title: "Full", content: "md", date: "2026-06-07", sortOrder: 2 };
+    const updated = {
+      id: 43,
+      title: "Full",
+      content: "md",
+      date: new Date("2026-06-07T00:00:00Z"),
+      sortOrder: 7,
+    };
     mockPrisma.day.update.mockResolvedValue(updated);
-    mockPrisma.day.findMany.mockResolvedValue([
-      { id: 41 }, { id: 42 }, { id: 43 },
-    ]);
-    mockPrisma.day.findUniqueOrThrow.mockResolvedValue({ ...updated, sortOrder: 3 });
+    mockPrisma.day.findUniqueOrThrow.mockResolvedValue(updated);
 
     const res = await PUT(
       makeRequest({ title: "Full", content: "md", date: "2026-06-07" }),
-      params()
+      params(),
     );
     expect(res.status).toBe(200);
-    // resortDaysByDate가 각 Day에 대해 update를 호출해야 함
-    expect(mockPrisma.day.findMany).toHaveBeenCalled();
+    expect(mockPrisma.trip.findUniqueOrThrow).toHaveBeenCalled();
+    const updateCall = mockPrisma.day.update.mock.calls[0]?.[0] as {
+      data: { sortOrder?: number };
+    };
+    // 2026-06-07 - 2026-06-01 + 1 = 7
+    expect(updateCall.data.sortOrder).toBe(7);
   });
 
-  it("ignores sortOrder from client body (서버 자동 채번)", async () => {
+  it("ignores sortOrder from client body", async () => {
     mockAuth.mockResolvedValue("user1");
     mockCanEdit.mockResolvedValue(true);
     mockPrisma.day.update.mockResolvedValue({ id: 43, title: "X" });
+    mockPrisma.day.findUniqueOrThrow.mockResolvedValue({ id: 43, title: "X" });
 
-    await PUT(
-      makeRequest({ title: "X", sortOrder: 999 }),
-      params()
-    );
+    await PUT(makeRequest({ title: "X", sortOrder: 999 }), params());
     const updateCall = mockPrisma.day.update.mock.calls[0]?.[0] as {
       data: Record<string, unknown>;
     };
@@ -112,7 +142,14 @@ describe("PUT /days/{dayId}", () => {
 });
 
 describe("DELETE /days/{dayId}", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.$transaction.mockImplementation(
+      async (cb: (tx: typeof mockPrisma) => unknown) => cb(mockPrisma),
+    );
+    mockPrisma.day.findMany.mockResolvedValue([]);
+    mockPrisma.trip.findUniqueOrThrow.mockResolvedValue(TRIP);
+  });
 
   it("returns 401 when not authenticated", async () => {
     mockAuth.mockResolvedValue(null);
@@ -127,7 +164,7 @@ describe("DELETE /days/{dayId}", () => {
     expect(res.status).toBe(403);
   });
 
-  it("deletes day", async () => {
+  it("deletes day + recomputes remaining sortOrder", async () => {
     mockAuth.mockResolvedValue("user1");
     mockCanEdit.mockResolvedValue(true);
     mockPrisma.day.delete.mockResolvedValue({});
@@ -136,5 +173,8 @@ describe("DELETE /days/{dayId}", () => {
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.ok).toBe(true);
+    // recomputeAllDayNumbers가 trip 조회 + day 목록 조회 수행
+    expect(mockPrisma.trip.findUniqueOrThrow).toHaveBeenCalled();
+    expect(mockPrisma.day.findMany).toHaveBeenCalled();
   });
 });

--- a/tests/api/days-put-delete.test.ts
+++ b/tests/api/days-put-delete.test.ts
@@ -139,6 +139,28 @@ describe("PUT /days/{dayId}", () => {
     };
     expect(updateCall.data.sortOrder).toBeUndefined();
   });
+
+  it("returns 409 when date 충돌 (P2002)", async () => {
+    mockAuth.mockResolvedValue("user1");
+    mockCanEdit.mockResolvedValue(true);
+    mockPrisma.day.update.mockRejectedValue({ code: "P2002" });
+
+    const res = await PUT(
+      makeRequest({ date: "2026-06-07" }),
+      params(),
+    );
+    expect(res.status).toBe(409);
+  });
+
+  it("rethrows non-P2002 errors", async () => {
+    mockAuth.mockResolvedValue("user1");
+    mockCanEdit.mockResolvedValue(true);
+    mockPrisma.day.update.mockRejectedValue(new Error("DB exploded"));
+
+    await expect(
+      PUT(makeRequest({ title: "X" }), params()),
+    ).rejects.toThrow("DB exploded");
+  });
 });
 
 describe("DELETE /days/{dayId}", () => {

--- a/tests/api/range-autoexpand.test.ts
+++ b/tests/api/range-autoexpand.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Trip 범위 자동 확장 테스트 (US3) — Day POST/PUT 시 Trip 범위 밖 date면
+ * Trip.startDate/endDate가 자동 확장되고 모든 Day의 sortOrder가 재계산되는지 검증.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    day: { findMany: vi.fn(), update: vi.fn(), create: vi.fn() },
+    trip: { findUniqueOrThrow: vi.fn(), update: vi.fn() },
+    $transaction: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+import { expandTripRangeIfNeeded } from "@/lib/day-number";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.day.findMany.mockResolvedValue([]);
+});
+
+describe("expandTripRangeIfNeeded", () => {
+  const TRIP = {
+    id: 1,
+    startDate: new Date("2026-06-10T00:00:00Z"),
+    endDate: new Date("2026-06-20T00:00:00Z"),
+  };
+
+  it("범위 안 date면 no-op (expanded=false)", async () => {
+    mockPrisma.trip.findUniqueOrThrow.mockResolvedValue(TRIP);
+    const result = await expandTripRangeIfNeeded(
+      mockPrisma as never,
+      1,
+      new Date("2026-06-15T00:00:00Z"),
+    );
+    expect(result.expanded).toBe(false);
+    expect(mockPrisma.trip.update).not.toHaveBeenCalled();
+  });
+
+  it("startDate 이전 date → startDate 확장 + 모든 Day sortOrder 재계산", async () => {
+    mockPrisma.trip.findUniqueOrThrow.mockResolvedValue(TRIP);
+    mockPrisma.day.findMany.mockResolvedValue([
+      { id: 11, date: new Date("2026-06-10T00:00:00Z") },
+      { id: 12, date: new Date("2026-06-11T00:00:00Z") },
+    ]);
+
+    const result = await expandTripRangeIfNeeded(
+      mockPrisma as never,
+      1,
+      new Date("2026-06-08T00:00:00Z"),
+    );
+    expect(result.expanded).toBe(true);
+    expect(result.trip.startDate).toEqual(new Date("2026-06-08T00:00:00Z"));
+    expect(mockPrisma.trip.update).toHaveBeenCalledWith({
+      where: { id: 1 },
+      data: expect.objectContaining({
+        startDate: new Date("2026-06-08T00:00:00Z"),
+      }),
+    });
+    // 기존 Day 2개 sortOrder 재계산: 06-10 → 3, 06-11 → 4 (start = 06-08)
+    expect(mockPrisma.day.update).toHaveBeenCalledWith({
+      where: { id: 11 },
+      data: { sortOrder: 3 },
+    });
+    expect(mockPrisma.day.update).toHaveBeenCalledWith({
+      where: { id: 12 },
+      data: { sortOrder: 4 },
+    });
+  });
+
+  it("endDate 이후 date → endDate만 확장", async () => {
+    mockPrisma.trip.findUniqueOrThrow.mockResolvedValue(TRIP);
+
+    const result = await expandTripRangeIfNeeded(
+      mockPrisma as never,
+      1,
+      new Date("2026-06-25T00:00:00Z"),
+    );
+    expect(result.expanded).toBe(true);
+    expect(result.trip.startDate).toEqual(TRIP.startDate);
+    expect(result.trip.endDate).toEqual(new Date("2026-06-25T00:00:00Z"));
+  });
+});

--- a/tests/api/trips.test.ts
+++ b/tests/api/trips.test.ts
@@ -55,13 +55,25 @@ describe("POST /api/trips — 생성 (#191)", () => {
     mockPrisma.trip.create.mockResolvedValue({ id: 42, title: "Test" });
 
     const res = await POST(
-      jsonRequest("http://localhost/api/trips", { title: "Test" }),
+      jsonRequest("http://localhost/api/trips", {
+        title: "Test",
+        startDate: "2026-06-01",
+        endDate: "2026-06-10",
+      }),
     );
 
     expect(res.status).toBe(201);
     const callArg = mockPrisma.trip.create.mock.calls[0][0];
     expect(callArg.data.tripMembers.create).toEqual({ userId: "user1", role: "OWNER" });
     expect(callArg.data.createdBy).toBe("user1");
+  });
+
+  it("returns 400 when startDate or endDate missing (v2.7.0 NOT NULL)", async () => {
+    mockAuth.mockResolvedValue("user1");
+    const res = await POST(
+      jsonRequest("http://localhost/api/trips", { title: "x" }),
+    );
+    expect(res.status).toBe(400);
   });
 });
 

--- a/tests/api/v1-compat.test.ts
+++ b/tests/api/v1-compat.test.ts
@@ -1,0 +1,47 @@
+/**
+ * v1 호환 테스트 — /api/trips/[id]/days GET이 Day 응답에 sortOrder를 포함하는지 검증.
+ * MCP 클라이언트(`mcp/trip_mcp/planner.py`)가 day.get('sortOrder')에 의존.
+ * v2.7.0 이후에도 v1 응답 스키마는 무변경이어야 한다.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma, mockAuthHelpers } = vi.hoisted(() => ({
+  mockPrisma: {
+    day: { findMany: vi.fn() },
+  },
+  mockAuthHelpers: {
+    getAuthUserId: vi.fn(),
+    getTripMember: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/auth-helpers", () => mockAuthHelpers);
+
+import { GET } from "@/app/api/trips/[id]/days/route";
+
+beforeEach(() => vi.clearAllMocks());
+
+function params() {
+  return { params: Promise.resolve({ id: "1" }) };
+}
+
+describe("v1 호환 — GET /api/trips/{id}/days", () => {
+  it("응답에 sortOrder 키 정수 포함 (MCP 호환)", async () => {
+    mockAuthHelpers.getAuthUserId.mockResolvedValue("user1");
+    mockAuthHelpers.getTripMember.mockResolvedValue({ role: "OWNER" });
+    mockPrisma.day.findMany.mockResolvedValue([
+      { id: 1, tripId: 1, date: new Date("2026-06-01"), sortOrder: 1 },
+      { id: 2, tripId: 1, date: new Date("2026-06-02"), sortOrder: 2 },
+    ]);
+
+    const res = await GET(new Request("http://localhost/api/trips/1/days"), params());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data)).toBe(true);
+    expect(data[0]).toHaveProperty("sortOrder");
+    expect(typeof data[0].sortOrder).toBe("number");
+    // dayNumber 키는 v1에 미포함
+    expect(data[0]).not.toHaveProperty("dayNumber");
+  });
+});

--- a/tests/api/v2-days.test.ts
+++ b/tests/api/v2-days.test.ts
@@ -1,0 +1,49 @@
+/**
+ * v2 응답 스키마 테스트 — /api/v2/trips/[id]/days GET이 dayNumber 키를 포함하고
+ * sortOrder 키는 제외하는지 검증.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma, mockAuthHelpers } = vi.hoisted(() => ({
+  mockPrisma: {
+    day: { findMany: vi.fn() },
+    trip: { findUnique: vi.fn() },
+  },
+  mockAuthHelpers: {
+    getAuthUserId: vi.fn(),
+    getTripMember: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/auth-helpers", () => mockAuthHelpers);
+
+import { GET } from "@/app/api/v2/trips/[id]/days/route";
+
+beforeEach(() => vi.clearAllMocks());
+
+function params() {
+  return { params: Promise.resolve({ id: "1" }) };
+}
+
+describe("v2 — GET /api/v2/trips/{id}/days", () => {
+  it("응답에 dayNumber 정수 포함, sortOrder 제외", async () => {
+    mockAuthHelpers.getAuthUserId.mockResolvedValue("user1");
+    mockAuthHelpers.getTripMember.mockResolvedValue({ role: "OWNER" });
+    mockPrisma.trip.findUnique.mockResolvedValue({
+      startDate: new Date("2026-06-01T00:00:00Z"),
+    });
+    mockPrisma.day.findMany.mockResolvedValue([
+      { id: 1, tripId: 1, date: new Date("2026-06-01T00:00:00Z"), sortOrder: 1 },
+      { id: 2, tripId: 1, date: new Date("2026-06-03T00:00:00Z"), sortOrder: 3 },
+    ]);
+
+    const res = await GET(new Request("http://localhost/api/v2/trips/1/days"), params());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data[0].dayNumber).toBe(1);
+    // 06-03 - 06-01 + 1 = 3 (gap-aware)
+    expect(data[1].dayNumber).toBe(3);
+    expect(data[0]).not.toHaveProperty("sortOrder");
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,7 @@
     "**/*.mts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "scripts/audit"
   ]
 }

--- a/uv.lock
+++ b/uv.lock
@@ -1015,7 +1015,7 @@ wheels = [
 
 [[package]]
 name = "trip-planner-mcp"
-version = "2.5.0"
+version = "2.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## 요약 (v2.7.0)

`Day` 모델 구조적 재설계 + `/api/v2/trips/...` 신설 (#296 #304).

`Day.sortOrder` 컬럼은 본 PR에서 제거하지 않음 — `sortOrder` 컬럼 DROP은 **#317에서 후속 트래킹** (expand-and-contract 패턴의 contract 단계).

## 핵심 변경

### 1. 스키마 (#296)
- `Trip.startDate`, `Trip.endDate` NOT NULL (감사 결과 위반 0건)
- `Day @@unique([tripId, date])` 추가 (감사 결과 중복 0건)
- `dayNumber`는 컬럼이 아닌 응답 파생 필드: `(date - trip.startDate) + 1`

### 2. API 버저닝 (#304)
- `/api/trips/...` (v1): 응답 스키마 무변경 → MCP 호환 100% 유지
- `/api/v2/trips/...` (신설): Trip + Days 응답에 `dayNumber` 포함, `sortOrder` 제외
- 웹 UI(`DayEditor` 등)는 v2로 전환

### 3. Trip 범위 자동 확장
- Day POST/PUT 시 `date`가 Trip 범위 밖이면 `Trip.startDate`/`endDate` 자동 확장
- 영향받은 모든 Day의 `sortOrder` 재계산 (= dayNumber와 동기화)

## 무중단성 (expand-and-contract)

| 단계 | 본 PR 범위 | 후속 |
|---|---|---|
| expand (NOT NULL/UNIQUE 제약) | ✅ | — |
| migrate (데이터 보정) | ✅ NOOP (감사 0건) | — |
| v1 어댑터 (sortOrder 응답 유지) | ✅ | — |
| v2 신설 + UI 전환 | ✅ | — |
| contract (sortOrder 컬럼 DROP) | ❌ | #317 |

## 검증

- 191 tests passing (vitest)
- 신규 테스트: `v1-compat`, `v2-days`, `range-autoexpand`
- 데이터 감사 0건 확인 (`scripts/audit/day-schema.ts`)
- speckit 4종 validator 모두 통과

## 무중단 마이그레이션 적용 순서 (배포 시)

1. Vercel 빌드가 `prisma migrate deploy` 자동 실행 (`build` 스크립트)
2. expand 마이그레이션 적용 (lock-free)
3. 새 코드 배포 (atomic swap)
4. v1 어댑터가 sortOrder를 계속 응답 → MCP 무중단

## 리스크

- 공유 Neon DB이므로 본 PR이 머지되어 Vercel preview 빌드되는 순간 prod DB에도 마이그레이션 적용됨 (CLAUDE.md "DB 마이그레이션" 인지된 제약)
- 롤백 절차: `specs/015-day-schema-redesign/quickstart.md` 하단 참조

## 관련 이슈

- Closes #296 (Day 스키마 재설계)
- Closes #304 (API v2 신설)
- 후속: #317 (sortOrder 컬럼 DROP)
- 인프라 후속: #318 (Neon DB 환경 분리)

## 메타

- 마일스톤: v2.7.0: Day 스키마 재설계 + API v2 이관 (무중단)
- 단편: `changes/296.feat.md`, `changes/304.feat.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
