### PR TITLE
chore(#349): PoC panel UX — localStorage + 자동 whoami + 재동의 버튼

### DIFF
--- a/src/app/poc-v290/panel.tsx
+++ b/src/app/poc-v290/panel.tsx
@@ -117,7 +117,7 @@ export function PocPanel() {
           <CardTitle>1. 내 상태</CardTitle>
           <CardDescription>
             로그인한 계정 정보 + calendar scope 부여 여부. 페이지 진입 시 자동 실행됨.
-            scopeGranted=false이면 아래 "scope 재동의" 버튼 클릭.
+            scopeGranted=false이면 아래 scope 재동의 버튼 클릭.
           </CardDescription>
         </CardHeader>
         <CardContent className="flex flex-wrap gap-2">

--- a/src/app/poc-v290/panel.tsx
+++ b/src/app/poc-v290/panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -27,6 +27,9 @@ type Action =
   | "list-my-calendars"
   | "list-acl";
 
+const STORAGE_CALENDAR_ID = "poc-v290:calendarId";
+const STORAGE_GUEST_EMAIL = "poc-v290:guestEmail";
+
 async function call(body: Record<string, unknown>) {
   const res = await fetch("/api/poc/v290", {
     method: "POST",
@@ -42,6 +45,37 @@ export function PocPanel() {
   const [guestEmail, setGuestEmail] = useState("");
   const [log, setLog] = useState<LogEntry[]>([]);
   const [busy, setBusy] = useState<Action | null>(null);
+  const autoWhoamiRan = useRef(false);
+
+  // 새로고침·OAuth 복귀 후에도 값 유지.
+  useEffect(() => {
+    try {
+      const cid = localStorage.getItem(STORAGE_CALENDAR_ID);
+      if (cid) setCalendarId(cid);
+      const email = localStorage.getItem(STORAGE_GUEST_EMAIL);
+      if (email) setGuestEmail(email);
+    } catch {
+      // localStorage 불가 환경(시크릿 모드 일부) — 무시
+    }
+  }, []);
+
+  useEffect(() => {
+    try {
+      if (calendarId) localStorage.setItem(STORAGE_CALENDAR_ID, calendarId);
+      else localStorage.removeItem(STORAGE_CALENDAR_ID);
+    } catch {
+      /* noop */
+    }
+  }, [calendarId]);
+
+  useEffect(() => {
+    try {
+      if (guestEmail) localStorage.setItem(STORAGE_GUEST_EMAIL, guestEmail);
+      else localStorage.removeItem(STORAGE_GUEST_EMAIL);
+    } catch {
+      /* noop */
+    }
+  }, [guestEmail]);
 
   const append = useCallback((action: string, data: unknown) => {
     setLog((prev) => [
@@ -69,21 +103,42 @@ export function PocPanel() {
     [append]
   );
 
+  // 페이지 진입 시 whoami 자동 실행 — scope 상태를 즉시 파악해 재동의 필요 여부 판단.
+  useEffect(() => {
+    if (autoWhoamiRan.current) return;
+    autoWhoamiRan.current = true;
+    void run("whoami");
+  }, [run]);
+
   return (
     <div className="space-y-6">
       <Card>
         <CardHeader>
           <CardTitle>1. 내 상태</CardTitle>
           <CardDescription>
-            로그인한 계정 정보 + calendar scope 부여 여부 확인. 시작 전에 한 번 누릅니다.
+            로그인한 계정 정보 + calendar scope 부여 여부. 페이지 진입 시 자동 실행됨.
+            scopeGranted=false이면 아래 "scope 재동의" 버튼 클릭.
           </CardDescription>
         </CardHeader>
-        <CardContent>
+        <CardContent className="flex flex-wrap gap-2">
           <Button
             onClick={() => run("whoami")}
             disabled={busy !== null}
           >
             whoami
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => {
+              // 현재 페이지 URL 쿼리를 보존하면서 consent 경로로 이동.
+              const bypass = new URLSearchParams(window.location.search);
+              const returnTo = window.location.pathname;
+              const params = new URLSearchParams({ returnTo });
+              for (const [k, v] of bypass.entries()) params.set(k, v);
+              window.location.href = `/api/gcal/consent?${params.toString()}`;
+            }}
+          >
+            scope 재동의 (Google 이동)
           </Button>
         </CardContent>
       </Card>


### PR DESCRIPTION
## 목적

v2.9.0 PoC 실측에서 OAuth 재동의 리다이렉트가 잦고, 그 때마다 ``calendarId``/``guestEmail`` state가 초기화돼 다음 버튼을 누르기 위한 **수동 붙여넣기가 반복** 발생. 또 계정별 Account.scope가 토큰 refresh 과정에서 빠지는 현상까지 겹쳐 "scope 재동의 URL을 주소창에 직접 입력" 단계도 반복. 테스트 회전을 빠르게 하기 위한 3가지 UX 개선.

## 변경

### 1. localStorage 지속성
- ``poc-v290:calendarId``, ``poc-v290:guestEmail`` 키로 저장/복원
- OAuth 재동의 후 복귀해도 state 유지 → ``list-acl``·``delete-calendar`` 즉시 활성
- 시크릿 창 localStorage 제한은 try/catch로 무시

### 2. 페이지 진입 시 whoami 자동 실행
- useRef로 1회 가드 → scope 상태 즉시 화면에 표시
- 수동으로 whoami 먼저 눌러야 하는 단계 생략

### 3. "scope 재동의 (Google 이동)" 버튼
- 현재 URL의 쿼리(Vercel bypass 포함)를 보존하며 ``/api/gcal/consent?returnTo=/poc-v290``로 이동
- 주소창에 직접 입력하는 마찰 제거

## 안전

- ``calendarId``는 비공개 식별자가 아니므로 브라우저 프로파일 localStorage 저장 무방
- 다른 계정으로 전환 시 시크릿 창(별도 프로파일)이므로 storage 교차 없음

## 이후

본 PR은 PoC 회전만 개선. v2.9.0 정식 구현에는 이 코드 이식 안 함 (``feedback_poc_workflow``).

Refs: #349, 마일스톤 #26