### PR TITLE
fix(425): sync 워크플로우 GITHUB_TOKEN 사용 — PR 생성 권한 fix

### DIFF
--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.AUTO_TAG_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: develop과의 diff 확인
         id: diff
@@ -31,7 +31,7 @@ jobs:
         id: existing
         if: steps.diff.outputs.has_diff == 'true'
         env:
-          GH_TOKEN: ${{ secrets.AUTO_TAG_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           OPEN_PR=$(gh pr list --base develop --search "head:sync/main-to-develop" --state open --json number --jq '.[0].number // empty')
           if [[ -n "$OPEN_PR" ]]; then
@@ -58,7 +58,7 @@ jobs:
       - name: sync PR 생성 + chore-no-news 라벨
         if: steps.diff.outputs.has_diff == 'true' && steps.existing.outputs.open_pr == ''
         env:
-          GH_TOKEN: ${{ secrets.AUTO_TAG_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr create \
             --base develop \

--- a/changes/425.fix.md
+++ b/changes/425.fix.md
@@ -1,0 +1,1 @@
+**자동 sync 워크플로우 PR 생성 권한 fix**: `secrets.AUTO_TAG_PAT` → `secrets.GITHUB_TOKEN` 교체. 왜: PAT에 `pull-requests: write` 미부여로 v2.10.2 첫 발효에서 PR 생성 단계만 실패. workflow의 `permissions: pull-requests: write`가 GITHUB_TOKEN에 자동 적용되어 PAT 의존 제거.


### PR DESCRIPTION
Closes #425. v2.10.2 자동 sync 첫 발효의 PR 생성 단계 실패 fix. main 도달 시점은 v2.10.3 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)