### PR TITLE
fix(#328): DB 분리 이후 stale JWT 세션 무효화 가드

### DIFF
--- a/changes/328.fix.md
+++ b/changes/328.fix.md
@@ -1,0 +1,1 @@
+**#318 DB 분리 이후 stale JWT 세션으로 인한 여행 생성 실패 수정**: `neondb` / `neondb_dev` 분리 이전에 발급된 쿠키를 가진 사용자는 새 DB에 존재하지 않는 `user.id`를 세션에 담고 있어 `POST /api/trips`에서 `Trip.createdBy` FK 위반(Prisma P2003)으로 실패했다. Auth.js `jwt` 콜백에서 토큰 userId의 DB 실존을 검증하고 없으면 세션을 무효화하여 자동 재로그인 흐름으로 유도한다. 향후 DB 이관·초기화 상황에서도 재발하지 않는 구조적 가드.

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -7,8 +7,17 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   adapter: PrismaAdapter(prisma),
   session: { strategy: "jwt" },
   callbacks: {
-    jwt({ token, user }) {
+    async jwt({ token, user }) {
       if (user?.id) token.id = user.id;
+      // DB 분리·이관·데이터 초기화 등으로 쿠키의 userId가 현재 DB에 존재하지 않을 수
+      // 있다(#328). 쿠키가 stale이면 세션을 무효화하여 재로그인으로 흐르게 한다.
+      if (token.id) {
+        const exists = await prisma.user.findUnique({
+          where: { id: token.id as string },
+          select: { id: true },
+        });
+        if (!exists) return null;
+      }
       return token;
     },
     session({ session, token }) {


### PR DESCRIPTION
## Summary

- `dev.trip.idean.me`에서 "여행 생성 실패" 회귀의 구조적 해결.
- 원인: #318(v2.7.2)의 `neondb`/`neondb_dev` 분리 이후, 이전 쿠키의 `user.id`가 새 DB에 존재하지 않아 `Trip.createdBy` FK 위반(Prisma P2003).
- 해결: `src/auth.ts` jwt 콜백에서 token.id의 DB 실존 여부를 확인하고 없으면 `null` 반환 → 세션 무효 → 로그인 화면 → 재로그인 → 정상화.

## 런타임 로그 (재현)

```
λ POST /api/trips
Error [PrismaClientKnownRequestError]: Invalid `prisma.trip.create()` invocation:
Foreign key constraint violated on the constraint: `trips_created_by_fkey`
code: 'P2003'
```

## 영향

- **Dev**: 사용자가 첫 요청에서 자동으로 재로그인 화면으로 유도되어 복구. 쿠키 지우거나 특별 조치 불필요.
- **Prod**: 매 세션 검증 시 `User.findUnique(pk)` 1회 추가. pk 조회이므로 실성능 영향 무시 가능.
- **향후**: DB 이관·초기화·테스트 환경 스위치 시 stale 쿠키 상황이 재발하지 않도록 **구조적으로** 방어.

## Test plan

- [x] `tsc --noEmit` 통과
- [x] `vitest run` 223/223 통과 (회귀 없음)
- [x] 수동: develop 머지 후 dev.trip.idean.me에서 기존 세션으로 여행 생성 시도 → 자동 재로그인 → 여행 생성 성공
- [x] GCal 연동(#305) E2E 검증 가능해짐

Closes #328