### PR TITLE
fix(#332): Google(OIDC) provider scope 동기화 누락 수정

### DIFF
--- a/changes/332-oidc.fix.md
+++ b/changes/332-oidc.fix.md
@@ -1,0 +1,1 @@
+**#332 scope 동기화가 Google(OIDC)에 적용되지 않던 버그 수정**: Auth.js v5에서 Google provider는 `account.type === "oidc"`로 분류되지만 이전 구현이 `type !== "oauth"` 이면 early return하여 **Google 재동의 시 scope 동기화가 한 번도 실행되지 않았음**. 결과적으로 DB의 `Account.scope`가 갱신되지 않아 #305 GCal consent 루프가 재발했다. `oauth` / `oidc` 둘 다 허용하도록 조건을 교정.

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -29,10 +29,16 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
      * PrismaAdapter는 기존 Account가 있으면 linkAccount를 호출하지 않아 재로그인
      * 시 새로 받은 access_token/refresh_token/scope/expires_at이 DB에 반영되지
      * 않는다. 이 콜백에서 직접 upsert하여 scope 증분 동의가 항상 반영되게 한다.
+     *
+     * Auth.js v5에서 Google은 `account.type === "oidc"`로 분류된다. 이전 구현이
+     * `type !== "oauth"` 이면 early return 했기 때문에 Google의 경우 실제로
+     * scope 동기화가 한 번도 실행되지 않아 consent 루프가 재발했다(#332b).
+     * provider 식별자만으로 게이트한다.
      */
     async signIn({ user, account }) {
-      if (!account || account.type !== "oauth") return true;
+      if (!account?.provider || !account.providerAccountId) return true;
       if (!user?.id) return true;
+      if (account.type !== "oauth" && account.type !== "oidc") return true;
       try {
         await prisma.account.updateMany({
           where: {


### PR DESCRIPTION
## Summary

#332(PR #333) 수정이 **Google에 적용되지 않는** 조건 버그를 가지고 있어 GCal consent 루프가 해소되지 않음. 런타임 로그로 확인:

\`\`\`
00:50:37  GET /api/auth/callback/google  ← OAuth 성공
00:50:38  POST /api/trips/3/gcal/link    ← 여전히 scope 없음 판단
00:50:39  GET /api/gcal/consent          ← 또 Google로 리디렉트 (루프)
\`\`\`

## 원인

Auth.js v5에서 Google provider의 \`account.type\`은 **\`"oidc\"\`**. 이전 코드가 \`type !== "oauth"\` 이면 early return 했기 때문에 Google 재동의 시 Account 동기화 블록이 **한 번도 실행되지 않았음**. 결과적으로 DB의 \`Account.scope\`가 옛 값 유지.

## 수정

\`src/auth.ts\` \`callbacks.signIn\`의 가드를 \`type !== "oauth" && type !== "oidc"\`로 교정. provider 타입과 무관하게 필요한 account 필드를 DB에 upsert.

## Test plan

- [x] \`tsc --noEmit\` 통과
- [x] \`vitest\` 225/225 통과
- [ ] dev 머지 후 수동: 로그아웃 → 재로그인 → "구글 캘린더에 올리기" → **루프 없이** 이벤트 생성 확인
- [ ] 런타임 로그에서 callback 성공 후 POST /gcal/link가 200으로 돌아오는지 확인

Closes #332