### PR TITLE
fix(#341): Activity 저장 시 IANA 타임존 자동 주입 (KST 약어 복구)

### DIFF
--- a/changes/341.fix.md
+++ b/changes/341.fix.md
@@ -1,0 +1,1 @@
+**Activity 저장 시 브라우저 IANA 타임존 자동 주입 (#341)**: `ActivityList`의 handleCreate/handleUpdate가 body에 `startTimezone`/`endTimezone`을 포함하지 않아 DB에 항상 null로 저장되어 `ActivityCard`가 KST 등 타임존 약어를 표시할 수 없었다(#325 표시 포맷 개선의 사각지대). `Intl.DateTimeFormat().resolvedOptions().timeZone`으로 감지한 브라우저 IANA 값을 startTime/endTime과 함께 전송하여 이후 표시 단계에서 약어(KST/WEST 등)가 정상 렌더되도록 한다.

--- a/src/components/ActivityList.tsx
+++ b/src/components/ActivityList.tsx
@@ -54,13 +54,33 @@ export default function ActivityList({
 
   const apiBase = `/api/trips/${tripId}/days/${dayId}/activities`;
 
+  /**
+   * 브라우저의 IANA 타임존 감지(#341). Activity 저장 시 startTime/endTime과
+   * 함께 전송해 ActivityCard가 KST 등 약어를 붙일 수 있게 한다.
+   * SSR 시 window 없음 대비해 함수 호출부에서만 평가한다.
+   */
+  function getBrowserTimezone(): string {
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+    } catch {
+      return "UTC";
+    }
+  }
+
   async function handleCreate(data: ActivityFormData) {
+    const tz = getBrowserTimezone();
     const body: Record<string, unknown> = {
       category: data.category,
       title: data.title,
     };
-    if (data.startTime) body.startTime = data.startTime;
-    if (data.endTime) body.endTime = data.endTime;
+    if (data.startTime) {
+      body.startTime = data.startTime;
+      body.startTimezone = tz;
+    }
+    if (data.endTime) {
+      body.endTime = data.endTime;
+      body.endTimezone = tz;
+    }
     if (data.location) body.location = data.location;
     if (data.memo) body.memo = data.memo;
     if (data.cost) body.cost = parseFloat(data.cost);
@@ -86,11 +106,14 @@ export default function ActivityList({
   }
 
   async function handleUpdate(activityId: number, data: ActivityFormData) {
+    const tz = getBrowserTimezone();
     const body: Record<string, unknown> = {
       category: data.category,
       title: data.title,
       startTime: data.startTime || null,
+      startTimezone: data.startTime ? tz : null,
       endTime: data.endTime || null,
+      endTimezone: data.endTime ? tz : null,
       location: data.location || null,
       memo: data.memo || null,
       cost: data.cost ? parseFloat(data.cost) : null,

--- a/src/components/ActivityList.tsx
+++ b/src/components/ActivityList.tsx
@@ -63,6 +63,7 @@ export default function ActivityList({
     try {
       return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
     } catch {
+      /* c8 ignore next -- defensive: 모든 현대 브라우저가 Intl을 지원. 테스트 도달 불가 */
       return "UTC";
     }
   }


### PR DESCRIPTION
## Summary

활동 카드에 KST 등 타임존 약어가 표시되지 않고 "01:30–02:30"만 렌더되던 문제 수정. #325가 표시 포맷(`tzLabel`)을 개선했지만 **DB의 `startTimezone`/`endTimezone`이 애초에 null**이어서 약어 로직이 실행되지 않았습니다.

## 원인

`src/components/ActivityList.tsx`의 `handleCreate`/`handleUpdate`가 body에 timezone 필드를 포함하지 않아 POST/PUT 시 null 저장.

## 수정

- `Intl.DateTimeFormat().resolvedOptions().timeZone`으로 브라우저 IANA(예: `Asia/Seoul`) 감지
- `startTime` 존재 시 `startTimezone` 동반 전송, `endTime` 동일
- Update 시엔 `startTime`이 null로 오면 `startTimezone`도 null (일관성)

백엔드는 이미 해당 필드를 받아 Prisma에 저장하도록 되어 있으므로 서버 수정 불필요.

## Test plan

- [x] `tsc --noEmit` 통과, `vitest` 225/225 통과
- [ ] dev 머지 후: 활동 신규 생성 → 카드에 "01:30 KST–02:30 KST" 표시
- [ ] 기존(null tz) 활동 편집 저장 → tz 주입 → 약어 표시

Closes #341