### PR TITLE
fix(019): 412 Precondition 타임스탬프 비교로 정확 판별

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **v2.8.0 마이그레이션 트립의 멤버 ACL 자동 복구 + 동의 후 자동 subscribe**: 백필 SQL은 DB의 TripCalendarLink 승격만 수행하고 Google 쪽 ACL 부여는 하지 못하므로, 승격된 트립에서 멤버가 "내 구글 캘린더에 추가"를 눌러도 404로 실패하는 문제를 해소. 오너가 "다시 반영하기"를 누르면 sync 전에 현재 멤버 전원에게 ACL을 idempotent하게 upsert해 Google 쪽 권한을 복구한다. 또 멤버가 subscribe 시 calendar scope 동의를 완료하고 돌아오면 자동으로 subscribe가 재시도되도록 `?gcal=subscribed` 쿼리를 auto-retry 대상에 추가.
 - **"직접 수정하여 건너뛴 이벤트" 카운터가 누적되는 문제**: sync를 누를 때마다 동일 이벤트가 반복 카운트되어 숫자가 선형 증가하던 버그 수정. 이번 sync의 실제 건너뛴 수로 덮어쓰도록 변경(v2 sync·v1 sync·v1 link 모두). 사용자 직접 수정 이벤트가 해결되면 다음 sync에서 자동으로 0으로 리셋된다.
 - **멤버 "내 구글 캘린더에 추가" 후에도 버튼·안내문이 그대로 유지되던 UX 이슈**: 상태 응답에 본인 subscription 상태(`mySubscription`)를 함께 반환하고, 패널은 `ADDED` 상태면 "내 캘린더에 추가됨" 배지 + "제거" 단일 버튼의 컴팩트 카드로 전환한다. 오너 쪽 "연결됨" 카드와 동일한 톤.
+- **412 Precondition 처리 개선 — "건너뛴 이벤트"의 오탐 제거**: 기존에는 모든 412가 "사용자가 GCal에서 직접 수정"으로 간주되어 skipped 집계되었으나, 실제로는 이전 sync의 ETag 레이스·Google 내부 메타데이터 업데이트로도 412가 발생해 앱 내 수정이 Google로 밀리지 못하는 문제가 있었다. 412 시 Google event.updated와 mapping.lastSyncedAt을 비교해, Google 쪽이 우리 마지막 sync 이후 수정되지 않았으면 현재 ETag로 안전하게 재-patch해 DB 상태를 반영한다. Google 쪽이 이후 수정된 경우에만 skipped로 집계해 사용자 편집을 존중한다.
 
 ### Chore
 

--- a/src/lib/gcal/sync.ts
+++ b/src/lib/gcal/sync.ts
@@ -3,8 +3,13 @@
  * 생성·갱신·삭제한다.
  *
  * 핵심 원칙(스펙 Clarifications 3, research R3):
- *  - 삭제·갱신은 If-Match(ETag) 조건부. 412/409 응답이면 "사용자가 GCal에서 직접
- *    수정했다"는 신호로 해석해 덮어쓰지 않고 skipped로 집계한다.
+ *  - 삭제·갱신은 If-Match(ETag) 조건부.
+ *  - 412 응답 시 **Google event.updated** 와 **mapping.lastSyncedAt** 을 비교해
+ *    "사용자가 GCal에서 직접 수정했는지"를 판단한다 (v2.9.0 개선).
+ *    - Google updated <= 우리 lastSyncedAt → Google의 내부 메타데이터/이전 sync의
+ *      ETag 레이스 등으로 ETag만 밀림. 현재 ETag로 재시도하여 우리 DB 상태를 반영.
+ *    - Google updated > 우리 lastSyncedAt → 사용자가 GCal에서 수정했다고 판단,
+ *      덮어쓰지 않고 skipped로 집계.
  *  - 원본(DB)은 절대 훼손하지 않는다. 부분 실패 허용.
  */
 
@@ -111,8 +116,17 @@ export async function syncActivities(
         }
       }
     } catch (err) {
-      if (isPreconditionFailed(err)) {
-        result.skipped++;
+      if (isPreconditionFailed(err) && mapping) {
+        // 412: ETag 불일치. 실제 사용자 수정 여부를 Google event.updated로 판별.
+        const outcome = await resolvePreconditionConflict(client, ctx.calendarId, mapping, event);
+        if (outcome === "updated") result.updated++;
+        else if (outcome === "cleaned") {
+          // 404로 내려가 mapping 정리된 경우 — 이후 sync에서 insert로 재생성
+        } else if (outcome === "failed") {
+          result.failed.push({ activityId: a.id, reason: "unknown" });
+        } else {
+          result.skipped++;
+        }
       } else if (getStatus(err) === 404 && mapping) {
         // 이벤트가 이미 삭제됨 → 매핑 정리
         await prisma.gCalEventMapping.delete({ where: { id: mapping.id } });
@@ -150,6 +164,71 @@ export async function syncActivities(
   }
 
   return result;
+}
+
+/**
+ * 412 발생 시 실제 사용자 수정 여부를 판별해 적절히 재시도하거나 skip한다.
+ *
+ * 반환:
+ *  - "updated": Google 쪽이 우리 마지막 sync 이후 수정되지 않았음 → 현재 ETag로 재-patch 성공, mapping 갱신
+ *  - "skipped": Google 쪽이 마지막 sync 이후 수정됨 → 사용자 편집 존중, 그대로 둠
+ *  - "cleaned": 404로 내려가 mapping 정리됨 (다음 sync에서 insert로 재생성)
+ *  - "failed": 복구 중 알 수 없는 에러
+ */
+async function resolvePreconditionConflict(
+  client: GCalClient,
+  calendarId: string,
+  mapping: GCalEventMapping,
+  desiredEvent: ReturnType<typeof formatActivityAsEvent>
+): Promise<"updated" | "skipped" | "cleaned" | "failed"> {
+  let currentRes;
+  try {
+    currentRes = await client.calendar.events.get({
+      calendarId,
+      eventId: mapping.googleEventId,
+    });
+  } catch (getErr) {
+    if (getStatus(getErr) === 404) {
+      await prisma.gCalEventMapping.delete({ where: { id: mapping.id } });
+      return "cleaned";
+    }
+    return "failed";
+  }
+
+  const googleUpdatedMs = currentRes.data.updated
+    ? new Date(currentRes.data.updated).getTime()
+    : 0;
+  const ourLastSyncMs = mapping.lastSyncedAt
+    ? mapping.lastSyncedAt.getTime()
+    : 0;
+  // 2초 오차 허용 — Google 내부 시각 차이·우리 서버 시계 보정.
+  const userTouchedInGoogle = googleUpdatedMs > ourLastSyncMs + 2000;
+
+  if (userTouchedInGoogle) {
+    return "skipped";
+  }
+
+  // Google 쪽은 사용자 수정 없음 → 현재 ETag로 재-patch 시도.
+  try {
+    const retryRes = await client.calendar.events.patch(
+      { calendarId, eventId: mapping.googleEventId, requestBody: desiredEvent },
+      { headers: { "If-Match": currentRes.data.etag ?? "" } }
+    );
+    if (retryRes.data.etag) {
+      await prisma.gCalEventMapping.update({
+        where: { id: mapping.id },
+        data: { syncedEtag: retryRes.data.etag, lastSyncedAt: new Date() },
+      });
+      return "updated";
+    }
+    return "failed";
+  } catch (retryErr) {
+    if (getStatus(retryErr) === 404) {
+      await prisma.gCalEventMapping.delete({ where: { id: mapping.id } });
+      return "cleaned";
+    }
+    return "failed";
+  }
 }
 
 /** 링크 해제 — 매핑된 이벤트를 모두 삭제하려 시도한다. 412면 보존. */


### PR DESCRIPTION
## 이슈

dev에서 사용자가 앱 내 활동 추가 → '다시 반영하기' 여러 번 눌러도 '직접 수정하여 건너뛴 이벤트: 1개' 고정 + 실제 Google에 반영 안됨.

## 원인

기존 412 경로는 '사용자가 GCal UI에서 수정'으로 가정했지만 실제로는:
- 이전 sync의 ETag race (DB 갱신 전 중단)
- Google 내부 메타데이터 업데이트  
- 재연결로 구 이벤트가 신 ETag 보유

등으로도 412가 발생 → 앱 내 수정이 Google로 영영 못 밀림.

## 수정

resolvePreconditionConflict() — 412 시:
1. events.get으로 현재 이벤트 조회
2. event.updated vs mapping.lastSyncedAt 비교 (2초 오차)
3. Google 미수정이면 현재 ETag로 재-patch → mapping 갱신 (updated 집계)
4. Google 수정됨이면 skipped (기존 동작)

## 검증

- [x] typecheck
- [ ] dev에서 '다시 반영하기' → skipped 0으로 떨어지고 활동이 Google 반영 확인

base: release/v2.9.0-merge. 머지 시 PR #374 자동 포함.

Refs: Epic #349, PR #374, 이전 hotfix #375 #377 #379