### PR TITLE
chore(413): WORKFLOW 현실화 + main→develop 자동 sync 워크플로우 도입

### DIFF
--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -1,0 +1,81 @@
+name: Sync main → develop
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.AUTO_TAG_PAT }}
+
+      - name: develop과의 diff 확인
+        id: diff
+        run: |
+          git fetch origin develop
+          if git diff --quiet origin/develop origin/main; then
+            echo "has_diff=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_diff=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: 이미 열린 sync PR 확인
+        id: existing
+        if: steps.diff.outputs.has_diff == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AUTO_TAG_PAT }}
+        run: |
+          OPEN_PR=$(gh pr list --base develop --search "head:sync/main-to-develop" --state open --json number --jq '.[0].number // empty')
+          if [[ -n "$OPEN_PR" ]]; then
+            echo "open_pr=$OPEN_PR" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: sync 브랜치 생성 + main 머지
+        if: steps.diff.outputs.has_diff == 'true' && steps.existing.outputs.open_pr == ''
+        id: branch
+        run: |
+          SHORT_SHA=$(git rev-parse --short origin/main)
+          BRANCH="sync/main-to-develop-${SHORT_SHA}"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git switch -c "$BRANCH" origin/develop
+          git merge origin/main --no-ff -m "Merge main into develop — sync ${SHORT_SHA}
+
+          자동 생성 sync PR (.github/workflows/sync-main-to-develop.yml).
+          release/* → main 직접 머지 패턴에서 develop이 자동 sync되지 않는 갭 해소."
+          git push origin "$BRANCH"
+
+      - name: sync PR 생성 + chore-no-news 라벨
+        if: steps.diff.outputs.has_diff == 'true' && steps.existing.outputs.open_pr == ''
+        env:
+          GH_TOKEN: ${{ secrets.AUTO_TAG_PAT }}
+        run: |
+          gh pr create \
+            --base develop \
+            --head "${{ steps.branch.outputs.branch }}" \
+            --label "chore-no-news" \
+            --title "sync: main → develop (자동, ${{ steps.branch.outputs.branch }})" \
+            --body "main에 새 변경(release 또는 hotfix 머지)이 들어와 develop과 분기됨. 본 PR은 자동 생성된 sync PR이며 \`docs/WORKFLOW.md\`의 \"main→develop 역머지 (자동)\" 섹션에 따라 개발자가 수동 머지한다.
+
+          - 트리거: main push (\`${{ github.sha }}\`)
+          - 워크플로우: \`.github/workflows/sync-main-to-develop.yml\`
+          - 자동 머지 비활성 — CI 게이트 통과 후 사람이 머지"
+
+      - name: 이미 열린 sync PR이 있을 때 skip 사유
+        if: steps.diff.outputs.has_diff == 'true' && steps.existing.outputs.open_pr != ''
+        run: |
+          echo "기존 열린 sync PR #${{ steps.existing.outputs.open_pr }}이 있어 skip. 머지 후 다시 트리거되어 보강 sync 가능."
+
+      - name: diff 없을 때 skip 사유
+        if: steps.diff.outputs.has_diff == 'false'
+        run: echo "main과 develop이 동일 — sync 불필요."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@
 ### 필수: feature → develop PR
 - 모든 코드 변경은 feature 브랜치 → develop PR로 진행한다
 - main, develop 브랜치에 직접 push 금지 (`enforce_admins: true`)
-- feature 브랜치 → develop PR → 머지 → 마일스톤 완료 시 develop → main PR
+- feature 브랜치 → develop PR → 머지 → 마일스톤 완료 시 release/vX.Y.Z → main PR (release 브랜치 패턴 v2.7.0+)
 
 ### 브랜치 최신화
 - feature 브랜치 작업 전 반드시 `git pull origin develop`으로 최신화
@@ -42,7 +42,8 @@ develop ──●──●──●───●──●──●──●──
 | PR 방향 | 머지 방식 | 이유 |
 |---------|----------|------|
 | feature/hotfix → develop | **Create a merge commit** | 커밋 조절은 개발자가 feature 브랜치에서 직접(push 전 `git rebase -i` 등). AI 하네스로 커밋을 관리하는 상황에서 웹의 수동 squash는 단순 합치기일 뿐 메시지가 의미에 맞게 재구성되지 않음 |
-| develop → main | **Create a merge commit** | 커밋 해시 보존, 역머지 시 충돌 방지 |
+| release/vX.Y.Z → main | **Create a merge commit** | 커밋 해시 보존, 자동 sync PR(main → develop)이 같은 머지 커밋을 다시 흡수해 충돌 방지 |
+| sync/main-to-develop-* → develop | **Create a merge commit** | release 직후 자동 생성된 sync PR (`.github/workflows/sync-main-to-develop.yml`) |
 
 > 커밋 수가 많아 정리가 필요하면 feature 브랜치에서 rebase/amend로 직접 정돈한 뒤 push한다. 웹 UI의 squash는 사용하지 않는다.
 
@@ -65,16 +66,18 @@ develop ──●──●──●───●──●──●──●──
 3. 마일스톤의 모든 이슈가 develop에 머지될 때까지 반복
 
 **릴리즈 (마일스톤 완료 시)**:
-1. release 브랜치에서 `uv run towncrier build --version X.Y.Z --yes` 실행
+1. `release/vX.Y.Z` 브랜치를 develop에서 분기
+2. `uv run towncrier build --version X.Y.Z --yes` 실행
    - `changes/*.md` 단편이 자동으로 `CHANGELOG.md`에 합쳐지고 단편은 삭제됨
    - 미리보기는 `--draft` 옵션
-2. `pyproject.toml`의 `version` 필드를 동일 X.Y.Z로 범프
-3. develop → main PR 생성 → 머지
+3. `pyproject.toml`의 `version` 필드를 동일 X.Y.Z로 범프
+4. release/vX.Y.Z → main PR 생성 → 머지 (`chore-no-news` 라벨 부착 — 단편이 이미 소비됐으므로)
 
 **CI 자동 (main 머지 후)**:
-4. `auto-tag.yml`: pyproject.toml 변경 감지 → annotated 태그 생성
-5. `auto-release.yml`: 태그 push → CHANGELOG 추출 → GitHub Release 생성
-6. `pypi-publish.yml`: 태그 push → 테스트 → PyPI 배포
+5. `auto-tag.yml`: pyproject.toml 변경 감지 → annotated 태그 생성
+6. `auto-release.yml`: 태그 push → CHANGELOG 추출 → GitHub Release 생성
+7. `pypi-publish.yml`: 태그 push → 테스트 → PyPI 배포
+8. `sync-main-to-develop.yml`: main과 develop diff 확인 → 차이 있으면 sync PR 자동 생성. 개발자가 PR 확인 후 수동 머지(자동 머지 아님)
 
 **버전 범프 기준 (SemVer)**:
 - MAJOR: 호환성 깨지는 변경 (API 스키마 변경, MCP 도구 삭제 등). 단편 타입 `breaking`
@@ -85,9 +88,9 @@ develop ──●──●──●───●──●──●──●──
 1. develop에서 `hotfix/*` 브랜치 생성
 2. 수정 + `changes/<이슈>.fix.md` 단편 추가
 3. hotfix → develop PR → 머지 → dev 환경 확인
-4. release 단계(towncrier build + 버전 PATCH 범프) 수행
-5. develop → main PR → 머지 → CI 자동 릴리즈
-6. main 직접 머지 금지 — dev 환경 검증 필수
+4. release 단계(`release/vX.Y.PATCH` 분기 + towncrier build + 버전 PATCH 범프) 수행
+5. release/vX.Y.PATCH → main PR → 머지 → CI 자동 릴리즈 + 자동 sync PR
+6. main 직접 push 금지 — dev 환경 검증 필수
 
 **마일스톤 정책**:
 - 모든 이슈는 마일스톤 필수 (마일스톤 = 버전 단위)

--- a/changes/413.docs.md
+++ b/changes/413.docs.md
@@ -1,0 +1,1 @@
+**WORKFLOW 현실화 + main→develop 자동 sync 워크플로우 도입**: v2.7.0 이후 정착된 `release/* → main 직접 머지` 패턴을 CLAUDE.md·docs/WORKFLOW.md에 명문화하고, release 머지 직후 sync PR을 자동 생성하는 GitHub Actions(`sync-main-to-develop.yml`)를 추가. 왜: 매 릴리즈마다 main이 develop보다 앞서고, 누군가 수동으로 sync PR을 만들지 않으면 다음 작업이 누락 베이스 위에서 시작되는 구조적 마찰이 반복됐다.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -112,9 +112,20 @@ Git Flow Lite. `main`은 프로덕션 유일 정본(태그 부여), `develop`은
    - `auto-release.yml` — 태그 push → CHANGELOG 추출 → GitHub Release 생성.
    - `pypi-publish.yml` — 태그 push → 테스트 → PyPI 배포.
 
-### main→develop 역머지
+### main→develop 역머지 (자동)
 
-`main`은 merge commit만 쌓이고 콘텐츠는 release 브랜치와 동일하다. 따라서 기본적으로 역머지는 불필요. `sync/main-to-develop-*` 브랜치는 기록용으로만 남는다.
+v2.7.0부터 운영 패턴은 **`release/vX.Y.Z` → `main` 직접 머지**다. release 브랜치가 `develop` 위에서 갈라져 나오기 때문에 release 머지 직후 `main`이 `develop`보다 앞선 상태가 된다 — develop 자동 sync는 일어나지 않는다.
+
+이 갭을 그대로 두면 다음 develop 기반 작업이 누락 베이스 위에서 시작(towncrier build 충돌, 스펙 메타 누락 등). v2.7.0~v2.10.0 사이 22커밋 분 부채가 한 번에 해소된 사례(#408)가 그 예.
+
+따라서 **`main` 머지 직후 자동으로 `sync/main-to-develop-*` PR이 생성**된다 (`.github/workflows/sync-main-to-develop.yml`):
+
+- 트리거: `main` push (release/* 또는 어떤 PR이든 머지 직후)
+- 동작: `main`과 `origin/develop` diff 확인 → 차이가 있으면 `sync/main-to-develop-<sha>` 브랜치 생성 + main 머지 + sync PR 자동 생성 + `chore-no-news` 라벨 부착
+- diff 없으면 skip (무한 루프 방지)
+- 자동 머지는 하지 않음 — 개발자가 PR 확인 후 수동 머지 (CI 게이트와 게이트 원칙 유지)
+
+수동 sync 필요 시(예: 워크플로우 일시 비활성화) `git switch -c sync/main-to-develop-<설명> origin/develop && git merge origin/main --no-ff` → push → PR 으로 동일 효과.
 
 ## 디자이너 협업 흐름
 
@@ -213,17 +224,20 @@ dev.trip.idean.me 환경에서 검증             ← 반드시 검증
         ↓
 release 단계 (towncrier build + PATCH 범프)
         ↓
-develop → main PR → 머지
+release/vX.Y.Z → main PR → 머지
         ↓
 CI 자동 릴리즈 (tag·GitHub Release·PyPI)
+        ↓
+자동 sync PR (main → develop) 생성 → 개발자 머지
 ```
 
 핵심 원칙:
 
-- **`main` 직접 머지 금지**. dev 환경 검증 필수.
+- **`main` 직접 push 금지**. release/* 또는 hotfix가 PR을 거쳐야 하며, dev 환경 검증 필수.
 - **단편 생략 금지**. 긴급해도 `changes/<이슈>.fix.md` 1개는 추가.
 - **피처와 동일한 CI 게이트 통과**. 핫픽스라는 이유로 검증을 건너뛰지 않는다.
 - **이슈 번호 필수**. "자명한 버그도 즉시 처리"가 원칙이지만 이슈 자체는 생성한다(추적성).
+- **release 머지 후 자동 sync PR 머지**. main에 들어간 변경이 develop으로 흘러가야 다음 작업이 누락 베이스 위에서 시작하지 않는다.
 
 ---
 
@@ -232,3 +246,4 @@ CI 자동 릴리즈 (tag·GitHub Release·PyPI)
 본 문서는 **구조적으로 업데이트되는 살아있는 정본**이다. 운영상 변경(정책·도구·규약 추가)이 있을 때마다 본 문서를 먼저 갱신하고 다른 문서(CLAUDE.md·DEVELOPMENT.md·README.md)를 그에 맞춰 조정한다.
 
 - 2026-04-19 초판 — v2.4.3(#270) 디자인 시스템 기반 제정과 함께 도입. 기존 CLAUDE.md의 Git 워크플로우·릴리즈·핫픽스 섹션을 흡수 정리.
+- 2026-04-27 (#413) — v2.7.0 이후 정착된 `release/* → main 직접 머지` 패턴을 명문화. `main → develop` 역머지 자동 sync 워크플로우(`.github/workflows/sync-main-to-develop.yml`) 도입.


### PR DESCRIPTION
Closes #413

## 요약

v2.7.0 이후 정착된 \`release/* → main 직접 머지\` 패턴을 명문화하고, release 머지 직후 sync PR을 자동 생성하는 GitHub Actions를 추가. 매 릴리즈마다 main이 develop보다 앞서서 누군가 수동으로 sync PR을 만들어야 하는 구조적 마찰을 해소.

## 변경 분류

### 문서 갱신
- **CLAUDE.md**: 릴리즈 프로세스 / PR 머지 전략 / 핫픽스 섹션을 실제 패턴으로 정정
- **docs/WORKFLOW.md**: \"main→develop 역머지\" 섹션을 자동화 안내로 갱신, 핫픽스 흐름도 정정, 변경 이력 추가

### 자동화
- **\`.github/workflows/sync-main-to-develop.yml\` 신설**
  - 트리거: main push (release/* 또는 hotfix 머지 직후)
  - 동작: main↔develop diff 확인 → \`sync/main-to-develop-<sha>\` 브랜치 생성 + main 머지 + sync PR 자동 생성 + \`chore-no-news\` 라벨
  - 자동 머지 비활성 — 개발자가 PR 확인 후 수동 머지 (게이트 원칙 유지)
  - 무한 루프 방지: diff 없으면 skip, 기존 열린 sync PR 있으면 skip

## 발효 시점

워크플로우 파일은 main에 도달해야 작동. 본 PR이 develop에 머지된 뒤 **다음 release(v2.10.2 또는 v2.11.0) 때 main에 도달 → 그 다음 main push부터 자동 sync 작동**. 그 전까지는 메모리·문서 갱신본대로 수동 sync.

## 후속 (다음 정리 회차)

- spec 020 T008 누락 테스트 작성
- 서브도메인 README (collaboration / export / itinerary / travel-search) 신규
- CLAUDE.md \"Active Technologies\" 섹션 통합 (현재 90줄+ 반복)

🤖 Generated with [Claude Code](https://claude.com/claude-code)