### PR TITLE
feat(417): Apple iCloud CalDAV provider 토대 (foundation)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,7 @@
 RAPIDAPI_KEY=your_rapidapi_key_here
 RAPIDAPI_HOST=booking-com15.p.rapidapi.com
+
+# spec 025 (#417) — Apple iCloud CalDAV provider
+# 32바이트 base64 인코딩 키. dev/preview/production 별도 키 사용.
+# 생성: openssl rand -base64 32
+APPLE_PASSWORD_ENCRYPTION_KEY=your_32_byte_base64_key_here

--- a/changes/417.feat.md
+++ b/changes/417.feat.md
@@ -1,0 +1,1 @@
+**Apple iCloud CalDAV provider 토대 도입** — `appleProvider` 객체, AES-256-GCM 암호화 모듈, `tsdav` 라이브러리 wrapper, ICS VEVENT 변환, `AppleCalendarCredential` 신규 테이블. 왜: 두 번째 캘린더 provider 정식 도입의 토대 — 위자드·라우트·sync 분해는 후속 PR로 분리해 회귀 위험을 단계적으로 관리.

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.1.16",
+        "tsdav": "^2.1.8",
         "tw-animate-css": "^1.4.0"
       },
       "devDependencies": {
@@ -5536,6 +5537,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
+      "license": "MIT"
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -6200,6 +6207,57 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cross-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/cross-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/cross-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -13040,6 +13098,15 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -14138,6 +14205,21 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/tsdav": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/tsdav/-/tsdav-2.1.8.tgz",
+      "integrity": "sha512-zvQvhZLzTaEmNNgJbBlUYT/JOq9Xpw/xkxCqs7IT2d2/7o7pss0iZOlZXuHJ5VcvSvTny42Vc6+6GyzZcrCJ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "base-64": "1.0.0",
+        "cross-fetch": "4.1.0",
+        "debug": "4.4.3",
+        "xml-js": "1.6.11"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -15160,6 +15242,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.1.16",
+    "tsdav": "^2.1.8",
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {

--- a/prisma/migrations/20260427000000_add_apple_credentials/migration.sql
+++ b/prisma/migrations/20260427000000_add_apple_credentials/migration.sql
@@ -1,0 +1,22 @@
+-- [migration-type: schema-only]
+-- spec 025 (#417) — Apple iCloud CalDAV 자격증명 테이블.
+-- 1 user 1 row (userId @id). user 삭제 시 cascade로 자동 정리.
+-- AES-256-GCM 암호문은 base64(ciphertext + 16바이트 auth tag) 단일 컬럼에 저장.
+-- IV는 row마다 12바이트 생성, base64로 보관.
+
+CREATE TABLE "apple_calendar_credentials" (
+    "user_id" TEXT NOT NULL,
+    "apple_id" TEXT NOT NULL,
+    "encrypted_password" TEXT NOT NULL,
+    "iv" TEXT NOT NULL,
+    "last_validated_at" TIMESTAMPTZ(3),
+    "last_error" TEXT,
+    "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3) NOT NULL,
+
+    CONSTRAINT "apple_calendar_credentials_pkey" PRIMARY KEY ("user_id")
+);
+
+-- foreign key (cascade)
+ALTER TABLE "apple_calendar_credentials" ADD CONSTRAINT "apple_calendar_credentials_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,7 @@ model User {
   gcalLinks                   GCalLink[]
   ownedCalendarLinks          TripCalendarLink[]           @relation("TripCalendarLinkOwner")
   memberCalendarSubscriptions MemberCalendarSubscription[] @relation("MemberCalendarSubscriptionUser")
+  appleCalendarCredential     AppleCalendarCredential?     @relation("AppleCalendarCredentialUser")
 
   @@map("users")
 }
@@ -290,6 +291,22 @@ model TripCalendarEventMapping {
   @@unique([tripCalendarLinkId, activityId])
   @@index([tripCalendarLinkId])
   @@map("trip_calendar_event_mappings")
+}
+
+// spec 025 (#417) — Apple iCloud CalDAV 자격증명. AES-256-GCM 암호화된 app-specific password 저장.
+model AppleCalendarCredential {
+  userId            String    @id @map("user_id")
+  appleId           String    @map("apple_id")
+  encryptedPassword String    @map("encrypted_password") // base64(ciphertext + auth tag)
+  iv                String                               // base64(12바이트 random)
+  lastValidatedAt   DateTime? @map("last_validated_at") @db.Timestamptz(3)
+  lastError         String?   @map("last_error")
+  createdAt         DateTime  @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt         DateTime  @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  user User @relation("AppleCalendarCredentialUser", fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("apple_calendar_credentials")
 }
 
 model MemberCalendarSubscription {

--- a/specs/025-apple-caldav-provider/plan.md
+++ b/specs/025-apple-caldav-provider/plan.md
@@ -10,7 +10,7 @@
 ## Coverage Targets
 
 - `tsdav` 2.x 채택 + Apple CalDAV 클라이언트 wrapper 도입 [why: caldav-client] [multi-step: 2]
-- DB expand: `AppleCalendarCredential` 신규 테이블 + `TripCalendarEventMapping.etag` 컬럼 활용 [why: db-credential] [multi-step: 2]
+- DB expand: `AppleCalendarCredential` 신규 테이블 신설 + 기존 `TripCalendarEventMapping`의 etag 필드 재사용(신규 추가 없음) [why: db-credential] [multi-step: 2]
 - AES-256-GCM 암호화 모듈 + env 키 검증 [why: crypto]
 - `appleProvider` 객체 — `CalendarProvider` 인터페이스의 모든 메서드 구현 [why: provider-impl] [multi-step: 4]
 - 위자드 UI(`AppleConnectWizard`) Step 1~7 가이드 + 검증 진입 [why: wizard-ui] [multi-step: 3]
@@ -340,7 +340,15 @@ tests/
 **Risk**: 사용자가 가이드 6단계를 완수 못 하고 이탈.
 **Mitigation**: 각 Step에 캡쳐 + appleid.apple.com 직접 링크 + 30초 스크린캐스트. Step 7 캡쳐는 본 피처 구현 후 추가.
 
-### R4 — 암호화 키 분실
+### R4 — createCalendar의 calendar-home URL 추정 휴리스틱
+**Risk**: `fetchCalendars` 응답의 첫 항목 URL에서 마지막 segment를 제거해 calendar-home URL을 추정한다. 신규 iCloud 계정으로 캘린더가 0건이거나 URL 구조가 달라지면 createCalendar가 throw 또는 잘못된 URL 반환.
+**Mitigation**: foundation PR 후 위자드 PR 통합 테스트에서 실 dev 환경 측정. 0건 케이스는 위자드 UI에서 "Apple Calendar 앱에서 기본 캘린더를 한 번 만들어 주세요" 안내로 분기. 후속 회차에서 PROPFIND `calendar-home-set`을 직접 조회하는 패턴으로 교체 검토.
+
+### R5 — MKCALENDAR props XML 직렬화
+**Risk**: `supported-calendar-component-set` props가 tsdav `xml-js` compact 형식으로 작성되어 있다. iCloud가 이 props를 올바르게 처리하는지 POC #345에서 props 없는 단순 MKCALENDAR만 검증됐을 가능성이 있다. 잘못 직렬화되면 VEVENT 미지원 캘린더가 생성되어 이후 PUT이 실패할 수 있다.
+**Mitigation**: 위자드 통합 테스트에서 생성된 캘린더의 supported-component-set을 PROPFIND로 검증. 실패 시 props 단순화(displayname만) + iCloud 기본 component-set에 의존.
+
+### R6 — 암호화 키 분실
 **Risk**: `APPLE_PASSWORD_ENCRYPTION_KEY` 분실/유출 시 모든 credential 복호화 불가 또는 노출.
 **Mitigation**: dev/preview/production 별도 키. Vercel env에만 저장. 키 회전 시 전체 재암호화 스크립트(별도 후속 — 본 피처는 키 1개 운영 가정).
 

--- a/specs/025-apple-caldav-provider/spec.md
+++ b/specs/025-apple-caldav-provider/spec.md
@@ -15,7 +15,7 @@ POC #345로 Apple iCloud CalDAV 연동의 핵심 동작이 실측 검증됐다(M
 
 1. **자동 캘린더 생성을 1순위, "기존 선택"은 고급 옵션** — POC 측정 #3에서 MKCALENDAR가 201 Created로 작동 확인. 사용자에겐 기본 액션 "trip-planner 전용 캘린더 자동 생성"만 노출하고, MKCALENDAR 실패 시에만 "기존 캘린더에 추가" 보조 옵션이 나타난다. VEVENT 컴포넌트가 없는 캘린더(미리 알림 등)는 목록에서 자동 제외(POC 추가 발견 B).
 
-2. **인증 정보 암호화는 단일 대칭키 (AES-256-GCM)** — Vercel env에 `APPLE_PASSWORD_ENCRYPTION_KEY`(32바이트 base64) 단 하나를 두고 Node `crypto`로 password 컬럼을 암호화한다. IV는 row마다 12바이트 생성·저장. 키 회전 시 전체 재암호화 필요(1인 운영·수십 명 규모에서 수동 회전 가능). 사용자 1000명 규모 도달 시 envelope encryption 도입 검토. 근거: POC 의사결정 #4 + ADR-0002(라이브러리 우선/비용 최소).
+2. **인증 정보 암호화는 단일 대칭키 (AES-256-GCM)** — 배포 환경 변수에 `APPLE_PASSWORD_ENCRYPTION_KEY`(32바이트 base64) 단 하나를 두고 표준 라이브러리로 password 컬럼을 암호화한다. IV는 row마다 12바이트 생성·저장. 키 회전 시 전체 재암호화 필요(1인 운영·수십 명 규모에서 수동 회전 가능). 사용자 1000명 규모 도달 시 envelope encryption 도입 검토. 근거: POC 의사결정 #4 + ADR-0002(라이브러리 우선/비용 최소).
 
 3. **에러 알림 채널은 401 즉시 UI 배너 + 그 외 일시 오류 무음** — POC 측정 #8에서 401이 즉시 반환됨 확인. 401은 사용자가 폐기·재발급한 경우 또는 Apple ID 비밀번호 변경(#10) 후 일괄 무효화된 경우. 두 케이스 모두 사용자 액션 필요 → 즉시 UI 배너로 안내 + 재인증 링크. 그 외 일시 오류(네트워크·5xx·rate limit)는 무음 처리하고 다음 sync에서 자동 재시도. Google과 동일 톤 유지.
 
@@ -118,7 +118,7 @@ trip 활동을 ICS VEVENT로 변환해 PUT. 응답 ETag를 `TripCalendarEventMap
 `appleProvider.classifyError`가 다음 매핑을 수행:
 - 401 → `auth_invalid`
 - 412 → `precondition_failed`
-- 5xx · 네트워크 · timeout → `transient_failure`
+- 429 (rate limit) · 5xx · 네트워크 · timeout → `transient_failure`
 - 그 외 → `null`
 
 `unregistered_user`/`already_linked`/`revoked`는 Apple에 해당 없음 → 항상 null.
@@ -166,7 +166,7 @@ Apple link trip의 멤버 가입·역할 변경·탈퇴 훅에서 `appleProvider
 
 ## Key Entities *(mandatory)*
 
-- **AppleCalendarCredential** (신규 테이블) — userId(FK User, unique) · appleId · encryptedPassword · iv · createdAt · lastValidatedAt · lastError. 1 user 1 row.
+- **AppleCalendarCredential** (신규 테이블) — userId(FK User, @id) · appleId · encryptedPassword · iv · createdAt · updatedAt · lastValidatedAt · lastError. 1 user 1 row.
 - **TripCalendarLink** (기존, 신규 컬럼 없음) — provider 컬럼은 #416에서 추가됨. Apple link는 `provider == "APPLE"` + calendarId가 CalDAV 캘린더 URL.
 - **TripCalendarEventMapping** (기존, `etag` 컬럼 추가) — Google은 syncedEtag 사용 중. Apple은 같은 컬럼 재사용.
 

--- a/specs/025-apple-caldav-provider/tasks.md
+++ b/specs/025-apple-caldav-provider/tasks.md
@@ -18,8 +18,8 @@ description: "Task list for #417 apple-caldav-provider (025)"
 
 **Purpose**: 신규 의존성 + env 키 + 디렉토리 준비
 
-- [ ] T001 `tsdav@^2.1.8` 의존성 추가 (`pnpm add tsdav` 또는 npm). package.json + lockfile 갱신 [artifact: package.json] [why: caldav-client]
-- [ ] T002 env `APPLE_PASSWORD_ENCRYPTION_KEY` 추가 — dev/preview/production 별도 32바이트 base64. Vercel env에 저장 + .env.example 갱신 [artifact: .env.example] [why: crypto]
+- [x] T001 `tsdav@^2.1.8` 의존성 추가 (`pnpm add tsdav` 또는 npm). package.json + lockfile 갱신 [artifact: package.json] [why: caldav-client]
+- [x] T002 env `APPLE_PASSWORD_ENCRYPTION_KEY` 추가 — dev/preview/production 별도 32바이트 base64. 배포 환경 변수에 저장 + .env.example 갱신 [artifact: .env.example] [why: crypto]
 
 ---
 
@@ -27,11 +27,11 @@ description: "Task list for #417 apple-caldav-provider (025)"
 
 **Purpose**: DB 마이그레이션 + 암호화 모듈 + tsdav wrapper. US1 진행 전 모두 완료 필요.
 
-- [ ] T003 Prisma schema — `AppleCalendarCredential` 모델 추가 (userId @id @relation User, appleId, encryptedPassword, iv, createdAt, updatedAt, lastValidatedAt, lastError) [artifact: prisma/schema.prisma::AppleCalendarCredential] [why: db-credential]
-- [ ] T004 마이그레이션 SQL — `apple_calendar_credentials` 테이블 생성 [artifact: prisma/migrations/20260427000000_add_apple_credentials/migration.sql] [why: db-credential] [migration-type: schema-only]
-- [ ] T005 [P] 암호화 모듈 — `encryptPassword(plaintext)` / `decryptPassword(ciphertext, iv)`. AES-256-GCM, env 키 32바이트 검증 [artifact: src/lib/calendar/provider/apple-crypto.ts] [why: crypto]
-- [ ] T006 [P] tsdav wrapper — `createAppleClient({ appleId, appPassword })` 단일 진입점 [artifact: src/lib/calendar/provider/apple-client.ts] [why: caldav-client]
-- [ ] T007 [P] ICS 변환 — `formatActivityAsIcs(activity, trip, ctx)` Activity → VEVENT ICS 문자열 [artifact: src/lib/calendar/ics.ts] [why: sync-delegate]
+- [x] T003 Prisma schema — `AppleCalendarCredential` 모델 추가 (userId @id @relation User, appleId, encryptedPassword, iv, createdAt, updatedAt, lastValidatedAt, lastError) [artifact: prisma/schema.prisma::AppleCalendarCredential] [why: db-credential]
+- [x] T004 마이그레이션 SQL — `apple_calendar_credentials` 테이블 생성 [artifact: prisma/migrations/20260427000000_add_apple_credentials/migration.sql] [why: db-credential] [migration-type: schema-only]
+- [x] T005 [P] 암호화 모듈 — `encryptPassword(plaintext)` / `decryptPassword(ciphertext, iv)`. AES-256-GCM, env 키 32바이트 검증 [artifact: src/lib/calendar/provider/apple-crypto.ts] [why: crypto]
+- [x] T006 [P] tsdav wrapper — `createAppleClient({ appleId, appPassword })` 단일 진입점 [artifact: src/lib/calendar/provider/apple-client.ts] [why: caldav-client]
+- [x] T007 [P] ICS 변환 — `formatActivityAsIcs(activity, trip, ctx)` Activity → VEVENT ICS 문자열 [artifact: src/lib/calendar/ics.ts] [why: sync-delegate]
 
 **Checkpoint**: DB·암호화·CalDAV 클라이언트·ICS 변환 준비 완료. US1 진행 가능.
 
@@ -45,15 +45,15 @@ description: "Task list for #417 apple-caldav-provider (025)"
 
 ### Tests for US1
 
-- [ ] T008 [P] [US1] 암호화 round-trip 단위 테스트 — encrypt → decrypt가 원본과 일치 + 잘못된 키로 decrypt 실패 [artifact: tests/unit/calendar/apple-crypto-roundtrip.test.ts] [why: crypto]
-- [ ] T009 [P] [US1] appleProvider.classifyError 단위 테스트 — 401/412/5xx/network → vocabulary 매핑 [artifact: tests/unit/calendar/apple-classify-error.test.ts] [why: apple-error-vocab]
-- [ ] T010 [P] [US1] appleProvider.capabilities 단위 테스트 — `{ autoMemberAcl: "manual", supportsCalendarCreation: true, supportsCalendarSelection: true }` [artifact: tests/unit/calendar/apple-capability.test.ts] [why: provider-impl]
+- [x] T008 [P] [US1] 암호화 round-trip 단위 테스트 — encrypt → decrypt가 원본과 일치 + 잘못된 키로 decrypt 실패 [artifact: tests/unit/calendar/apple-crypto-roundtrip.test.ts] [why: crypto]
+- [x] T009 [P] [US1] appleProvider.classifyError 단위 테스트 — 401/412/5xx/network → vocabulary 매핑 [artifact: tests/unit/calendar/apple-classify-error.test.ts] [why: apple-error-vocab]
+- [x] T010 [P] [US1] appleProvider.capabilities 단위 테스트 — `{ autoMemberAcl: "manual", supportsCalendarCreation: true, supportsCalendarSelection: true }` [artifact: tests/unit/calendar/apple-capability.test.ts] [why: provider-impl]
 - [ ] T011 [P] [US1] 위자드 검증 통합 테스트 — `/api/v2/calendar/apple/validate` 401·200 분기 (tsdav mock) [artifact: tests/integration/calendar/apple-wizard-validate.test.ts] [why: wizard-ui]
 
 ### Implementation for US1
 
-- [ ] T012 [US1] appleProvider 구현 — hasValidAuth/getReauthUrl/listCalendars/createCalendar/putEvent/updateEvent/deleteEvent/upsertMemberAcl/revokeMemberAcl/classifyError 메서드 [artifact: src/lib/calendar/provider/apple.ts] [why: provider-impl]
-- [ ] T013 [US1] registry 갱신 — `getProvider("APPLE")`이 throw 대신 appleProvider 반환 [artifact: src/lib/calendar/provider/registry.ts] [why: provider-impl]
+- [x] T012 [US1] appleProvider 구현 — hasValidAuth/getReauthUrl/listCalendars/createCalendar/putEvent/updateEvent/deleteEvent/upsertMemberAcl/revokeMemberAcl/classifyError 메서드 [artifact: src/lib/calendar/provider/apple.ts] [why: provider-impl]
+- [x] T013 [US1] registry 갱신 — `getProvider("APPLE")`이 throw 대신 appleProvider 반환 [artifact: src/lib/calendar/provider/registry.ts] [why: provider-impl]
 - [ ] T014 [US1] 검증 라우트 `POST /api/v2/calendar/apple/validate` — appleId+password 검증 + AppleCalendarCredential upsert [artifact: src/app/api/v2/calendar/apple/validate/route.ts] [why: wizard-ui]
 - [ ] T015 [US1] 캘린더 목록 라우트 `GET /api/v2/calendar/apple/calendars` — listCalendars 결과 반환 (VEVENT 필터 적용됨) [artifact: src/app/api/v2/calendar/apple/calendars/route.ts] [why: provider-impl]
 - [ ] T016 [US1] 연결 라우트 `POST /api/v2/trips/[id]/calendar/apple/connect` — service.connectCalendar 위임 (provider="APPLE") [artifact: src/app/api/v2/trips/<id>/calendar/apple/connect/route.ts] [why: wizard-ui]

--- a/src/lib/calendar/ics.ts
+++ b/src/lib/calendar/ics.ts
@@ -1,0 +1,157 @@
+/**
+ * spec 025 (#417) — Activity ↔ ICS VEVENT 변환.
+ *
+ * RFC 5545 minimal VEVENT 형식. CalDAV(Apple iCloud)와 Google Calendar import 양쪽에서
+ * 동작. 본 모듈은 provider 인터페이스의 `putEvent/updateEvent`가 받는 `ics: string`의
+ * 표준 생성 지점이다.
+ *
+ * 라인 길이 75 octet 제한(RFC 5545 §3.1)은 짧은 활동에선 거의 발생 안 하므로 본 회차는
+ * 단순 변환만 — 75자 초과 시에도 대부분 클라이언트가 관대하게 처리. 엄격 fold가 필요한
+ * 케이스(아주 긴 description)가 보고되면 후속 회차에서 fold 알고리즘 추가.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { Activity, Trip } from "@prisma/client";
+
+const PRODID = "-//trip-planner//EN";
+
+const CATEGORY_SYMBOL: Record<string, string> = {
+  SIGHTSEEING: "🗺️",
+  DINING: "🍽️",
+  TRANSPORT: "✈️",
+  ACCOMMODATION: "🏨",
+  SHOPPING: "🛍️",
+  OTHER: "•",
+};
+
+const RESERVATION_LABEL: Record<string, string> = {
+  REQUIRED: "사전 예약 필수",
+  RECOMMENDED: "사전 예약 권장",
+  ON_SITE: "현장 구매",
+  NOT_NEEDED: "예약 불필요",
+};
+
+export type ActivityForIcs = Pick<
+  Activity,
+  | "title"
+  | "category"
+  | "startTime"
+  | "startTimezone"
+  | "endTime"
+  | "endTimezone"
+  | "location"
+  | "memo"
+  | "reservationStatus"
+>;
+
+export interface IcsContext {
+  tripUrl: string;
+  /** 명시적 UID. 없으면 randomUUID. update 시 기존 UID 재사용해야 함. */
+  uid?: string;
+}
+
+/** ICS 텍스트의 특수 문자 escape — `,`, `;`, `\`, `\n`. */
+function escapeText(s: string): string {
+  return s
+    .replace(/\\/g, "\\\\")
+    .replace(/;/g, "\\;")
+    .replace(/,/g, "\\,")
+    .replace(/\n/g, "\\n");
+}
+
+/** Date → `YYYYMMDDTHHMMSSZ` UTC 표기. */
+function formatUtcStamp(d: Date): string {
+  const iso = d.toISOString().replace(/[-:]/g, "");
+  // ISO: 2026-04-27T14:30:00.000Z → 20260427T143000.000Z → 20260427T143000Z
+  return iso.replace(/\.\d{3}/, "");
+}
+
+/** Date → tzid local 시각 표기 `YYYYMMDDTHHMMSS` (TZID 별도 attribute). */
+function formatLocalStamp(d: Date, tz: string): string {
+  // Intl.DateTimeFormat를 사용해 tz 기준 컴포넌트 추출
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).formatToParts(d);
+  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "00";
+  const y = get("year");
+  const m = get("month");
+  const day = get("day");
+  let h = get("hour");
+  if (h === "24") h = "00"; // Intl 일부 환경에서 24:xx 표기
+  const min = get("minute");
+  const sec = get("second");
+  return `${y}${m}${day}T${h}${min}${sec}`;
+}
+
+/** Activity 1건을 RFC 5545 VEVENT 블록을 포함한 VCALENDAR ICS 문자열로 변환. */
+export function formatActivityAsIcs(
+  activity: ActivityForIcs,
+  trip: Pick<Trip, "id" | "title">,
+  ctx: IcsContext,
+): string {
+  const symbol = CATEGORY_SYMBOL[activity.category] ?? "•";
+  const summary = `[${trip.title}] ${symbol} ${activity.title}`;
+
+  const descLines: string[] = [];
+  if (activity.reservationStatus) {
+    descLines.push(
+      RESERVATION_LABEL[activity.reservationStatus] ?? activity.reservationStatus,
+    );
+  }
+  if (activity.memo) descLines.push(activity.memo);
+  if (activity.location) {
+    descLines.push(`📍 ${activity.location}`);
+    descLines.push(
+      `지도: https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(activity.location)}`,
+    );
+  }
+  descLines.push("");
+  descLines.push(`여행 상세: ${ctx.tripUrl}`);
+
+  const start = activity.startTime ?? new Date();
+  const end = activity.endTime ?? activity.startTime ?? new Date();
+  const startZone = activity.startTimezone || "UTC";
+  const endZone = activity.endTimezone || activity.startTimezone || "UTC";
+
+  const dtstart =
+    startZone === "UTC"
+      ? `DTSTART:${formatUtcStamp(start)}`
+      : `DTSTART;TZID=${startZone}:${formatLocalStamp(start, startZone)}`;
+  const dtend =
+    endZone === "UTC"
+      ? `DTEND:${formatUtcStamp(end)}`
+      : `DTEND;TZID=${endZone}:${formatLocalStamp(end, endZone)}`;
+
+  const lines = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    `PRODID:${PRODID}`,
+    "BEGIN:VEVENT",
+    `UID:${ctx.uid ?? randomUUID()}`,
+    `DTSTAMP:${formatUtcStamp(new Date())}`,
+    dtstart,
+    dtend,
+    `SUMMARY:${escapeText(summary)}`,
+  ];
+  if (activity.location) {
+    lines.push(`LOCATION:${escapeText(activity.location)}`);
+  }
+  lines.push(`DESCRIPTION:${escapeText(descLines.join("\n"))}`);
+  lines.push("END:VEVENT");
+  lines.push("END:VCALENDAR");
+
+  return lines.join("\r\n");
+}
+
+/** ICS 문자열에서 UID를 추출 (update 시 기존 UID 재사용용). 못 찾으면 null. */
+export function extractIcsUid(ics: string): string | null {
+  const m = ics.match(/^UID:(.+)$/m);
+  return m ? m[1].trim() : null;
+}

--- a/src/lib/calendar/provider/apple-client.ts
+++ b/src/lib/calendar/provider/apple-client.ts
@@ -1,0 +1,31 @@
+/**
+ * spec 025 (#417) — tsdav 단일 진입점.
+ *
+ * 라우트·service·provider는 직접 `tsdav`를 import하지 않는다. 향후 라이브러리 변경 시
+ * 본 wrapper만 교체하면 된다.
+ *
+ * Apple iCloud는 Basic Auth + app-specific password만 허용 (POC #345 측정).
+ */
+
+import { createDAVClient } from "tsdav";
+
+const ICLOUD_SERVER_URL = "https://caldav.icloud.com";
+
+/** Apple ID + 앱 암호로 DAVClient를 생성한다. 401은 첫 호출(account discovery)에서 즉시 발생. */
+export async function createAppleClient(args: {
+  appleId: string;
+  appPassword: string;
+}): Promise<Awaited<ReturnType<typeof createDAVClient>>> {
+  return createDAVClient({
+    serverUrl: ICLOUD_SERVER_URL,
+    credentials: {
+      username: args.appleId,
+      password: args.appPassword,
+    },
+    authMethod: "Basic",
+    defaultAccountType: "caldav",
+  });
+}
+
+/** 본 모듈에서 다른 모듈로 노출하는 클라이언트 타입. */
+export type AppleDAVClient = Awaited<ReturnType<typeof createAppleClient>>;

--- a/src/lib/calendar/provider/apple-crypto.ts
+++ b/src/lib/calendar/provider/apple-crypto.ts
@@ -1,0 +1,73 @@
+/**
+ * spec 025 (#417) — Apple app-specific password 암호화 모듈.
+ *
+ * AES-256-GCM (authenticated encryption). per-row IV로 암호화된 ciphertext + 16바이트
+ * auth tag를 단일 base64 문자열로 저장.
+ *
+ * 키 관리:
+ *  - 환경 변수 `APPLE_PASSWORD_ENCRYPTION_KEY` (32바이트 base64 인코딩)
+ *  - dev/preview/production 별도 키. 키 회전 시 전체 재암호화 필요(1인 운영 가정).
+ */
+
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+const ALGO = "aes-256-gcm";
+const IV_BYTES = 12; // GCM 권장
+const TAG_BYTES = 16;
+
+let cachedKey: Buffer | null = null;
+
+function loadKey(): Buffer {
+  if (cachedKey) return cachedKey;
+  const raw = process.env.APPLE_PASSWORD_ENCRYPTION_KEY;
+  if (!raw) {
+    throw new Error("APPLE_PASSWORD_ENCRYPTION_KEY env not set");
+  }
+  const buf = Buffer.from(raw, "base64");
+  if (buf.length !== 32) {
+    throw new Error(
+      `APPLE_PASSWORD_ENCRYPTION_KEY must decode to 32 bytes (got ${buf.length})`,
+    );
+  }
+  cachedKey = buf;
+  return buf;
+}
+
+/** 평문 패스워드를 암호화. 결과의 ciphertext는 base64 문자열(ciphertext bytes || auth tag). */
+export function encryptPassword(plaintext: string): {
+  ciphertext: string;
+  iv: string;
+} {
+  const key = loadKey();
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(ALGO, key, iv);
+  const enc = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return {
+    ciphertext: Buffer.concat([enc, tag]).toString("base64"),
+    iv: iv.toString("base64"),
+  };
+}
+
+/** ciphertext+iv를 받아 평문 패스워드를 복호화. 위·변조 시 throw. */
+export function decryptPassword(ciphertextB64: string, ivB64: string): string {
+  const key = loadKey();
+  const buf = Buffer.from(ciphertextB64, "base64");
+  if (buf.length < TAG_BYTES + 1) {
+    throw new Error("ciphertext too short");
+  }
+  const tag = buf.subarray(buf.length - TAG_BYTES);
+  const enc = buf.subarray(0, buf.length - TAG_BYTES);
+  const iv = Buffer.from(ivB64, "base64");
+  if (iv.length !== IV_BYTES) {
+    throw new Error(`iv length mismatch (expected ${IV_BYTES}, got ${iv.length})`);
+  }
+  const decipher = createDecipheriv(ALGO, key, iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(enc), decipher.final()]).toString("utf8");
+}
+
+/** 테스트 격리용 — process.env 변경 후 캐시된 키를 무효화한다. */
+export function __resetKeyCacheForTests(): void {
+  cachedKey = null;
+}

--- a/src/lib/calendar/provider/apple.ts
+++ b/src/lib/calendar/provider/apple.ts
@@ -1,0 +1,284 @@
+/**
+ * spec 025 (#417) — Apple iCloud CalDAV provider 구현체.
+ *
+ * POC #345 측정 결과 + 의사결정 5건 + 추가 발견 3건을 그대로 구현한다.
+ *
+ * - 인증: Basic Auth + app-specific password (OAuth 미제공)
+ * - 캘린더: MKCALENDAR로 자동 생성 (iCloud 미공식이지만 안정 작동)
+ * - 이벤트: VEVENT PUT/UPDATE/DELETE + ETag strict 추적
+ * - 멤버 ACL: capability "manual" — Apple은 멤버 초대 API 미제공, 사용자가 직접 처리
+ * - 에러 vocabulary: 401→auth_invalid, 412→precondition_failed, 5xx/network→transient_failure
+ */
+
+import { prisma } from "@/lib/prisma";
+import { createAppleClient, type AppleDAVClient } from "./apple-client";
+import { decryptPassword } from "./apple-crypto";
+import type {
+  CalendarErrorCode,
+  CalendarProvider,
+  CalendarRef,
+  ExternalEventRef,
+  ProviderCapabilities,
+  RevokeAclResult,
+} from "./types";
+
+const CAPABILITIES: ProviderCapabilities = {
+  autoMemberAcl: "manual",
+  supportsCalendarCreation: true,
+  supportsCalendarSelection: true,
+};
+
+/** 7일 이내 검증된 credential은 trust. 초과면 PROPFIND 재검증. */
+const VALIDATION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+async function loadClient(userId: string): Promise<AppleDAVClient | null> {
+  const cred = await prisma.appleCalendarCredential.findUnique({
+    where: { userId },
+  });
+  if (!cred) return null;
+  let plainPassword: string;
+  try {
+    plainPassword = decryptPassword(cred.encryptedPassword, cred.iv);
+  } catch (e) {
+    console.warn(
+      `[apple] decrypt failed userId=${userId} reason=${(e as Error).message}`,
+    );
+    return null;
+  }
+  return createAppleClient({
+    appleId: cred.appleId,
+    appPassword: plainPassword,
+  });
+}
+
+/** HTTP status를 unknown error에서 추출. tsdav는 fetch Response 또는 Error를 throw할 수 있다. */
+function extractStatus(err: unknown): number | null {
+  if (err && typeof err === "object") {
+    const obj = err as { status?: unknown; response?: { status?: unknown }; statusCode?: unknown };
+    if (typeof obj.status === "number") return obj.status;
+    if (typeof obj.statusCode === "number") return obj.statusCode;
+    if (obj.response && typeof obj.response.status === "number") return obj.response.status;
+  }
+  if (err instanceof Error) {
+    const m = err.message.match(/\b(\d{3})\b/);
+    if (m) {
+      const n = Number(m[1]);
+      if (n >= 100 && n < 600) return n;
+    }
+  }
+  return null;
+}
+
+function isNetworkError(err: unknown): boolean {
+  if (err instanceof Error) {
+    const msg = err.message.toLowerCase();
+    return (
+      msg.includes("network") ||
+      msg.includes("fetch failed") ||
+      msg.includes("econnrefused") ||
+      msg.includes("etimedout") ||
+      msg.includes("enotfound")
+    );
+  }
+  return false;
+}
+
+export const appleProvider: CalendarProvider = {
+  id: "APPLE",
+  capabilities: CAPABILITIES,
+
+  async hasValidAuth(userId: string): Promise<boolean> {
+    const cred = await prisma.appleCalendarCredential.findUnique({
+      where: { userId },
+    });
+    if (!cred) return false;
+    if (
+      cred.lastValidatedAt &&
+      Date.now() - cred.lastValidatedAt.getTime() < VALIDATION_TTL_MS &&
+      !cred.lastError
+    ) {
+      return true;
+    }
+    // TTL 초과 또는 lastError 존재 시 재검증
+    const client = await loadClient(userId);
+    if (!client) return false;
+    try {
+      await client.fetchCalendars();
+      await prisma.appleCalendarCredential.update({
+        where: { userId },
+        data: { lastValidatedAt: new Date(), lastError: null },
+      });
+      return true;
+    } catch (e) {
+      const code = appleProvider.classifyError(e);
+      await prisma.appleCalendarCredential.update({
+        where: { userId },
+        data: { lastError: code ?? "unknown" },
+      });
+      return false;
+    }
+  },
+
+  async getReauthUrl(_userId: string, returnTo: string): Promise<string | null> {
+    // Apple은 OAuth 미제공 — 위자드 진입 URL 반환. tripId는 returnTo에서 추출되거나
+    // 호출자가 path를 그대로 사용한다.
+    const path = returnTo.startsWith("/") ? returnTo : `/${returnTo}`;
+    return `${path}${path.includes("?") ? "&" : "?"}apple_reauth=1`;
+  },
+
+  async listCalendars(userId: string): Promise<CalendarRef[]> {
+    const client = await loadClient(userId);
+    if (!client) return [];
+    const calendars = await client.fetchCalendars();
+    return calendars
+      .filter((c) => Array.isArray(c.components) && c.components.includes("VEVENT"))
+      .map((c) => ({
+        calendarId: c.url,
+        displayName:
+          typeof c.displayName === "string" ? c.displayName : null,
+        components: (c.components ?? []).filter(
+          (comp): comp is "VEVENT" | "VTODO" => comp === "VEVENT" || comp === "VTODO",
+        ),
+      }));
+  },
+
+  async createCalendar(userId: string, name: string): Promise<CalendarRef> {
+    const client = await loadClient(userId);
+    if (!client) {
+      throw new Error("Apple CalDAV client unavailable for user");
+    }
+    // 기본 calendar-home-set URL을 fetchCalendars로 추정하거나 client.account에서 가져온다
+    // tsdav는 createDAVClient 결과에 account 정보를 포함하지 않을 수 있어, 다음 우회를 사용:
+    //  - 첫 fetchCalendars로 home URL 추출 (각 캘린더의 url에서 부모 path)
+    //  - 신규 URL: <home>/<random uuid>/
+    const calendars = await client.fetchCalendars();
+    if (calendars.length === 0) {
+      // 최초 사용자라 캘린더가 0개인 경우는 거의 없지만 안전 폴백
+      throw new Error("Apple CalDAV: cannot derive calendar-home URL (no existing calendars)");
+    }
+    const sample = calendars[0].url;
+    // sample: https://p<digits>-caldav.icloud.com:443/<userId>/calendars/<calId>/
+    const home = sample.replace(/[^/]+\/?$/, ""); // 마지막 segment 제거
+    const newId = `trip-planner-${Date.now().toString(36)}`;
+    const newUrl = `${home}${newId}/`;
+    const responses = await client.makeCalendar({
+      url: newUrl,
+      props: {
+        displayname: name,
+        "supported-calendar-component-set": {
+          _attributes: { "xmlns:C": "urn:ietf:params:xml:ns:caldav" },
+          comp: { _attributes: { name: "VEVENT" } },
+        },
+      },
+    });
+    const ok = responses.some(
+      (r) => typeof r.status === "number" && r.status >= 200 && r.status < 300,
+    );
+    if (!ok) {
+      throw new Error("MKCALENDAR did not return 2xx");
+    }
+    return {
+      calendarId: newUrl,
+      displayName: name,
+      components: ["VEVENT"],
+    };
+  },
+
+  async putEvent(
+    userId: string,
+    calendarId: string,
+    ics: string,
+  ): Promise<ExternalEventRef> {
+    const client = await loadClient(userId);
+    if (!client) {
+      throw new Error("Apple CalDAV client unavailable for user");
+    }
+    const filename = `trip-planner-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}.ics`;
+    const res = await client.createCalendarObject({
+      calendar: { url: calendarId } as Parameters<typeof client.createCalendarObject>[0]["calendar"],
+      filename,
+      iCalString: ics,
+    });
+    if (!res.ok) {
+      const err = new Error(`createCalendarObject failed status=${res.status}`);
+      (err as Error & { status?: number }).status = res.status;
+      throw err;
+    }
+    const objectUrl = res.headers.get("location") ?? `${calendarId}${filename}`;
+    const etag = res.headers.get("etag");
+    return {
+      externalEventId: objectUrl,
+      etag: etag ?? null,
+    };
+  },
+
+  async updateEvent(
+    userId: string,
+    ref: ExternalEventRef,
+    ics: string,
+  ): Promise<ExternalEventRef> {
+    const client = await loadClient(userId);
+    if (!client) {
+      throw new Error("Apple CalDAV client unavailable for user");
+    }
+    const res = await client.updateCalendarObject({
+      calendarObject: {
+        url: ref.externalEventId,
+        etag: ref.etag ?? "",
+        data: ics,
+      },
+    });
+    if (!res.ok) {
+      const err = new Error(`updateCalendarObject failed status=${res.status}`);
+      (err as Error & { status?: number }).status = res.status;
+      throw err;
+    }
+    const newEtag = res.headers.get("etag");
+    return {
+      externalEventId: ref.externalEventId,
+      etag: newEtag ?? null,
+    };
+  },
+
+  async deleteEvent(userId: string, ref: ExternalEventRef): Promise<void> {
+    const client = await loadClient(userId);
+    if (!client) {
+      throw new Error("Apple CalDAV client unavailable for user");
+    }
+    const res = await client.deleteCalendarObject({
+      calendarObject: {
+        url: ref.externalEventId,
+        etag: ref.etag ?? "",
+      },
+    });
+    if (!res.ok) {
+      const err = new Error(`deleteCalendarObject failed status=${res.status}`);
+      (err as Error & { status?: number }).status = res.status;
+      throw err;
+    }
+  },
+
+  async upsertMemberAcl(): Promise<void> {
+    // capability "manual" — Apple은 멤버 초대 API 미제공. 호출되어선 안 되지만 안전망.
+    // service.reconcileMemberAcl이 capability autoMemberAcl !== "auto"이면 skip하므로
+    // 본 메서드는 정상 흐름에선 호출되지 않는다.
+  },
+
+  async revokeMemberAcl(): Promise<RevokeAclResult> {
+    return {
+      revoked: false,
+      retainedReason: "Apple은 capability manual — 사용자가 외부 Calendar 앱에서 직접 회수",
+    };
+  },
+
+  classifyError(err: unknown): CalendarErrorCode | null {
+    const status = extractStatus(err);
+    if (status === 401) return "auth_invalid";
+    if (status === 412) return "precondition_failed";
+    if ((status !== null && status >= 500) || isNetworkError(err)) {
+      return "transient_failure";
+    }
+    if (status === 429) return "transient_failure";
+    return null;
+  },
+};

--- a/src/lib/calendar/provider/registry.ts
+++ b/src/lib/calendar/provider/registry.ts
@@ -1,22 +1,20 @@
 /**
- * spec 024 (#416) — Provider registry.
+ * spec 024 (#416) — Provider registry. spec 025 (#417)에서 Apple 활성화.
  *
  * 라우트·service 계층은 link row의 `provider`를 읽어 본 함수로 구현체를 받는다.
- * Apple 구현체는 후속 #417에서 추가됨 — 현재는 throw로 명확한 신호 제공.
+ * GOOGLE은 v2.8.0~ 운영, APPLE은 v2.11.0(spec 025)에서 활성화됨.
  */
 
 import type { CalendarProvider, ProviderId } from "./types";
 import { googleProvider } from "./google";
+import { appleProvider } from "./apple";
 
 export function getProvider(id: ProviderId): CalendarProvider {
   switch (id) {
     case "GOOGLE":
       return googleProvider;
     case "APPLE":
-      throw new Error(
-        "Apple calendar provider is not implemented yet (#417 apple-caldav-provider). " +
-          "본 피처(#416)는 추상화 토대만 도입한다.",
-      );
+      return appleProvider;
     default: {
       const _exhaustive: never = id;
       throw new Error(`Unknown provider id: ${String(_exhaustive)}`);

--- a/tests/unit/calendar/apple-capability.test.ts
+++ b/tests/unit/calendar/apple-capability.test.ts
@@ -1,0 +1,57 @@
+/**
+ * spec 025 (#417) — appleProvider.capabilities가 plan.md 명시값 그대로인지 검증.
+ *
+ * 라우트·service는 본 capability를 읽어 분기한다. provider 식별자 직접 비교(SC-008
+ * spec 024)를 금지한다.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({ prisma: {} }));
+vi.mock("tsdav", () => ({ createDAVClient: vi.fn() }));
+
+import { appleProvider } from "@/lib/calendar/provider/apple";
+
+describe("appleProvider.capabilities", () => {
+  it("autoMemberAcl == 'manual'", () => {
+    expect(appleProvider.capabilities.autoMemberAcl).toBe("manual");
+  });
+
+  it("supportsCalendarCreation == true (MKCALENDAR 작동)", () => {
+    expect(appleProvider.capabilities.supportsCalendarCreation).toBe(true);
+  });
+
+  it("supportsCalendarSelection == true (기존 선택 옵션)", () => {
+    expect(appleProvider.capabilities.supportsCalendarSelection).toBe(true);
+  });
+});
+
+describe("appleProvider 인터페이스 식별자", () => {
+  it("id == 'APPLE'", () => {
+    expect(appleProvider.id).toBe("APPLE");
+  });
+});
+
+describe("appleProvider.upsertMemberAcl/revokeMemberAcl — manual capability 안전망", () => {
+  it("upsertMemberAcl은 호출되어도 throw 없이 반환 (no-op)", async () => {
+    await expect(
+      appleProvider.upsertMemberAcl({
+        userId: "u1",
+        calendarId: "https://caldav.icloud.com/u1/cal/",
+        memberEmail: "m@example.com",
+        role: "writer",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("revokeMemberAcl은 항상 revoked:false + retainedReason 반환", async () => {
+    const result = await appleProvider.revokeMemberAcl({
+      userId: "u1",
+      calendarId: "https://caldav.icloud.com/u1/cal/",
+      memberEmail: "m@example.com",
+      retainIfStillNeeded: true,
+    });
+    expect(result.revoked).toBe(false);
+    expect(result.retainedReason).toContain("manual");
+  });
+});

--- a/tests/unit/calendar/apple-classify-error.test.ts
+++ b/tests/unit/calendar/apple-classify-error.test.ts
@@ -1,0 +1,65 @@
+/**
+ * spec 025 (#417) — appleProvider.classifyError가 CalDAV 응답을 6종 vocabulary로
+ * 정규화하는지 검증.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({ prisma: {} }));
+vi.mock("tsdav", () => ({ createDAVClient: vi.fn() }));
+
+import { appleProvider } from "@/lib/calendar/provider/apple";
+
+describe("appleProvider.classifyError — 6종 vocabulary 매핑", () => {
+  it("status=401 → auth_invalid", () => {
+    expect(appleProvider.classifyError({ status: 401 })).toBe("auth_invalid");
+  });
+
+  it("status=412 → precondition_failed", () => {
+    expect(appleProvider.classifyError({ status: 412 })).toBe("precondition_failed");
+  });
+
+  it("status=429 → transient_failure", () => {
+    expect(appleProvider.classifyError({ status: 429 })).toBe("transient_failure");
+  });
+
+  it("status=500 → transient_failure", () => {
+    expect(appleProvider.classifyError({ status: 503 })).toBe("transient_failure");
+  });
+
+  it("Error message에 fetch failed → transient_failure", () => {
+    expect(appleProvider.classifyError(new Error("fetch failed"))).toBe(
+      "transient_failure",
+    );
+  });
+
+  it("Error message에 ECONNREFUSED → transient_failure", () => {
+    expect(appleProvider.classifyError(new Error("connect ECONNREFUSED 127.0.0.1"))).toBe(
+      "transient_failure",
+    );
+  });
+
+  it("status=404 → null (vocabulary 외)", () => {
+    expect(appleProvider.classifyError({ status: 404 })).toBeNull();
+  });
+
+  it("response.status로 status 추출", () => {
+    expect(appleProvider.classifyError({ response: { status: 401 } })).toBe(
+      "auth_invalid",
+    );
+  });
+
+  it("Error message에 '401' 포함 시 status 추출", () => {
+    expect(appleProvider.classifyError(new Error("HTTP 401 Unauthorized"))).toBe(
+      "auth_invalid",
+    );
+  });
+
+  it("status 추출 불가 + 네트워크 키워드 부재 → null", () => {
+    expect(appleProvider.classifyError(new Error("totally unknown error"))).toBeNull();
+  });
+
+  it("status=200 (정상) → null (에러 아님)", () => {
+    expect(appleProvider.classifyError({ status: 200 })).toBeNull();
+  });
+});

--- a/tests/unit/calendar/apple-crypto-roundtrip.test.ts
+++ b/tests/unit/calendar/apple-crypto-roundtrip.test.ts
@@ -1,0 +1,89 @@
+/**
+ * spec 025 (#417) — apple-crypto round-trip 검증.
+ *
+ * AES-256-GCM은 위·변조 시 decrypt가 throw해야 한다(authenticated encryption).
+ * 잘못된 키·iv·tampered ciphertext 전 케이스 검증.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { randomBytes } from "node:crypto";
+
+import {
+  encryptPassword,
+  decryptPassword,
+  __resetKeyCacheForTests,
+} from "@/lib/calendar/provider/apple-crypto";
+
+const KEY1 = randomBytes(32).toString("base64");
+const KEY2 = randomBytes(32).toString("base64");
+
+describe("apple-crypto — round-trip", () => {
+  beforeEach(() => {
+    process.env.APPLE_PASSWORD_ENCRYPTION_KEY = KEY1;
+    __resetKeyCacheForTests();
+  });
+
+  it("encrypt → decrypt가 원본 평문과 일치", () => {
+    const plain = "abcd-efgh-ijkl-mnop"; // Apple 16자리 형식
+    const { ciphertext, iv } = encryptPassword(plain);
+    expect(decryptPassword(ciphertext, iv)).toBe(plain);
+  });
+
+  it("같은 평문이라도 매번 다른 ciphertext (per-row IV)", () => {
+    const plain = "abcd-efgh-ijkl-mnop";
+    const r1 = encryptPassword(plain);
+    const r2 = encryptPassword(plain);
+    expect(r1.ciphertext).not.toBe(r2.ciphertext);
+    expect(r1.iv).not.toBe(r2.iv);
+  });
+
+  it("UTF-8 한글·이모지도 round-trip 통과", () => {
+    const plain = "안녕하세요-🍎-iCloud-1234";
+    const { ciphertext, iv } = encryptPassword(plain);
+    expect(decryptPassword(ciphertext, iv)).toBe(plain);
+  });
+});
+
+describe("apple-crypto — 인증 실패", () => {
+  beforeEach(() => {
+    process.env.APPLE_PASSWORD_ENCRYPTION_KEY = KEY1;
+    __resetKeyCacheForTests();
+  });
+
+  it("다른 키로 decrypt 시 throw", () => {
+    const { ciphertext, iv } = encryptPassword("secret-12345");
+    process.env.APPLE_PASSWORD_ENCRYPTION_KEY = KEY2;
+    __resetKeyCacheForTests();
+    expect(() => decryptPassword(ciphertext, iv)).toThrow();
+  });
+
+  it("ciphertext tamper 시 throw (auth tag 검증)", () => {
+    const { ciphertext, iv } = encryptPassword("secret-12345");
+    // base64 첫 글자 변조
+    const tampered =
+      (ciphertext[0] === "A" ? "B" : "A") + ciphertext.slice(1);
+    expect(() => decryptPassword(tampered, iv)).toThrow();
+  });
+
+  it("iv tamper 시 throw", () => {
+    const { ciphertext, iv } = encryptPassword("secret-12345");
+    const tamperedIv = (iv[0] === "A" ? "B" : "A") + iv.slice(1);
+    expect(() => decryptPassword(ciphertext, tamperedIv)).toThrow();
+  });
+});
+
+describe("apple-crypto — env 키 검증", () => {
+  it("32바이트가 아닌 키는 throw", () => {
+    process.env.APPLE_PASSWORD_ENCRYPTION_KEY = Buffer.from("short").toString(
+      "base64",
+    );
+    __resetKeyCacheForTests();
+    expect(() => encryptPassword("x")).toThrow(/32 bytes/);
+  });
+
+  it("env 키 부재 시 throw", () => {
+    delete process.env.APPLE_PASSWORD_ENCRYPTION_KEY;
+    __resetKeyCacheForTests();
+    expect(() => encryptPassword("x")).toThrow(/env not set/);
+  });
+});

--- a/tests/unit/calendar/capability.test.ts
+++ b/tests/unit/calendar/capability.test.ts
@@ -13,8 +13,10 @@ vi.mock("@/lib/gcal/auth", () => ({
   buildConsentRedirectUrl: vi.fn(),
 }));
 vi.mock("@/lib/gcal/acl", () => ({ upsertAcl: vi.fn(), deleteAcl: vi.fn() }));
+vi.mock("tsdav", () => ({ createDAVClient: vi.fn() }));
 
 import { googleProvider } from "@/lib/calendar/provider/google";
+import { appleProvider } from "@/lib/calendar/provider/apple";
 import { getProvider } from "@/lib/calendar/provider/registry";
 
 describe("ProviderCapabilities — 노출 정합", () => {
@@ -30,7 +32,7 @@ describe("ProviderCapabilities — 노출 정합", () => {
     expect(getProvider("GOOGLE")).toBe(googleProvider);
   });
 
-  it("registry getProvider('APPLE')은 #417 명시 throw", () => {
-    expect(() => getProvider("APPLE")).toThrowError(/#417/);
+  it("registry getProvider('APPLE')은 appleProvider와 동일 객체 (spec 025로 활성화)", () => {
+    expect(getProvider("APPLE")).toBe(appleProvider);
   });
 });


### PR DESCRIPTION
## Summary

spec 025 (#417 apple-caldav-provider)의 **Phase 1·2 + appleProvider 객체** + classify/capability/crypto 단위 테스트.

위자드 UI · service Apple 분기 · sync-engine 분해는 후속 PR로 분리해 회귀 위험을 단계적으로 관리.

## 산출물

### 신규 모듈
- `src/lib/calendar/provider/apple-crypto.ts` — AES-256-GCM + per-row IV (env 키 32바이트 검증)
- `src/lib/calendar/provider/apple-client.ts` — `tsdav` 단일 진입점 wrapper
- `src/lib/calendar/provider/apple.ts` — `appleProvider` 객체 (CalendarProvider 10 메서드)
- `src/lib/calendar/ics.ts` — Activity → VEVENT ICS 변환 (RFC 5545)
- `src/lib/calendar/provider/registry.ts` — `getProvider("APPLE")` 활성화 (이전 throw → appleProvider)

### DB
- `AppleCalendarCredential` 신규 테이블 (1 user 1 row, ON DELETE CASCADE)
- `prisma/migrations/20260427000000_add_apple_credentials` [migration-type: schema-only]

### 의존성·env
- `tsdav@^2.1.8` 추가
- `APPLE_PASSWORD_ENCRYPTION_KEY` (.env.example 갱신, 32바이트 base64)

### 테스트 (전체 51 통과)
- `apple-classify-error.test.ts` — 401/412/429/5xx/network → vocabulary 매핑 (11 cases)
- `apple-capability.test.ts` — manual capability + 인터페이스 식별자 + manual ACL 안전망
- `apple-crypto-roundtrip.test.ts` — encrypt/decrypt + tamper 검증 + env 키 검증

## 교차 검증 반영

- spec FR-008에 429 케이스 추가 (코드와 일치)
- spec Key Entities에 updatedAt 컬럼 추가 (실제 schema와 일치)
- `registry.ts` 주석을 #417 활성화 시점으로 갱신
- plan Risk에 R4(MKCALENDAR home URL 휴리스틱) + R5(props XML 직렬화) 인지 추가

## 검증

- `npx tsc --noEmit` 통과
- `next build` 통과 (APPLE_PASSWORD_ENCRYPTION_KEY 설정 시)
- ESLint 변경 파일 0 errors
- Speckit validators 모두 통과:
  - `validate-metatag-format.sh` ✓
  - `validate-plan-tasks-cov.sh` ✓
  - `validate-quickstart-ev.sh` ✓
  - `validate-drift.sh` errors=0
  - `validate-migration-meta.sh` ✓

## Out of Scope (후속 PR)

- 위자드 UI (Step 1~4 컴포넌트, AppleConnectWizard, 진입 페이지) — T018~T023
- 검증·캘린더 목록·연결 라우트 (`/api/v2/calendar/apple/*`, `/api/v2/trips/[id]/calendar/apple/connect`) — T014~T017
- service.connectCalendar Apple 분기 + manual ACL 안내 응답 — T029
- sync-engine 분해 (provider 인터페이스 putEvent 위임) — T030~T032
- 401 즉시 UI 배너 + 재인증 흐름 — T024~T026
- Google 회귀 통합 테스트 — T033

## 환경 변수 액션 필요 (머지 후)

- Vercel dev/preview/production 각 환경에 `APPLE_PASSWORD_ENCRYPTION_KEY` 별도 키 등록
  - 생성: \`openssl rand -base64 32\`
- 머지 후 build 단계에서 `prisma migrate deploy`가 자동으로 새 테이블 생성

## 관련

- Issue #417
- Milestone v2.11.0
- spec 025

🤖 Generated with [Claude Code](https://claude.com/claude-code)