### PR TITLE
fix(019): v2.8.0 마이그레이션 트립 ACL 자동 복구 + 자동 subscribe (dev 테스트 발견)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **ADR 0003: 여행 캘린더는 여행당 1개 공유 캘린더 (v2.9.0 #363)**: 멤버별 중복 캘린더 문제 해결을 위한 아키텍처 결정을 `docs/adr/0003-per-trip-shared-calendar.md`로 고정. 이유·대안·trade-off·contract 타임라인 명시. ([#363](https://github.com/idean3885/trip-planner/issues/363))
 
+### Fixed
+
+- **v2.8.0 마이그레이션 트립의 멤버 ACL 자동 복구 + 동의 후 자동 subscribe**: 백필 SQL은 DB의 TripCalendarLink 승격만 수행하고 Google 쪽 ACL 부여는 하지 못하므로, 승격된 트립에서 멤버가 "내 구글 캘린더에 추가"를 눌러도 404로 실패하는 문제를 해소. 오너가 "다시 반영하기"를 누르면 sync 전에 현재 멤버 전원에게 ACL을 idempotent하게 upsert해 Google 쪽 권한을 복구한다. 또 멤버가 subscribe 시 calendar scope 동의를 완료하고 돌아오면 자동으로 subscribe가 재시도되도록 `?gcal=subscribed` 쿼리를 auto-retry 대상에 추가.
+
 ### Chore
 
 - **레거시 GCal 상태 API가 공유 모델 응답에 적응 (v2.9.0 #361)**: `GET /api/trips/{id}/gcal/status`가 신규 `TripCalendarLink`가 있으면 그것을 우선 사용하고, 없을 때만 기존 per-user `GCalLink`로 폴백한다. 외부 MCP 클라이언트와 웹 UI가 같은 응답 형식을 받으며 v2.9.0 이후에도 기존 통합이 깨지지 않는다. ([#361](https://github.com/idean3885/trip-planner/issues/361))

--- a/src/app/api/v2/trips/[id]/calendar/sync/route.ts
+++ b/src/app/api/v2/trips/[id]/calendar/sync/route.ts
@@ -22,6 +22,7 @@ import {
 } from "@/lib/gcal/auth";
 import { getCalendarClient, classifyError } from "@/lib/gcal/client";
 import { syncActivities } from "@/lib/gcal/sync";
+import { upsertAcl, mapRoleToAcl } from "@/lib/gcal/acl";
 import type { ConsentRequired, SyncResponse, GCalLastError } from "@/types/gcal";
 
 function normalizeLastError(raw: string | null): GCalLastError {
@@ -84,6 +85,28 @@ export async function POST(
   const client = await getCalendarClient(session.user.id);
   if (!client) {
     return NextResponse.json({ error: "no_google_account" }, { status: 409 });
+  }
+
+  // 현재 멤버 전원에게 ACL 재부여 (idempotent). v2.8.0 → v2.9.0 마이그레이션으로 승격된
+  // 트립은 DB 레코드만 존재하고 Google 쪽 ACL이 부여되지 않은 상태라, 오너가 sync를
+  // 실행할 때 ACL 부여를 함께 복구한다. 오너 본인은 Google이 자동 owner 데이터 오너로
+  // 인식하므로 대상 아님. 실패는 로그만 남기고 sync 자체는 계속 진행.
+  const members = await prisma.tripMember.findMany({
+    where: { tripId, NOT: { role: TripRole.OWNER } },
+    include: { user: { select: { email: true } } },
+  });
+  for (const m of members) {
+    if (!m.user.email) continue;
+    const aclResult = await upsertAcl(client.calendar, {
+      calendarId: link.calendarId,
+      email: m.user.email,
+      role: mapRoleToAcl(m.role),
+    });
+    if (!aclResult.ok) {
+      console.warn(
+        `[gcal] sync-time ACL upsert failed tripId=${tripId} userId=${m.userId} reason=${aclResult.reason}`
+      );
+    }
   }
 
   // 이벤트 매핑은 기존 GCalLink 기반 재활용. 없으면 bridge 생성(신규 v2.9.0 트립).

--- a/src/components/GCalLinkPanel.tsx
+++ b/src/components/GCalLinkPanel.tsx
@@ -55,7 +55,9 @@ export default function GCalLinkPanel({ tripId, role = "OWNER" }: Props) {
     if (typeof window === "undefined") return;
     const qp = new URLSearchParams(window.location.search);
     const action = qp.get("gcal");
-    if (action !== "link-ready" && action !== "sync-ready") return;
+    if (action !== "link-ready" && action !== "sync-ready" && action !== "subscribed") {
+      return;
+    }
 
     const loopKey = `gcal-auto-${action}-${tripId}`;
     if (window.sessionStorage.getItem(loopKey) === "1") {
@@ -70,6 +72,7 @@ export default function GCalLinkPanel({ tripId, role = "OWNER" }: Props) {
     qp.delete("gcal");
     window.history.replaceState(null, "", `${window.location.pathname}`);
     if (action === "link-ready") void handleLink("DEDICATED");
+    else if (action === "subscribed") void handleSubscribe("add");
     else void handleSync();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tripId]);


### PR DESCRIPTION
## Dev 테스트 발견 버그 2건

릴리즈 직전 dev.trip.idean.me 실측에서 v2.8.0 마이그레이션 트립이 게스트 구독 시 404로 실패. 원인·수정 요약:

### Bug 1 — 마이그레이션 ACL 누락
- 백필 SQL은 DB의 TripCalendarLink 승격만 처리하고 Google API의 ACL 부여는 수행 불가
- 결과: 기존 트립의 멤버가 "내 구글 캘린더에 추가" 누르면 calendarList.insert가 404(권한 없음)
- **수정**: sync 엔드포인트가 현재 멤버 전원 ACL을 idempotent upsert 후 이벤트 동기화. 오너가 "다시 반영하기" 1회 눌러 복구 가능

### Bug 2 — OAuth 동의 후 subscribe 미실행
- `?gcal=subscribed` 쿼리가 auto-retry 화이트리스트에 없어 복귀 후 버튼이 그대로 남음
- **수정**: `GCalLinkPanel`의 auto-retry 조건에 `subscribed` 추가, handleSubscribe("add") 자동 호출

## 변경

- ``src/app/api/v2/trips/[id]/calendar/sync/route.ts``: sync 전 ACL 재부여 루프
- ``src/components/GCalLinkPanel.tsx``: `subscribed` 복귀 처리
- ``CHANGELOG.md``: v2.9.0 Fixed 섹션 추가

## 검증

- [x] TypeScript typecheck
- [x] ESLint
- [ ] dev 배포 후 사용자가 "데브 테스트" 트립에서 "다시 반영하기" → 호스트 B 계정에서 "내 구글 캘린더에 추가" 정상 동작 확인

## base

``release/v2.9.0-merge``. 머지 시 PR #374의 릴리즈 PR이 자동으로 본 수정을 포함하게 됨.

Refs: Epic #349, PR #374