### PR TITLE
fix(019): 412 해소에 컨텐츠 비교 1차 판정 — 진짜 사용자 편집만 skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **v2.8.0 마이그레이션 트립의 멤버 ACL 자동 복구 + 동의 후 자동 subscribe**: 백필 SQL은 DB의 TripCalendarLink 승격만 수행하고 Google 쪽 ACL 부여는 하지 못하므로, 승격된 트립에서 멤버가 "내 구글 캘린더에 추가"를 눌러도 404로 실패하는 문제를 해소. 오너가 "다시 반영하기"를 누르면 sync 전에 현재 멤버 전원에게 ACL을 idempotent하게 upsert해 Google 쪽 권한을 복구한다. 또 멤버가 subscribe 시 calendar scope 동의를 완료하고 돌아오면 자동으로 subscribe가 재시도되도록 `?gcal=subscribed` 쿼리를 auto-retry 대상에 추가.
 - **"직접 수정하여 건너뛴 이벤트" 카운터가 누적되는 문제**: sync를 누를 때마다 동일 이벤트가 반복 카운트되어 숫자가 선형 증가하던 버그 수정. 이번 sync의 실제 건너뛴 수로 덮어쓰도록 변경(v2 sync·v1 sync·v1 link 모두). 사용자 직접 수정 이벤트가 해결되면 다음 sync에서 자동으로 0으로 리셋된다.
 - **멤버 "내 구글 캘린더에 추가" 후에도 버튼·안내문이 그대로 유지되던 UX 이슈**: 상태 응답에 본인 subscription 상태(`mySubscription`)를 함께 반환하고, 패널은 `ADDED` 상태면 "내 캘린더에 추가됨" 배지 + "제거" 단일 버튼의 컴팩트 카드로 전환한다. 오너 쪽 "연결됨" 카드와 동일한 톤.
-- **412 Precondition 처리 개선 — "건너뛴 이벤트"의 오탐 제거**: 기존에는 모든 412가 "사용자가 GCal에서 직접 수정"으로 간주되어 skipped 집계되었으나, 실제로는 이전 sync의 ETag 레이스·Google 내부 메타데이터 업데이트로도 412가 발생해 앱 내 수정이 Google로 밀리지 못하는 문제가 있었다. 412 시 Google event.updated와 mapping.lastSyncedAt을 비교해, Google 쪽이 우리 마지막 sync 이후 수정되지 않았으면 현재 ETag로 안전하게 재-patch해 DB 상태를 반영한다. Google 쪽이 이후 수정된 경우에만 skipped로 집계해 사용자 편집을 존중한다.
+- **412 Precondition 처리 개선 — "건너뛴 이벤트"의 오탐 제거**: 412 시 Google 현재 이벤트의 **컨텐츠(summary·description·location·start·end)**를 우리가 설정하려는 값과 먼저 비교한다. 같으면 ETag만 밀린 상태로 판단해 조용히 갱신(`updated`). 다를 때만 Google `updated`와 `lastSyncedAt`을 비교하여, 우리 앱 편집이면 재-patch로 밀고 Google 편집이면 `skipped`로 보존. 결과적으로 "사용자가 GCal에서 직접 수정한 경우에만" skipped에 잡힌다.
 
 ### Chore
 

--- a/src/lib/gcal/sync.ts
+++ b/src/lib/gcal/sync.ts
@@ -13,6 +13,7 @@
  *  - 원본(DB)은 절대 훼손하지 않는다. 부분 실패 허용.
  */
 
+import type { calendar_v3 } from "@googleapis/calendar";
 import { prisma } from "@/lib/prisma";
 import {
   classifyError,
@@ -167,13 +168,42 @@ export async function syncActivities(
 }
 
 /**
+ * 이벤트 컨텐츠 비교 — summary/description/location/start/end가 모두 같으면 true.
+ * Google이 내부적으로 정규화한 값(예: timeZone 표현 차이)과 우리 값의 미세 차이를
+ * 허용하기 위해 start/end는 UTC 밀리초로 비교, 문자열은 trim 비교.
+ */
+function eventContentsMatch(
+  current: calendar_v3.Schema$Event,
+  desired: ReturnType<typeof formatActivityAsEvent>
+): boolean {
+  const normStr = (s: string | null | undefined) => (s ?? "").trim();
+  if (normStr(current.summary) !== normStr(desired.summary)) return false;
+  if (normStr(current.location) !== normStr(desired.location)) return false;
+  if (normStr(current.description) !== normStr(desired.description)) return false;
+  const toMs = (v: string | null | undefined) =>
+    v ? new Date(v).getTime() : 0;
+  // desired는 dateTime만 사용. current는 all-day일 수 있어 date도 폴백.
+  const curStart = toMs(current.start?.dateTime ?? current.start?.date);
+  const desStart = toMs(desired.start.dateTime);
+  if (curStart !== desStart) return false;
+  const curEnd = toMs(current.end?.dateTime ?? current.end?.date);
+  const desEnd = toMs(desired.end.dateTime);
+  if (curEnd !== desEnd) return false;
+  return true;
+}
+
+/**
  * 412 발생 시 실제 사용자 수정 여부를 판별해 적절히 재시도하거나 skip한다.
  *
- * 반환:
- *  - "updated": Google 쪽이 우리 마지막 sync 이후 수정되지 않았음 → 현재 ETag로 재-patch 성공, mapping 갱신
- *  - "skipped": Google 쪽이 마지막 sync 이후 수정됨 → 사용자 편집 존중, 그대로 둠
- *  - "cleaned": 404로 내려가 mapping 정리됨 (다음 sync에서 insert로 재생성)
- *  - "failed": 복구 중 알 수 없는 에러
+ * 판정 순서:
+ *  1. events.get으로 현재 이벤트 조회. 404면 mapping 정리(cleaned).
+ *  2. 컨텐츠(summary/description/location/start/end)가 desiredEvent와 같으면
+ *     Google 상태가 이미 우리 의도와 일치 → 조용히 ETag 갱신(updated).
+ *  3. 컨텐츠가 다르면:
+ *     - Google updated <= 우리 lastSyncedAt + 2s → 앱 편집이 push 안 된 상태 →
+ *       현재 ETag로 재-patch (updated).
+ *     - Google updated > 우리 lastSyncedAt + 2s → 사용자가 GCal에서 편집 →
+ *       skipped (덮어쓰지 않음).
  */
 async function resolvePreconditionConflict(
   client: GCalClient,
@@ -195,20 +225,32 @@ async function resolvePreconditionConflict(
     return "failed";
   }
 
+  // 1차 판정: 컨텐츠가 이미 일치 → ETag만 밀린 상태로 판단, 조용히 refresh.
+  if (eventContentsMatch(currentRes.data, desiredEvent)) {
+    await prisma.gCalEventMapping.update({
+      where: { id: mapping.id },
+      data: {
+        syncedEtag: currentRes.data.etag ?? mapping.syncedEtag,
+        lastSyncedAt: new Date(),
+      },
+    });
+    return "updated";
+  }
+
+  // 2차 판정: 컨텐츠가 다르다. timestamp로 "누가 바꿨나" 구분.
   const googleUpdatedMs = currentRes.data.updated
     ? new Date(currentRes.data.updated).getTime()
     : 0;
   const ourLastSyncMs = mapping.lastSyncedAt
     ? mapping.lastSyncedAt.getTime()
     : 0;
-  // 2초 오차 허용 — Google 내부 시각 차이·우리 서버 시계 보정.
   const userTouchedInGoogle = googleUpdatedMs > ourLastSyncMs + 2000;
 
   if (userTouchedInGoogle) {
     return "skipped";
   }
 
-  // Google 쪽은 사용자 수정 없음 → 현재 ETag로 재-patch 시도.
+  // Google 쪽은 사용자 수정 없음 → 우리 앱 편집을 밀어넣는다 (현재 ETag로 재-patch).
   try {
     const retryRes = await client.calendar.events.patch(
       { calendarId, eventId: mapping.googleEventId, requestBody: desiredEvent },


### PR DESCRIPTION
## 이슈

hotfix #4(타임스탬프 비교) 배포 후에도 v2.8.0부터 남아있던 오래된 mapping 1건이 계속 skipped로 분류되어 앱 내 새 데이터를 Google에 반영하지 못함.

## 원인 분석

- 오래된 mapping.lastSyncedAt: v2.8.0 초기 sync (수일 전)
- Google event.updated: 그 이후 내부 메타데이터 갱신 등으로 약간 더 최근
- 타임스탬프만 비교하면 '사용자 GCal 편집'으로 오판 → skipped
- 결과: 앱 내 편집이 Google로 영영 못 밀림

## 수정

resolvePreconditionConflict 1차 판정에 **컨텐츠 비교** 추가:

1. events.get 현재 이벤트 조회 (404면 mapping 정리)
2. **컨텐츠(summary·description·location·start·end) 일치** → 조용히 ETag refresh → updated (이 케이스가 사용자 이슈)
3. 컨텐츠 다름 → 타임스탬프 비교로 누가 바꿨는지 구분 (hotfix #4 로직)

## 검증

- [x] typecheck
- [ ] dev에서 '다시 반영하기' → skipped 0 + 앱 변경 사항 Google 반영 확인

base: release/v2.9.0-merge.

Refs: Epic #349, PR #374, 이전 hotfix #375 #377 #379 #381