### PR TITLE
chore(#349): v2.9.0 GCal 공유 PoC를 dev 환경에 임시 배치

### DIFF
--- a/src/app/api/poc/v290/route.ts
+++ b/src/app/api/poc/v290/route.ts
@@ -1,0 +1,362 @@
+/**
+ * PoC v2.9.0 — Google Calendar 공유 플로우 검증 엔드포인트.
+ *
+ * 목적: 5개 시나리오를 실측해 v2.9.0 재설계의 기술적 전제를 검증한다.
+ *  1) acl.insert 재호출 시 중복 생성 여부
+ *  2) 게스트 토큰으로 calendarList.insert 성공 조건 (ACL·scope 의존성)
+ *  3) role=writer/reader Google UI 반영
+ *  4) sendNotifications:false 실제 무음
+ *  5) role 변경(acl.patch)의 반영 지연
+ *
+ * 보안: production 빌드(VERCEL_ENV=production) 차단. 세션 유저의 본인 Google 토큰으로만 호출.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { getCalendarClient, classifyError, getStatus } from "@/lib/gcal/client";
+import { hasCalendarScope } from "@/lib/gcal/auth";
+
+const POC_DISABLED_MESSAGE =
+  "PoC endpoint is not available in production. Set VERCEL_ENV=preview or run locally.";
+
+function assertPocEnabled(): NextResponse | null {
+  if (process.env.VERCEL_ENV === "production") {
+    return NextResponse.json({ error: POC_DISABLED_MESSAGE }, { status: 404 });
+  }
+  return null;
+}
+
+type Action =
+  | "whoami"
+  | "create-calendar"
+  | "insert-acl"
+  | "list-acl"
+  | "patch-acl-role"
+  | "delete-calendar"
+  | "subscribe-calendar"
+  | "unsubscribe-calendar"
+  | "list-my-calendars"
+  | "run-owner-scenario"
+  | "run-guest-scenario";
+
+interface ActionRequest {
+  action: Action;
+  calendarId?: string;
+  calendarSummary?: string;
+  guestEmail?: string;
+  role?: "reader" | "writer" | "owner" | "freeBusyReader";
+  sendNotifications?: boolean;
+}
+
+export async function POST(req: NextRequest) {
+  const blocked = assertPocEnabled();
+  if (blocked) return blocked;
+
+  const session = await auth();
+  if (!session?.user?.id || !session.user.email) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+
+  const body = (await req.json().catch(() => ({}))) as Partial<ActionRequest>;
+  const action = body.action;
+  if (!action) {
+    return NextResponse.json({ error: "missing_action" }, { status: 400 });
+  }
+
+  if (action === "whoami") {
+    const scopeGranted = await hasCalendarScope(session.user.id);
+    return NextResponse.json({
+      userId: session.user.id,
+      email: session.user.email,
+      scopeGranted,
+      env: process.env.VERCEL_ENV ?? "local",
+    });
+  }
+
+  const client = await getCalendarClient(session.user.id);
+  if (!client) {
+    return NextResponse.json(
+      { error: "no_google_account_or_missing_scope" },
+      { status: 409 }
+    );
+  }
+
+  const started = Date.now();
+  const result: Record<string, unknown> = { action, actor: session.user.email };
+
+  try {
+    switch (action) {
+      case "create-calendar": {
+        const res = await client.calendar.calendars.insert({
+          requestBody: { summary: body.calendarSummary ?? "PoC v2.9.0 Trip Calendar" },
+        });
+        result.status = res.status;
+        result.calendarId = res.data.id;
+        result.summary = res.data.summary;
+        result.etag = res.data.etag;
+        break;
+      }
+      case "insert-acl": {
+        if (!body.calendarId || !body.guestEmail) {
+          return NextResponse.json({ error: "missing_calendar_or_email" }, { status: 400 });
+        }
+        const res = await client.calendar.acl.insert({
+          calendarId: body.calendarId,
+          sendNotifications: body.sendNotifications ?? false,
+          requestBody: {
+            scope: { type: "user", value: body.guestEmail },
+            role: body.role ?? "reader",
+          },
+        });
+        result.status = res.status;
+        result.ruleId = res.data.id;
+        result.role = res.data.role;
+        result.etag = res.data.etag;
+        break;
+      }
+      case "list-acl": {
+        if (!body.calendarId) {
+          return NextResponse.json({ error: "missing_calendar" }, { status: 400 });
+        }
+        const res = await client.calendar.acl.list({ calendarId: body.calendarId });
+        result.status = res.status;
+        result.count = res.data.items?.length ?? 0;
+        result.rules = res.data.items?.map((r) => ({
+          id: r.id,
+          role: r.role,
+          scope: r.scope,
+        }));
+        break;
+      }
+      case "patch-acl-role": {
+        if (!body.calendarId || !body.guestEmail || !body.role) {
+          return NextResponse.json({ error: "missing_fields" }, { status: 400 });
+        }
+        const ruleId = `user:${body.guestEmail}`;
+        const res = await client.calendar.acl.patch({
+          calendarId: body.calendarId,
+          ruleId,
+          sendNotifications: body.sendNotifications ?? false,
+          requestBody: { role: body.role },
+        });
+        result.status = res.status;
+        result.ruleId = res.data.id;
+        result.role = res.data.role;
+        break;
+      }
+      case "delete-calendar": {
+        if (!body.calendarId) {
+          return NextResponse.json({ error: "missing_calendar" }, { status: 400 });
+        }
+        const res = await client.calendar.calendars.delete({ calendarId: body.calendarId });
+        result.status = res.status;
+        break;
+      }
+      case "subscribe-calendar": {
+        if (!body.calendarId) {
+          return NextResponse.json({ error: "missing_calendar" }, { status: 400 });
+        }
+        const res = await client.calendar.calendarList.insert({
+          requestBody: { id: body.calendarId },
+        });
+        result.status = res.status;
+        result.calendarId = res.data.id;
+        result.summary = res.data.summary;
+        result.accessRole = res.data.accessRole;
+        break;
+      }
+      case "unsubscribe-calendar": {
+        if (!body.calendarId) {
+          return NextResponse.json({ error: "missing_calendar" }, { status: 400 });
+        }
+        const res = await client.calendar.calendarList.delete({ calendarId: body.calendarId });
+        result.status = res.status;
+        break;
+      }
+      case "list-my-calendars": {
+        const res = await client.calendar.calendarList.list({ maxResults: 50 });
+        result.status = res.status;
+        result.count = res.data.items?.length ?? 0;
+        result.calendars = res.data.items?.map((c) => ({
+          id: c.id,
+          summary: c.summary,
+          accessRole: c.accessRole,
+        }));
+        break;
+      }
+      case "run-owner-scenario": {
+        if (!body.guestEmail) {
+          return NextResponse.json({ error: "missing_guest_email" }, { status: 400 });
+        }
+        const steps: Record<string, unknown>[] = [];
+        // 1) Create calendar
+        const created = await client.calendar.calendars.insert({
+          requestBody: { summary: body.calendarSummary ?? "PoC v2.9.0 Auto" },
+        });
+        const calendarId = created.data.id as string;
+        steps.push({ step: "create", status: created.status, calendarId });
+
+        // 2) First acl.insert as reader (sendNotifications:false)
+        const acl1 = await client.calendar.acl.insert({
+          calendarId,
+          sendNotifications: false,
+          requestBody: {
+            scope: { type: "user", value: body.guestEmail },
+            role: "reader",
+          },
+        });
+        steps.push({
+          step: "acl-insert-1st",
+          status: acl1.status,
+          ruleId: acl1.data.id,
+          role: acl1.data.role,
+        });
+
+        // 3) Second acl.insert with same email+role (duplicate test)
+        const acl2Result = await client.calendar.acl
+          .insert({
+            calendarId,
+            sendNotifications: false,
+            requestBody: {
+              scope: { type: "user", value: body.guestEmail },
+              role: "reader",
+            },
+          })
+          .then((r) => ({
+            step: "acl-insert-2nd",
+            status: r.status,
+            ruleId: r.data.id,
+            role: r.data.role,
+            observation: r.data.id === acl1.data.id ? "same-rule-id" : "different-rule-id",
+          }))
+          .catch((err) => ({
+            step: "acl-insert-2nd",
+            status: getStatus(err),
+            error: classifyError(err).reason,
+          }));
+        steps.push(acl2Result);
+
+        // 4) acl.list to see actual stored rules
+        const listed = await client.calendar.acl.list({ calendarId });
+        const guestRules = listed.data.items?.filter(
+          (r) => r.scope?.type === "user" && r.scope?.value === body.guestEmail
+        );
+        steps.push({
+          step: "acl-list",
+          totalRules: listed.data.items?.length ?? 0,
+          guestRuleCount: guestRules?.length ?? 0,
+          guestRules: guestRules?.map((r) => ({ id: r.id, role: r.role })),
+        });
+
+        // 5) acl.patch role reader → writer
+        const patched = await client.calendar.acl
+          .patch({
+            calendarId,
+            ruleId: `user:${body.guestEmail}`,
+            sendNotifications: false,
+            requestBody: { role: "writer" },
+          })
+          .then((r) => ({ step: "acl-patch-role", status: r.status, newRole: r.data.role }))
+          .catch((err) => ({
+            step: "acl-patch-role",
+            status: getStatus(err),
+            error: classifyError(err).reason,
+          }));
+        steps.push(patched);
+
+        result.calendarId = calendarId;
+        result.steps = steps;
+        result.note =
+          "Copy calendarId to guest account and run 'run-guest-scenario'. After verification run 'delete-calendar' to cleanup.";
+        break;
+      }
+      case "run-guest-scenario": {
+        if (!body.calendarId) {
+          return NextResponse.json({ error: "missing_calendar" }, { status: 400 });
+        }
+        const steps: Record<string, unknown>[] = [];
+
+        // 1) Subscribe via calendarList.insert
+        const sub = await client.calendar.calendarList
+          .insert({ requestBody: { id: body.calendarId } })
+          .then((r) => ({
+            step: "calendarList-insert",
+            status: r.status,
+            accessRole: r.data.accessRole,
+            summary: r.data.summary,
+          }))
+          .catch((err) => ({
+            step: "calendarList-insert",
+            status: getStatus(err),
+            error: classifyError(err).reason,
+          }));
+        steps.push(sub);
+
+        // 2) List my calendars to confirm appears
+        const listed = await client.calendar.calendarList.list({ maxResults: 50 });
+        const found = listed.data.items?.find((c) => c.id === body.calendarId);
+        steps.push({
+          step: "calendarList-list",
+          totalCalendars: listed.data.items?.length ?? 0,
+          found: Boolean(found),
+          foundAccessRole: found?.accessRole,
+        });
+
+        // 3) Attempt events.list on shared calendar (verifies read path)
+        const events = await client.calendar.events
+          .list({ calendarId: body.calendarId, maxResults: 5 })
+          .then((r) => ({
+            step: "events-list",
+            status: r.status,
+            count: r.data.items?.length ?? 0,
+          }))
+          .catch((err) => ({
+            step: "events-list",
+            status: getStatus(err),
+            error: classifyError(err).reason,
+          }));
+        steps.push(events);
+
+        result.steps = steps;
+        break;
+      }
+      default:
+        return NextResponse.json({ error: `unknown_action:${action}` }, { status: 400 });
+    }
+  } catch (err) {
+    const { reason } = classifyError(err);
+    return NextResponse.json(
+      {
+        ...result,
+        error: reason,
+        errorStatus: getStatus(err),
+        errorMessage: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 }
+    );
+  }
+
+  result.durationMs = Date.now() - started;
+  return NextResponse.json(result);
+}
+
+export async function GET() {
+  const blocked = assertPocEnabled();
+  if (blocked) return blocked;
+  return NextResponse.json({
+    name: "PoC v2.9.0 — Google Calendar Share Flow",
+    actions: [
+      "whoami",
+      "create-calendar",
+      "insert-acl",
+      "list-acl",
+      "patch-acl-role",
+      "delete-calendar",
+      "subscribe-calendar",
+      "unsubscribe-calendar",
+      "list-my-calendars",
+      "run-owner-scenario",
+      "run-guest-scenario",
+    ],
+  });
+}

--- a/src/app/poc-v290/page.tsx
+++ b/src/app/poc-v290/page.tsx
@@ -1,0 +1,34 @@
+/**
+ * PoC v2.9.0 — Google Calendar 공유 플로우 수동 검증 페이지.
+ *
+ * 배포 조건: VERCEL_ENV !== "production" (dev.trip.idean.me + preview URL + 로컬)
+ * 사용법: Google 로그인 후 "내 상태" 확인 → "오너 시나리오" 또는 "게스트 시나리오" 실행.
+ */
+
+import { notFound } from "next/navigation";
+import { PocPanel } from "./panel";
+
+export const metadata = {
+  title: "PoC v2.9.0 — GCal Share Flow",
+  robots: { index: false, follow: false },
+};
+
+export const dynamic = "force-dynamic";
+
+export default function PocV290Page() {
+  if (process.env.VERCEL_ENV === "production") {
+    notFound();
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 p-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold">PoC v2.9.0 — Google Calendar Share Flow</h1>
+        <p className="text-muted-foreground text-sm">
+          Epic #349 기술 검증. 본 페이지는 프로덕션(trip.idean.me)에서 404.
+        </p>
+      </header>
+      <PocPanel />
+    </div>
+  );
+}

--- a/src/app/poc-v290/panel.tsx
+++ b/src/app/poc-v290/panel.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+interface LogEntry {
+  at: string;
+  action: string;
+  data: unknown;
+}
+
+type Action =
+  | "whoami"
+  | "run-owner-scenario"
+  | "run-guest-scenario"
+  | "delete-calendar"
+  | "unsubscribe-calendar"
+  | "list-my-calendars"
+  | "list-acl";
+
+async function call(body: Record<string, unknown>) {
+  const res = await fetch("/api/poc/v290", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const json = await res.json().catch(() => ({}));
+  return { httpStatus: res.status, body: json };
+}
+
+export function PocPanel() {
+  const [calendarId, setCalendarId] = useState("");
+  const [guestEmail, setGuestEmail] = useState("");
+  const [log, setLog] = useState<LogEntry[]>([]);
+  const [busy, setBusy] = useState<Action | null>(null);
+
+  const append = useCallback((action: string, data: unknown) => {
+    setLog((prev) => [
+      { at: new Date().toISOString(), action, data },
+      ...prev,
+    ]);
+  }, []);
+
+  const run = useCallback(
+    async (action: Action, extra: Record<string, unknown> = {}) => {
+      setBusy(action);
+      try {
+        const { httpStatus, body } = await call({ action, ...extra });
+        append(action, { httpStatus, ...(body as Record<string, unknown>) });
+        if (
+          action === "run-owner-scenario" &&
+          typeof (body as { calendarId?: string }).calendarId === "string"
+        ) {
+          setCalendarId((body as { calendarId: string }).calendarId);
+        }
+      } finally {
+        setBusy(null);
+      }
+    },
+    [append]
+  );
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>1. 내 상태</CardTitle>
+          <CardDescription>
+            로그인한 계정 정보 + calendar scope 부여 여부 확인. 시작 전에 한 번 누릅니다.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button
+            onClick={() => run("whoami")}
+            disabled={busy !== null}
+          >
+            whoami
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>2. 오너 시나리오 (계정 A)</CardTitle>
+          <CardDescription>
+            (create-calendar) + (acl.insert 1차/2차) + (acl.list) + (acl.patch role 변경)을 자동 실행.
+            완료 후 calendarId가 화면에 채워집니다.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="guest-email">게스트 이메일 (계정 B)</Label>
+            <Input
+              id="guest-email"
+              placeholder="guest@gmail.com"
+              value={guestEmail}
+              onChange={(e) => setGuestEmail(e.target.value)}
+            />
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              onClick={() => run("run-owner-scenario", { guestEmail })}
+              disabled={busy !== null || !guestEmail}
+            >
+              Run owner scenario
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => run("list-acl", { calendarId })}
+              disabled={busy !== null || !calendarId}
+            >
+              list-acl
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>3. 게스트 시나리오 (계정 B)</CardTitle>
+          <CardDescription>
+            오너 시나리오에서 얻은 calendarId를 붙여넣고 실행. (calendarList.insert) + (calendarList.list) +
+            (events.list) 자동 실행. 로그아웃 후 계정 B로 다시 로그인해 실행하세요.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="calendar-id">calendarId</Label>
+            <Input
+              id="calendar-id"
+              placeholder="abc...@group.calendar.google.com"
+              value={calendarId}
+              onChange={(e) => setCalendarId(e.target.value)}
+            />
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              onClick={() => run("run-guest-scenario", { calendarId })}
+              disabled={busy !== null || !calendarId}
+            >
+              Run guest scenario
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => run("list-my-calendars")}
+              disabled={busy !== null}
+            >
+              list-my-calendars
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>4. 정리 (Cleanup)</CardTitle>
+          <CardDescription>
+            PoC 종료 후 양쪽 계정에서 실행. 오너: delete-calendar. 게스트: unsubscribe-calendar.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              variant="destructive"
+              onClick={() => run("delete-calendar", { calendarId })}
+              disabled={busy !== null || !calendarId}
+            >
+              delete-calendar (오너)
+            </Button>
+            <Button
+              variant="secondary"
+              onClick={() => run("unsubscribe-calendar", { calendarId })}
+              disabled={busy !== null || !calendarId}
+            >
+              unsubscribe (게스트)
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Log (최신 순)</CardTitle>
+          <CardDescription>
+            복사해서 research 문서에 붙여넣기. 실측 결과는 자동 타임스탬프 포함.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {log.length === 0 ? (
+            <p className="text-muted-foreground text-sm">아직 실행 내역 없음</p>
+          ) : (
+            <pre className="bg-muted max-h-[480px] overflow-auto rounded p-3 text-xs">
+              {JSON.stringify(log, null, 2)}
+            </pre>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## 목적

Epic #349 **v2.9.0 Google Calendar 공유 플로우 재설계**의 기술 전제 5건을 실측 검증하기 위한 PoC 페이지를 **dev.trip.idean.me에 배포**.

**머지 목표**: develop → dev.trip.idean.me

## 왜 spike 워크트리가 아니라 develop에 올리나

- Vercel preview URL(``trip-planner-git-<branch>-...vercel.app``)에서 ``redirect_uri_mismatch`` — Google Cloud OAuth 클라이언트에 매번 새 redirect URI 등록 필요
- dev.trip.idean.me는 이미 OAuth 등록되어 있어 즉시 로그인 가능
- PoC 코드는 ``VERCEL_ENV === "production"`` 조건으로 **trip.idean.me(prod)에서는 404** → prod 노출 0

## 안전 장치

| 리소스 | prod 노출 |
|---|---|
| ``/poc-v290`` 페이지 | ``VERCEL_ENV === "production"`` 시 ``notFound()`` |
| ``/api/poc/v290`` 엔드포인트 | ``VERCEL_ENV === "production"`` 시 404 응답 |
| DB 영향 | 없음 (Prisma 미사용, Google API 직접 호출만) |
| 다른 사용자 노출 | 로그인 필수 (middleware 보호) |

## 변경 파일

- ``src/app/poc-v290/page.tsx`` — 서버 컴포넌트, VERCEL_ENV 가드
- ``src/app/poc-v290/panel.tsx`` — 클라이언트 컴포넌트, 시나리오 버튼 + JSON 로그
- ``src/app/api/poc/v290/route.ts`` — 11개 액션 통합 POST 엔드포인트

## 검증 매트릭스 (머지 후 dev에서 실행)

| # | 시나리오 | 버튼 | 기대 |
|---|---|---|---|
| 1 | ``acl.insert`` 재호출 시 rule_id 동일성 | run-owner-scenario 내부 | idempotent 여부 확정 → ``list-then-upsert`` 전략 결정 |
| 2 | 게스트 토큰으로 ``calendarList.insert`` | run-guest-scenario | 200 + accessRole |
| 3 | role=reader로 events.list 가능 | run-guest-scenario | 200 |
| 4 | ``sendNotifications:false`` 실제 무음 | 양쪽 Gmail 수동 확인 | 공유 알림 이메일 **없음** |
| 5 | ``acl.patch``로 role 변경 | run-owner-scenario 마지막 | 200 + 새 role |

## 실측 순서

1. 계정 A로 https://dev.trip.idean.me/auth/signin 로그인
2. https://dev.trip.idean.me/poc-v290 → **whoami** → ``scopeGranted: true`` 확인
3. 게스트 이메일(계정 B) 입력 → **Run owner scenario** → log 저장, calendarId 복사
4. 로그아웃 → 계정 B로 로그인 → ``/poc-v290``
5. calendarId 붙여넣기 → **Run guest scenario** → log 저장
6. 양쪽 Gmail 받은편지함 확인 (이메일 미발송 여부 — #4)
7. 계정 B에서 **unsubscribe** → 계정 A에서 **delete-calendar** (정리)
8. 양쪽 JSON log를 **Epic #349 댓글**에 붙여넣기

## 사후 정리

실측 완료 후 별도 **cleanup PR**로 ``poc-v290/`` 및 ``api/poc/`` 제거.

## 체크

- [ ] dev.trip.idean.me/poc-v290 접근 (로그인 후) 정상
- [ ] trip.idean.me/poc-v290 → 404
- [ ] 오너 실측 완료, log 첨부
- [ ] 게스트 실측 완료, log 첨부
- [ ] sendNotifications:false 이메일 미발송 확인
- [ ] cleanup

Refs: #349, 마일스톤 #26