### PR TITLE
fix(420): GCalLinkPanel flaky 테스트 timeout 안정화

### DIFF
--- a/changes/420.fix.md
+++ b/changes/420.fix.md
@@ -1,0 +1,1 @@
+**`GCalLinkPanel` 미등록 분기 테스트 flaky 안정화**: CI coverage 환경에서 base-ui Dialog portal 마운트 지연으로 timeout이 부족하던 단위 테스트의 timeout을 늘림. 사용자 가시 변경 0. 왜: PR #418/#419 머지 시 develop CI에서 일관 실패 → 재실행으로만 통과되던 패턴을 구조적으로 해소.

--- a/tests/components/GCalLinkPanel.test.tsx
+++ b/tests/components/GCalLinkPanel.test.tsx
@@ -88,10 +88,21 @@ describe("GCalLinkPanel — spec 021 Testing 모드 미등록 UI", () => {
     render(<GCalLinkPanel tripId={5} role={role} />);
 
     // 역할별 초기 트리거 클릭 → API 호출 발생(미등록 에러).
+    // CI coverage 환경에서 base-ui Dialog portal 마운트 지연으로 default 1000ms timeout
+    // 내 CTA를 못 찾는 flaky 발생 (#420 — PR #418/#419 머지 시 develop CI 관찰).
+    // findByRole timeout 3000ms로 늘려 안정화.
     if (role === "OWNER") {
-      const trigger = await screen.findByRole("button", { name: "구글 캘린더 연결" });
+      const trigger = await screen.findByRole(
+        "button",
+        { name: "구글 캘린더 연결" },
+        { timeout: 3000 },
+      );
       fireEvent.click(trigger);
-      const cta = await screen.findByRole("button", { name: "공유 캘린더 연결" });
+      const cta = await screen.findByRole(
+        "button",
+        { name: "공유 캘린더 연결" },
+        { timeout: 3000 },
+      );
       fireEvent.click(cta);
     } else {
       const trigger = await screen.findByRole("button", { name: /구글 캘린더 \(공유\)/ });


### PR DESCRIPTION
Closes #420

CI coverage 환경에서 base-ui Dialog portal 지연으로 default timeout 안에 CTA를 못 찾던 flaky 안정화. \`findByRole\` timeout 3000ms로 증가.

PR #418/#419 머지 직후 develop CI 일관 실패 → 재실행으로만 통과되던 패턴 구조적 해소.

검증 의미는 동일. UI/사용자 가시 변경 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)