### PR TITLE
sync: main → develop (v2.10.3 — 자동 워크플로우 PR 생성 단계만 수동)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## [2.10.3] - 2026-04-27
+
+### Fixed
+
+- **자동 sync 워크플로우 PR 생성 권한 fix**: `secrets.AUTO_TAG_PAT` → `secrets.GITHUB_TOKEN` 교체. 왜: PAT에 `pull-requests: write` 미부여로 v2.10.2 첫 발효에서 PR 생성 단계만 실패. workflow의 `permissions: pull-requests: write`가 GITHUB_TOKEN에 자동 적용되어 PAT 의존 제거. ([#425](https://github.com/idean3885/trip-planner/issues/425))
+
+
 ## [2.10.2] - 2026-04-27
 
 ### Added

--- a/changes/425.fix.md
+++ b/changes/425.fix.md
@@ -1,1 +1,0 @@
-**자동 sync 워크플로우 PR 생성 권한 fix**: `secrets.AUTO_TAG_PAT` → `secrets.GITHUB_TOKEN` 교체. 왜: PAT에 `pull-requests: write` 미부여로 v2.10.2 첫 발효에서 PR 생성 단계만 실패. workflow의 `permissions: pull-requests: write`가 GITHUB_TOKEN에 자동 적용되어 PAT 의존 제거.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trip-planner-mcp"
-version = "2.10.2"
+version = "2.10.3"
 description = "여행 숙소, 항공편, 관광지 검색 + 구조화 활동 관리 MCP 서버 (20개 도구)"
 requires-python = ">=3.10"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1015,7 +1015,7 @@ wheels = [
 
 [[package]]
 name = "trip-planner-mcp"
-version = "2.10.1"
+version = "2.10.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
v2.10.3 release 후 자동 sync 워크플로우 두 번째 발효. 브랜치 push는 정상, PR 생성에서 'GitHub Actions is not permitted to create or approve pull requests' 에러 — 레포 설정 변경 필요(이슈 #428).

🤖 Generated with [Claude Code](https://claude.com/claude-code)