### PR TITLE
feat(019/2): 오너 공유 캘린더 연결 API + ACL 래퍼 (#356)

### DIFF
--- a/changes/356.feat.md
+++ b/changes/356.feat.md
@@ -1,0 +1,1 @@
+**오너 공유 캘린더 연결 API (v2.9.0 #356)**: `POST /api/v2/trips/{id}/calendar`로 여행 오너가 공유 캘린더 1개를 연결하면 현재 멤버 전원에게 역할별 권한(오너=owner / 호스트=writer / 게스트=reader)이 서버에서 자동 부여된다. 재호출은 idempotent(중복 rule 생성 없음)이며, `DELETE`로 연결 해제 시 ACL 회수만 시도하고 캘린더 자체는 외부 계정에 유지된다.

--- a/src/app/api/v2/trips/[id]/calendar/route.ts
+++ b/src/app/api/v2/trips/[id]/calendar/route.ts
@@ -1,0 +1,286 @@
+/**
+ * v2 per-trip 공유 캘린더 API (#349, spec 019).
+ *
+ * POST   /api/v2/trips/[id]/calendar — 오너가 공유 캘린더 연결 (생성 또는 채택) + 현재 멤버 전원 ACL 자동 부여
+ * DELETE /api/v2/trips/[id]/calendar — 오너가 연결 해제 (ACL 회수는 시도만, 캘린더 자체는 Google에 유지)
+ * GET    /api/v2/trips/[id]/calendar — 현재 사용자 시점의 연결 상태 (오너는 전체 ACL, 멤버는 본인 subscription만)
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { TripRole, type TripMember, type User } from "@prisma/client";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { getTripMember } from "@/lib/auth-helpers";
+import {
+  buildConsentRedirectUrl,
+  hasCalendarScope,
+} from "@/lib/gcal/auth";
+import { getCalendarClient, classifyError } from "@/lib/gcal/client";
+import { dedicatedCalendarName } from "@/lib/gcal/format";
+import {
+  upsertAcl,
+  deleteAcl,
+  mapRoleToAcl,
+  type AclUpsertResult,
+} from "@/lib/gcal/acl";
+import type {
+  ConsentRequired,
+  MemberAclState,
+  TripCalendarLinkResponse,
+  TripCalendarLinkState,
+  TripCalendarLastError,
+} from "@/types/gcal";
+
+function normalizeLastError(raw: string | null): TripCalendarLastError {
+  if (!raw) return null;
+  if (raw === "REVOKED" || raw === "RATE_LIMITED" || raw === "NETWORK" || raw === "UNKNOWN") {
+    return raw;
+  }
+  return "UNKNOWN";
+}
+
+function toMemberAclState(
+  m: TripMember & { user: Pick<User, "id" | "email"> },
+  aclResult: AclUpsertResult | undefined
+): MemberAclState {
+  return {
+    userId: m.userId,
+    email: m.user.email ?? "",
+    role: m.role,
+    aclRole: mapRoleToAcl(m.role),
+    aclStatus: aclResult?.ok ? "granted" : "failed",
+    aclError: aclResult?.ok ? undefined : (aclResult?.reason as MemberAclState["aclError"]),
+  };
+}
+
+async function loadMembersWithEmails(tripId: number) {
+  return prisma.tripMember.findMany({
+    where: { tripId },
+    include: { user: { select: { id: true, email: true } } },
+  });
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+  const tripId = Number((await params).id);
+  if (!Number.isFinite(tripId)) {
+    return NextResponse.json({ error: "bad_trip_id" }, { status: 400 });
+  }
+
+  // 오너만 공유 캘린더를 생성·연결할 수 있다.
+  const member = await getTripMember(tripId, session.user.id);
+  if (!member) {
+    return NextResponse.json({ error: "not_a_member" }, { status: 403 });
+  }
+  if (member.role !== TripRole.OWNER) {
+    return NextResponse.json({ error: "owner_only" }, { status: 403 });
+  }
+
+  // Calendar scope 필요.
+  if (!(await hasCalendarScope(session.user.id))) {
+    const body: ConsentRequired = {
+      error: "consent_required",
+      authorizationUrl: buildConsentRedirectUrl(`/trips/${tripId}?gcal=link-ready`),
+    };
+    return NextResponse.json(body, { status: 409 });
+  }
+
+  const trip = await prisma.trip.findUnique({
+    where: { id: tripId },
+    select: { id: true, title: true },
+  });
+  if (!trip) {
+    return NextResponse.json({ error: "trip_not_found" }, { status: 404 });
+  }
+
+  const client = await getCalendarClient(session.user.id);
+  if (!client) {
+    return NextResponse.json({ error: "no_google_account" }, { status: 409 });
+  }
+
+  // 기존 링크가 있으면 그대로 재사용. 없으면 신규 생성.
+  let link = await prisma.tripCalendarLink.findUnique({
+    where: { tripId },
+  });
+
+  if (!link) {
+    let calendarId: string;
+    let calendarName: string;
+    try {
+      const res = await client.calendar.calendars.insert({
+        requestBody: { summary: dedicatedCalendarName(trip.title) },
+      });
+      calendarId = res.data.id ?? "";
+      calendarName = res.data.summary ?? dedicatedCalendarName(trip.title);
+      if (!calendarId) throw new Error("empty calendar id from insert");
+    } catch (err) {
+      const { reason } = classifyError(err);
+      return NextResponse.json(
+        { error: "calendar_create_failed", reason },
+        { status: 502 }
+      );
+    }
+    link = await prisma.tripCalendarLink.create({
+      data: {
+        tripId,
+        ownerId: session.user.id,
+        calendarId,
+        calendarName,
+      },
+    });
+  }
+
+  // 현재 멤버 전원에게 ACL 자동 부여. 오너 자신은 Google이 이미 owner 데이터 오너로
+  // 간주하므로 별도 ACL 삽입 불필요(insert 시도해도 idempotent지만 scope 불필요 메시지만 더함).
+  const members = await loadMembersWithEmails(tripId);
+  const results = new Map<string, AclUpsertResult>();
+  for (const m of members) {
+    if (m.role === TripRole.OWNER) continue;
+    if (!m.user.email) continue;
+    const result = await upsertAcl(client.calendar, {
+      calendarId: link.calendarId,
+      email: m.user.email,
+      role: mapRoleToAcl(m.role),
+    });
+    results.set(m.userId, result);
+  }
+
+  const anyFailed = Array.from(results.values()).some((r) => !r.ok);
+  const body: TripCalendarLinkResponse = {
+    status: anyFailed ? "partial" : "ok",
+    link: toLinkState(link),
+    members: members.map((m) => toMemberAclState(m, results.get(m.userId))),
+  };
+  return NextResponse.json(body);
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+  const tripId = Number((await params).id);
+  if (!Number.isFinite(tripId)) {
+    return NextResponse.json({ error: "bad_trip_id" }, { status: 400 });
+  }
+
+  const member = await getTripMember(tripId, session.user.id);
+  if (member?.role !== TripRole.OWNER) {
+    return NextResponse.json({ error: "owner_only" }, { status: 403 });
+  }
+
+  const link = await prisma.tripCalendarLink.findUnique({
+    where: { tripId },
+  });
+  if (!link) {
+    return NextResponse.json({ error: "not_linked" }, { status: 404 });
+  }
+
+  const client = await getCalendarClient(session.user.id);
+  if (client) {
+    // 멤버 ACL 회수 시도. 실패는 기록만 하고 계속 진행(DB 레코드 정리는 확실히 수행).
+    const members = await loadMembersWithEmails(tripId);
+    for (const m of members) {
+      if (m.role === TripRole.OWNER) continue;
+      if (!m.user.email) continue;
+      await deleteAcl(client.calendar, {
+        calendarId: link.calendarId,
+        email: m.user.email,
+      });
+    }
+  }
+
+  // 캘린더 자체는 Google에 남겨둔다 (사용자 데이터 보존 원칙).
+  // MemberCalendarSubscription은 cascade로 함께 제거.
+  await prisma.tripCalendarLink.delete({ where: { id: link.id } });
+
+  return NextResponse.json({ status: "ok" });
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+  const tripId = Number((await params).id);
+  if (!Number.isFinite(tripId)) {
+    return NextResponse.json({ error: "bad_trip_id" }, { status: 400 });
+  }
+
+  const member = await getTripMember(tripId, session.user.id);
+  if (!member) {
+    return NextResponse.json({ error: "not_a_member" }, { status: 403 });
+  }
+
+  const link = await prisma.tripCalendarLink.findUnique({
+    where: { tripId },
+  });
+  if (!link) {
+    const scopeGranted = await hasCalendarScope(session.user.id);
+    return NextResponse.json({ linked: false, scopeGranted });
+  }
+
+  // 오너는 전체 ACL 상태까지. 일반 멤버는 본인 subscription 상태만.
+  if (member.role === TripRole.OWNER) {
+    const members = await loadMembersWithEmails(tripId);
+    return NextResponse.json({
+      linked: true,
+      link: toLinkState(link),
+      members: members.map((m) => ({
+        userId: m.userId,
+        email: m.user.email ?? "",
+        role: m.role,
+        aclRole: mapRoleToAcl(m.role),
+        aclStatus: "granted", // 본 엔드포인트는 조회만. 실제 상태는 subscribe 엔드포인트 결과로 갱신
+      })),
+    });
+  }
+
+  const subscription = await prisma.memberCalendarSubscription.findUnique({
+    where: { linkId_userId: { linkId: link.id, userId: session.user.id } },
+  });
+  return NextResponse.json({
+    linked: true,
+    link: toLinkState(link),
+    subscription: subscription
+      ? {
+          tripId,
+          status: subscription.status,
+          accessRole: null,
+          lastError: subscription.lastError,
+        }
+      : null,
+  });
+}
+
+function toLinkState(link: {
+  tripId: number;
+  calendarId: string;
+  calendarName: string | null;
+  ownerId: string;
+  lastSyncedAt: Date | null;
+  lastError: string | null;
+  skippedCount: number;
+}): TripCalendarLinkState {
+  return {
+    tripId: link.tripId,
+    calendarId: link.calendarId,
+    calendarName: link.calendarName,
+    ownerId: link.ownerId,
+    lastSyncedAt: link.lastSyncedAt?.toISOString() ?? null,
+    lastError: normalizeLastError(link.lastError),
+    skippedCount: link.skippedCount,
+  };
+}

--- a/src/lib/gcal/acl.ts
+++ b/src/lib/gcal/acl.ts
@@ -1,0 +1,123 @@
+/**
+ * Google Calendar ACL 관리 래퍼.
+ *
+ * v2.9.0 per-trip 공유 모델에서 오너의 토큰으로 공유 캘린더의 ACL을 관리한다.
+ * PoC(#349)에서 확인: acl.insert는 동일 scope에 대해 idempotent(same rule_id 반환,
+ * 중복 Rule 생성 없음) → list-then-upsert 사전 조회 불필요.
+ */
+
+import type { calendar_v3 } from "@googleapis/calendar";
+import { TripRole } from "@prisma/client";
+import { classifyError, getStatus } from "./errors";
+
+export type AclRole = "reader" | "writer" | "owner" | "freeBusyReader";
+
+/** 트립 역할에서 파생 가능한 ACL role 서브셋. */
+export type MemberAclRole = "owner" | "writer" | "reader";
+
+/** 트립 역할을 외부 캘린더 ACL role로 매핑한다. */
+export function mapRoleToAcl(role: TripRole): MemberAclRole {
+  switch (role) {
+    case TripRole.OWNER:
+      return "owner";
+    case TripRole.HOST:
+      return "writer";
+    case TripRole.GUEST:
+      return "reader";
+  }
+}
+
+export interface AclUpsertInput {
+  calendarId: string;
+  email: string;
+  role: AclRole;
+}
+
+export interface AclUpsertResult {
+  ok: boolean;
+  ruleId?: string | null;
+  role?: string | null;
+  reason?: string;
+  status?: number;
+}
+
+/**
+ * 특정 이메일에 대해 지정 role을 부여/갱신한다.
+ * insert가 idempotent이므로 그냥 insert를 시도한다. 에러 발생 시 분류해 반환.
+ * sendNotifications는 Google이 Gmail 간 공유에서 자동 발송(외부 통제).
+ */
+export async function upsertAcl(
+  calendar: calendar_v3.Calendar,
+  input: AclUpsertInput
+): Promise<AclUpsertResult> {
+  try {
+    const res = await calendar.acl.insert({
+      calendarId: input.calendarId,
+      sendNotifications: false,
+      requestBody: {
+        scope: { type: "user", value: input.email },
+        role: input.role,
+      },
+    });
+    return {
+      ok: true,
+      ruleId: res.data.id ?? null,
+      role: res.data.role ?? null,
+      status: res.status,
+    };
+  } catch (err) {
+    const { reason } = classifyError(err);
+    return { ok: false, reason, status: getStatus(err) };
+  }
+}
+
+/**
+ * 명시적으로 role을 갱신해야 할 때(예: reader ↔ writer 전환) patch 호출.
+ * rule ID 형식은 `user:<email>`로 결정적.
+ */
+export async function patchAclRole(
+  calendar: calendar_v3.Calendar,
+  input: AclUpsertInput
+): Promise<AclUpsertResult> {
+  try {
+    const res = await calendar.acl.patch({
+      calendarId: input.calendarId,
+      ruleId: `user:${input.email}`,
+      sendNotifications: false,
+      requestBody: { role: input.role },
+    });
+    return {
+      ok: true,
+      ruleId: res.data.id ?? null,
+      role: res.data.role ?? null,
+      status: res.status,
+    };
+  } catch (err) {
+    const { reason } = classifyError(err);
+    return { ok: false, reason, status: getStatus(err) };
+  }
+}
+
+export interface AclDeleteInput {
+  calendarId: string;
+  email: string;
+}
+
+/** 특정 이메일의 ACL 제거. 404는 "이미 없음"으로 성공 간주. */
+export async function deleteAcl(
+  calendar: calendar_v3.Calendar,
+  input: AclDeleteInput
+): Promise<AclUpsertResult> {
+  try {
+    const res = await calendar.acl.delete({
+      calendarId: input.calendarId,
+      ruleId: `user:${input.email}`,
+    });
+    return { ok: true, status: res.status };
+  } catch (err) {
+    const status = getStatus(err);
+    if (status === 404) return { ok: true, status };
+    const { reason } = classifyError(err);
+    return { ok: false, reason, status };
+  }
+}

--- a/src/types/gcal.ts
+++ b/src/types/gcal.ts
@@ -83,3 +83,51 @@ export const GCAL_EVENTS_SCOPE = GCAL_SCOPE;
 
 /** 전용 캘린더 이름 접미어. 사용자의 다른 캘린더와 구분 목적. */
 export const DEDICATED_CALENDAR_SUFFIX = " (trip-planner)" as const;
+
+// ============================================================
+// v2.9.0 per-trip 공유 모델 (#349, spec 019)
+// ============================================================
+
+export type TripCalendarLastError = GCalLastError;
+
+export interface MemberAclState {
+  userId: string;
+  email: string;
+  role: "OWNER" | "HOST" | "GUEST";
+  aclRole: "owner" | "writer" | "reader";
+  /** 해당 멤버의 ACL 부여 성공 여부. 실패면 사유 포함. */
+  aclStatus: "granted" | "failed";
+  aclError?: FailureReason;
+}
+
+export interface TripCalendarLinkState {
+  tripId: number;
+  calendarId: string;
+  calendarName: string | null;
+  ownerId: string;
+  lastSyncedAt: string | null;
+  lastError: TripCalendarLastError;
+  skippedCount: number;
+}
+
+export interface TripCalendarLinkResponse {
+  status: "ok" | "partial" | "failed";
+  link: TripCalendarLinkState;
+  members: MemberAclState[];
+}
+
+export type MemberSubscriptionStatusValue = "NOT_ADDED" | "ADDED" | "ERROR";
+
+export interface MemberSubscriptionState {
+  tripId: number;
+  status: MemberSubscriptionStatusValue;
+  accessRole: string | null;
+  lastError: string | null;
+}
+
+export interface MemberSubscribeResponse {
+  status: "ok" | "consent_required" | "failed";
+  subscription?: MemberSubscriptionState;
+  authorizationUrl?: string;
+  error?: FailureReason;
+}


### PR DESCRIPTION
## 목적

v2.9.0 per-trip 공유 모델의 오너 연결 엔드포인트. PoC(#349)에서 확인한 ``acl.insert`` idempotent 성질을 활용해 단순 insert 반복으로 멤버 ACL 관리.

## 해결 이슈

- Closes #356 (owner-link)

## 변경

- ``src/lib/gcal/acl.ts`` — upsertAcl/patchAclRole/deleteAcl 래퍼 + mapRoleToAcl
- ``src/types/gcal.ts`` — v2 API 타입 (TripCalendarLinkResponse, MemberAclState 등)
- ``src/app/api/v2/trips/[id]/calendar/route.ts`` — POST/DELETE/GET 3종
- ``changes/356.feat.md``

## 설계 포인트

- **Idempotent insert**: PoC 결과 동일 scope 재호출 시 same rule_id → list-then-upsert 사전 조회 불필요
- **오너 본인 skip**: Google에서 캘린더 생성자는 자동으로 owner 데이터 오너 → ACL 삽입 불필요
- **DELETE는 데이터 보존**: 연결 해제 시 ACL 회수 시도 + DB 링크 제거. 외부 캘린더 자체는 유지
- **GET 역할별 응답**: 오너는 전체 멤버 상태, 일반 멤버는 본인 subscription만 (정보 분리)

## 검증

- [x] TypeScript typecheck
- [x] ESLint
- [ ] dev.trip.idean.me에서 실제 시나리오 검증 (후속 #360 UI 구현 후 통합 테스트에서)

## 이후

- #357 member-lifecycle (멤버 가입·역할 변경·탈퇴 훅)
- #358 member-subscribe (멤버 수동 subscribe 엔드포인트)
- #359 sync-engine, #360 ui-states, #361 legacy-compat, #362 verify, #363 contract-reserve

Refs: #349, 마일스톤 #26