### PR TITLE
chore(019): hotfix2 forward-port — skippedCount set (release #377 동일)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **v2.8.0 마이그레이션 트립의 멤버 ACL 자동 복구 + 동의 후 자동 subscribe**: 백필 SQL은 DB의 TripCalendarLink 승격만 수행하고 Google 쪽 ACL 부여는 하지 못하므로, 승격된 트립에서 멤버가 "내 구글 캘린더에 추가"를 눌러도 404로 실패하는 문제를 해소. 오너가 "다시 반영하기"를 누르면 sync 전에 현재 멤버 전원에게 ACL을 idempotent하게 upsert해 Google 쪽 권한을 복구한다. 또 멤버가 subscribe 시 calendar scope 동의를 완료하고 돌아오면 자동으로 subscribe가 재시도되도록 `?gcal=subscribed` 쿼리를 auto-retry 대상에 추가.
+- **"직접 수정하여 건너뛴 이벤트" 카운터가 누적되는 문제**: sync를 누를 때마다 동일 이벤트가 반복 카운트되어 숫자가 선형 증가하던 버그 수정. 이번 sync의 실제 건너뛴 수로 덮어쓰도록 변경(v2 sync·v1 sync·v1 link 모두). 사용자 직접 수정 이벤트가 해결되면 다음 sync에서 자동으로 0으로 리셋된다.
 
 ### Chore
 

--- a/src/app/api/trips/[id]/gcal/link/route.ts
+++ b/src/app/api/trips/[id]/gcal/link/route.ts
@@ -132,11 +132,12 @@ export async function POST(
       : "failed"
     : "ok";
 
+  // skippedCount는 이번 호출의 건너뛴 이벤트 수로 set (누적 방지, 이전 increment 버그 수정).
   const updated = await prisma.gCalLink.update({
     where: { id: link.id },
     data: {
       lastSyncedAt: new Date(),
-      skippedCount: { increment: result.skipped },
+      skippedCount: result.skipped,
       lastError: hasFailure ? inferLastError(result) : null,
     },
   });

--- a/src/app/api/trips/[id]/gcal/sync/route.ts
+++ b/src/app/api/trips/[id]/gcal/sync/route.ts
@@ -89,11 +89,12 @@ export async function PATCH(
       : "failed"
     : "ok";
 
+  // skippedCount는 이번 sync의 건너뛴 이벤트 수로 set (매 호출마다 누적되지 않도록).
   const updated = await prisma.gCalLink.update({
     where: { id: link.id },
     data: {
       lastSyncedAt: new Date(),
-      skippedCount: { increment: result.skipped },
+      skippedCount: result.skipped,
       lastError: hasFailure ? inferLastError(result) : null,
     },
   });

--- a/src/app/api/v2/trips/[id]/calendar/sync/route.ts
+++ b/src/app/api/v2/trips/[id]/calendar/sync/route.ts
@@ -146,11 +146,14 @@ export async function POST(
       : "failed"
     : "ok";
 
+  // skippedCount는 "이번 sync에서 사용자가 직접 수정한 이벤트 수"를 표시한다.
+  // 매 sync마다 set(덮어쓰기)로 갱신해 누적되지 않도록 한다. 이전 동작(increment)은
+  // 동일 이벤트가 매 호출마다 다시 카운트되어 숫자가 선형 증가하는 문제가 있었다.
   const updatedLink = await prisma.tripCalendarLink.update({
     where: { id: link.id },
     data: {
       lastSyncedAt: new Date(),
-      skippedCount: { increment: result.skipped },
+      skippedCount: result.skipped,
       lastError: hasFailure ? inferLastError(result) : null,
     },
   });
@@ -159,7 +162,7 @@ export async function POST(
     where: { id: bridgeLink.id },
     data: {
       lastSyncedAt: new Date(),
-      skippedCount: { increment: result.skipped },
+      skippedCount: result.skipped,
       lastError: hasFailure ? inferLastError(result) : null,
     },
   });


### PR DESCRIPTION
PR #377로 release/v2.9.0-merge에 머지된 hotfix를 develop에도 forward-port. dev.trip.idean.me에서 '다시 반영하기' 반복 시 카운터 누적 없음 확인 가능.\n\nRefs: PR #377, #374, Epic #349