### PR TITLE
fix(019): 멤버 subscribe 상태를 UI 반영 — 추가 후 컴팩트 카드

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **v2.8.0 마이그레이션 트립의 멤버 ACL 자동 복구 + 동의 후 자동 subscribe**: 백필 SQL은 DB의 TripCalendarLink 승격만 수행하고 Google 쪽 ACL 부여는 하지 못하므로, 승격된 트립에서 멤버가 "내 구글 캘린더에 추가"를 눌러도 404로 실패하는 문제를 해소. 오너가 "다시 반영하기"를 누르면 sync 전에 현재 멤버 전원에게 ACL을 idempotent하게 upsert해 Google 쪽 권한을 복구한다. 또 멤버가 subscribe 시 calendar scope 동의를 완료하고 돌아오면 자동으로 subscribe가 재시도되도록 `?gcal=subscribed` 쿼리를 auto-retry 대상에 추가.
 - **"직접 수정하여 건너뛴 이벤트" 카운터가 누적되는 문제**: sync를 누를 때마다 동일 이벤트가 반복 카운트되어 숫자가 선형 증가하던 버그 수정. 이번 sync의 실제 건너뛴 수로 덮어쓰도록 변경(v2 sync·v1 sync·v1 link 모두). 사용자 직접 수정 이벤트가 해결되면 다음 sync에서 자동으로 0으로 리셋된다.
+- **멤버 "내 구글 캘린더에 추가" 후에도 버튼·안내문이 그대로 유지되던 UX 이슈**: 상태 응답에 본인 subscription 상태(`mySubscription`)를 함께 반환하고, 패널은 `ADDED` 상태면 "내 캘린더에 추가됨" 배지 + "제거" 단일 버튼의 컴팩트 카드로 전환한다. 오너 쪽 "연결됨" 카드와 동일한 톤.
 
 ### Chore
 

--- a/src/app/api/trips/[id]/gcal/status/route.ts
+++ b/src/app/api/trips/[id]/gcal/status/route.ts
@@ -8,6 +8,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { TripRole } from "@prisma/client";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { getTripMember } from "@/lib/auth-helpers";
@@ -43,6 +44,19 @@ export async function GET(
   // v2.9.0: TripCalendarLink가 존재하면 그걸 응답 정본으로 사용.
   const sharedLink = await prisma.tripCalendarLink.findUnique({ where: { tripId } });
   if (sharedLink) {
+    // 비-오너 멤버의 본인 subscription 상태를 함께 반환해 UI가 역할·상태별 카드를 렌더할 수 있게 함.
+    type MySubscription =
+      | { status: "NOT_ADDED" | "ADDED" | "ERROR"; lastError: string | null }
+      | null;
+    let mySubscription: MySubscription = null;
+    if (member.role !== TripRole.OWNER) {
+      const sub = await prisma.memberCalendarSubscription.findUnique({
+        where: { linkId_userId: { linkId: sharedLink.id, userId: session.user.id } },
+      });
+      mySubscription = sub
+        ? { status: sub.status, lastError: sub.lastError ?? null }
+        : { status: "NOT_ADDED", lastError: null };
+    }
     const body: StatusResponse = {
       linked: true,
       link: {
@@ -53,6 +67,7 @@ export async function GET(
         lastError: normalizeLastError(sharedLink.lastError),
         skippedCount: sharedLink.skippedCount,
       },
+      mySubscription,
     };
     return NextResponse.json(body);
   }

--- a/src/components/GCalLinkPanel.tsx
+++ b/src/components/GCalLinkPanel.tsx
@@ -340,7 +340,42 @@ export default function GCalLinkPanel({ tripId, role = "OWNER" }: Props) {
   const isRevoked = link.lastError === "REVOKED";
 
   if (!isOwner) {
-    // 호스트·게스트: 본인 subscribe 상태 + 추가/제거 버튼만.
+    // 호스트·게스트: 본인 subscribe 상태에 따라 컴팩트(추가됨) / 안내(미추가) 카드로 분기.
+    const sub = status.mySubscription;
+    const isAdded = sub?.status === "ADDED";
+
+    if (isAdded) {
+      // 추가 완료 상태 — 오너 쪽 "연결됨" 카드처럼 컴팩트하게 유지.
+      return (
+        <Card size="sm">
+          <CardContent className="space-y-1">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold">구글 캘린더 (공유)</h3>
+              <span className="text-[11px] rounded px-1.5 py-0.5 bg-emerald-100 text-emerald-700">
+                내 캘린더에 추가됨
+              </span>
+            </div>
+            {link.calendarName && (
+              <p className="text-xs text-muted-foreground">
+                캘린더: <span className="text-foreground">{link.calendarName}</span>
+              </p>
+            )}
+          </CardContent>
+          <CardFooter>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => void handleSubscribe("remove")}
+              disabled={busy}
+            >
+              내 캘린더에서 제거
+            </Button>
+          </CardFooter>
+        </Card>
+      );
+    }
+
+    // 미추가 / 에러 상태 — 안내 + 추가 버튼.
     return (
       <Card size="sm">
         <CardContent className="space-y-2">
@@ -360,12 +395,9 @@ export default function GCalLinkPanel({ tripId, role = "OWNER" }: Props) {
             부여되어 있으며, 추가하지 않아도 앱 내 일정은 정상 이용 가능합니다.
           </p>
         </CardContent>
-        <CardFooter className="gap-2">
+        <CardFooter>
           <Button size="sm" onClick={() => void handleSubscribe("add")} disabled={busy}>
             내 구글 캘린더에 추가
-          </Button>
-          <Button size="sm" variant="ghost" onClick={() => void handleSubscribe("remove")} disabled={busy}>
-            제거
           </Button>
         </CardFooter>
       </Card>

--- a/src/types/gcal.ts
+++ b/src/types/gcal.ts
@@ -64,7 +64,15 @@ export interface ConsentRequired {
 }
 
 export type StatusResponse =
-  | { linked: true; link: GCalLinkState }
+  | {
+      linked: true;
+      link: GCalLinkState;
+      /** v2.9.0: 비-오너 멤버의 본인 subscription 상태. 오너 응답에는 null. */
+      mySubscription?: {
+        status: "NOT_ADDED" | "ADDED" | "ERROR";
+        lastError: string | null;
+      } | null;
+    }
   | { linked: false; scopeGranted: boolean };
 
 /**


### PR DESCRIPTION
## 이슈

dev 테스트에서 발견: 호스트·게스트가 '내 구글 캘린더에 추가' 성공해도 버튼·안내문이 그대로 남아 어색.

## 수정

- StatusResponse에 옵셔널 mySubscription (NOT_ADDED|ADDED|ERROR, lastError) 추가
- 상태 API가 비-오너 조회 시 MemberCalendarSubscription 조회 포함
- 패널: ADDED면 '내 캘린더에 추가됨' 배지 + '제거' 단일 버튼 컴팩트 카드, 아니면 기존 안내+'추가' 버튼

오너 쪽 '연결됨' 카드와 동일한 톤.

## base

release/v2.9.0-merge. 머지 시 PR #374 자동 포함.

Refs: Epic #349, PR #374, PR #375, PR #377