### PR TITLE
fix(019): 호스트도 sync 트리거 가능

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **"건너뛴 이벤트" 카운터 누적 버그**. 왜: sync마다 누적되던 `skippedCount`를 현재 run의 실제 값으로 덮어쓰도록 변경.
 - **subscribe 성공 후에도 안 바뀌는 UX**. 왜: 상태 응답에 `mySubscription`을 추가해 ADDED 상태면 컴팩트 카드(오너 "연결됨" 카드와 동일 톤)로 전환.
 - **412 오탐으로 앱 편집이 Google에 안 밀리는 문제**. 왜: 412 시 **컨텐츠 비교 → 타임스탬프 비교** 순서로 판정해, 진짜 사용자 GCal 편집일 때만 `skipped`로 남긴다.
+- **호스트가 본인 편집을 sync 트리거 못 하던 문제**. 왜: 호스트도 트립 편집 권한이 있으므로 "다시 반영하기"를 쓸 수 있도록 확장(서버는 오너 토큰으로 수행).
 
 ### Chore
 

--- a/src/app/api/v2/trips/[id]/calendar/sync/route.ts
+++ b/src/app/api/v2/trips/[id]/calendar/sync/route.ts
@@ -55,23 +55,25 @@ export async function POST(
     return NextResponse.json({ error: "bad_trip_id" }, { status: 400 });
   }
 
-  // 오너만 sync 가능.
+  // OWNER·HOST 모두 sync 트리거 가능. GUEST는 편집 권한 없어 불가.
+  // Google API는 항상 링크 오너의 토큰으로 실행된다(이벤트 데이터 오너 = 트립 오너).
   const member = await getTripMember(tripId, session.user.id);
-  if (member?.role !== TripRole.OWNER) {
-    return NextResponse.json({ error: "owner_only" }, { status: 403 });
-  }
-
-  if (!(await hasCalendarScope(session.user.id))) {
-    const body: ConsentRequired = {
-      error: "consent_required",
-      authorizationUrl: buildConsentRedirectUrl(`/trips/${tripId}?gcal=synced`),
-    };
-    return NextResponse.json(body, { status: 409 });
+  if (!member || (member.role !== TripRole.OWNER && member.role !== TripRole.HOST)) {
+    return NextResponse.json({ error: "editor_only" }, { status: 403 });
   }
 
   const link = await prisma.tripCalendarLink.findUnique({ where: { tripId } });
   if (!link) {
     return NextResponse.json({ error: "not_linked" }, { status: 404 });
+  }
+
+  // 오너가 직접 sync할 때만 본인 scope 점검. 호스트는 오너 토큰 경유라 본인 scope 무관.
+  if (member.role === TripRole.OWNER && !(await hasCalendarScope(session.user.id))) {
+    const body: ConsentRequired = {
+      error: "consent_required",
+      authorizationUrl: buildConsentRedirectUrl(`/trips/${tripId}?gcal=synced`),
+    };
+    return NextResponse.json(body, { status: 409 });
   }
 
   const trip = await prisma.trip.findUnique({
@@ -82,9 +84,10 @@ export async function POST(
     return NextResponse.json({ error: "trip_not_found" }, { status: 404 });
   }
 
-  const client = await getCalendarClient(session.user.id);
+  // 항상 링크 오너 토큰으로 Google API 호출.
+  const client = await getCalendarClient(link.ownerId);
   if (!client) {
-    return NextResponse.json({ error: "no_google_account" }, { status: 409 });
+    return NextResponse.json({ error: "owner_token_unavailable" }, { status: 502 });
   }
 
   // 현재 멤버 전원에게 ACL 재부여 (idempotent). v2.8.0 → v2.9.0 마이그레이션으로 승격된

--- a/src/components/GCalLinkPanel.tsx
+++ b/src/components/GCalLinkPanel.tsx
@@ -353,6 +353,9 @@ export default function GCalLinkPanel({ tripId, role = "OWNER" }: Props) {
   if (!isOwner) {
     const sub = status.mySubscription;
     const isAdded = sub?.status === "ADDED";
+    // HOST는 트립 편집 권한이 있으므로 sync 트리거도 허용 (서버가 오너 토큰으로 수행).
+    // GUEST는 편집 불가라 sync도 안 함.
+    const canSync = role === "HOST";
 
     return (
       <Dialog>
@@ -378,10 +381,20 @@ export default function GCalLinkPanel({ tripId, role = "OWNER" }: Props) {
               부여되어 있으며, 추가하지 않아도 앱 내 일정은 정상 이용 가능합니다.
             </p>
           )}
-          <DialogFooter>
+          {canSync && link.lastSyncedAt && (
+            <p className="text-xs text-muted-foreground">
+              마지막 반영: {new Date(link.lastSyncedAt).toLocaleString("ko-KR")}
+            </p>
+          )}
+          <DialogFooter className="gap-2 flex-wrap">
             <DialogClose className={cn(buttonVariants({ variant: "ghost", size: "sm" }))}>
               닫기
             </DialogClose>
+            {canSync && (
+              <Button size="sm" variant="outline" onClick={() => void handleSync()} disabled={busy}>
+                다시 반영하기
+              </Button>
+            )}
             {isAdded ? (
               <Button
                 size="sm"


### PR DESCRIPTION
## What\n\n호스트 다이얼로그에 '다시 반영하기' 버튼 추가. v2 sync 엔드포인트가 OWNER+HOST를 허용.\n\n## Why\n\n호스트가 편집한 일정을 Google에 반영할 방법이 없어 오너 접속을 기다려야 했음. 서버는 오너의 저장된 토큰을 사용하므로 호스트 본인의 scope는 불필요.\n\n## 동작\n\n- 호스트가 앱에서 일정 추가/수정 → 캘린더 버튼 → 다이얼로그 → '다시 반영하기'\n- 서버: OWNER/HOST 가드 통과 → 오너 토큰으로 Google API 호출\n- GUEST는 여전히 sync 불가 (편집 권한 없음)\n\nRefs: PR #374