### PR TITLE
feat(417): Apple 라우트 3종 + service connectAppleCalendar 분기

### DIFF
--- a/changes/417-routes.feat.md
+++ b/changes/417-routes.feat.md
@@ -1,0 +1,1 @@
+**Apple iCloud CalDAV 라우트 3종 + service `connectAppleCalendar` 분기 추가**. 왜: 위자드(다음 PR) 진입점 — 자격증명 검증·캘린더 목록·trip 연결 모두 capability "manual" 분기로 멤버 ACL 자동 호출 0회 보장 + manualAclGuidance 안내.

--- a/specs/025-apple-caldav-provider/tasks.md
+++ b/specs/025-apple-caldav-provider/tasks.md
@@ -54,10 +54,10 @@ description: "Task list for #417 apple-caldav-provider (025)"
 
 - [x] T012 [US1] appleProvider 구현 — hasValidAuth/getReauthUrl/listCalendars/createCalendar/putEvent/updateEvent/deleteEvent/upsertMemberAcl/revokeMemberAcl/classifyError 메서드 [artifact: src/lib/calendar/provider/apple.ts] [why: provider-impl]
 - [x] T013 [US1] registry 갱신 — `getProvider("APPLE")`이 throw 대신 appleProvider 반환 [artifact: src/lib/calendar/provider/registry.ts] [why: provider-impl]
-- [ ] T014 [US1] 검증 라우트 `POST /api/v2/calendar/apple/validate` — appleId+password 검증 + AppleCalendarCredential upsert [artifact: src/app/api/v2/calendar/apple/validate/route.ts] [why: wizard-ui]
-- [ ] T015 [US1] 캘린더 목록 라우트 `GET /api/v2/calendar/apple/calendars` — listCalendars 결과 반환 (VEVENT 필터 적용됨) [artifact: src/app/api/v2/calendar/apple/calendars/route.ts] [why: provider-impl]
-- [ ] T016 [US1] 연결 라우트 `POST /api/v2/trips/[id]/calendar/apple/connect` — service.connectCalendar 위임 (provider="APPLE") [artifact: src/app/api/v2/trips/<id>/calendar/apple/connect/route.ts] [why: wizard-ui]
-- [ ] T017 [US1] service.connectCalendar Apple 분기 — provider 분기 후 createCalendar 호출, link 생성 시 provider="APPLE" [artifact: src/lib/calendar/service.ts] [why: provider-impl]
+- [x] T014 [US1] 검증 라우트 `POST /api/v2/calendar/apple/validate` — appleId+password 검증 + AppleCalendarCredential upsert [artifact: src/app/api/v2/calendar/apple/validate/route.ts] [why: wizard-ui]
+- [x] T015 [US1] 캘린더 목록 라우트 `GET /api/v2/calendar/apple/calendars` — listCalendars 결과 반환 (VEVENT 필터 적용됨) [artifact: src/app/api/v2/calendar/apple/calendars/route.ts] [why: provider-impl]
+- [x] T016 [US1] 연결 라우트 `POST /api/v2/trips/<id>/calendar/apple/connect` — service.connectAppleCalendar 위임 (provider="APPLE") [artifact: src/app/api/v2/trips/<id>/calendar/apple/connect/route.ts] [why: wizard-ui]
+- [x] T017 [US1] service.connectAppleCalendar — provider.hasValidAuth 검증 + createCalendar 호출, link 생성 시 provider="APPLE" + manualAclGuidance 응답 포함 [artifact: src/lib/calendar/service.ts] [why: provider-impl]
 - [ ] T018 [US1] 위자드 UI Step 1 — 2FA·패스키 사전 안내 [artifact: src/components/calendar/Step1Prerequisites.tsx] [why: wizard-ui]
 - [ ] T019 [US1] 위자드 UI Step 2 — appleid.apple.com 외부 링크 + 가이드 캡쳐 임베드 [artifact: src/components/calendar/Step2GuideLink.tsx] [why: wizard-ui]
 - [ ] T020 [US1] 위자드 UI Step 3 — Apple ID + 16자리 암호 입력 + validate 호출 [artifact: src/components/calendar/Step3CredentialsInput.tsx] [why: wizard-ui]
@@ -97,11 +97,11 @@ description: "Task list for #417 apple-caldav-provider (025)"
 ### Tests for US3
 
 - [ ] T027 [P] [US3] VTODO 필터 단위 테스트 — fetchCalendars mock 응답에서 VEVENT만 반환 [artifact: tests/unit/calendar/apple-vtodo-filter.test.ts] [why: provider-impl]
-- [ ] T028 [P] [US3] manual ACL 분기 단위 테스트 — capability `manual`이면 service가 upsertMemberAcl 호출 0회 + manualAclGuidance 응답 포함 [artifact: tests/unit/calendar/service-manual-acl-branch.test.ts] [why: manual-acl]
+- [x] T028 [P] [US3] manual ACL 분기 단위 테스트 — capability `manual`이면 service가 upsertMemberAcl 호출 0회 + manualAclGuidance 응답 포함 [artifact: tests/unit/calendar/service-manual-acl-branch.test.ts] [why: manual-acl]
 
 ### Implementation for US3
 
-- [ ] T029 [US3] service.connectCalendar manual 분기 — capability `auto`가 아니면 ACL 호출 skip + 응답 body에 `manualAclGuidance` (멤버 이메일 목록 안내 텍스트) 포함 [artifact: src/lib/calendar/service.ts::connectCalendar] [why: manual-acl]
+- [x] T029 [US3] service.connectAppleCalendar manual 분기 — capability `auto`가 아니면 ACL 호출 skip + 응답 body에 `manualAclGuidance` (멤버 이메일 목록 안내 텍스트) 포함 [artifact: src/lib/calendar/service.ts::connectAppleCalendar] [why: manual-acl]
 
 **Checkpoint**: VTODO 필터 + manual ACL 안내 동작. US3 완료.
 

--- a/src/app/api/v2/calendar/apple/calendars/route.ts
+++ b/src/app/api/v2/calendar/apple/calendars/route.ts
@@ -1,0 +1,53 @@
+/**
+ * spec 025 (#417) — Apple iCloud 캘린더 목록 조회.
+ *
+ * GET /api/v2/calendar/apple/calendars
+ *   응답: { calendars: CalendarRef[] }
+ *
+ * "기존 캘린더에 추가" 옵션의 선택 목록. listCalendars는 VTODO 캘린더를 자동 필터한다
+ * (POC 추가 발견 B). 401인 경우 위자드 재진입 안내.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { appleProvider } from "@/lib/calendar/provider/apple";
+
+export async function GET(_req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+
+  const cred = await prisma.appleCalendarCredential.findUnique({
+    where: { userId: session.user.id },
+  });
+  if (!cred) {
+    return NextResponse.json(
+      { error: "apple_not_authenticated" },
+      { status: 409 },
+    );
+  }
+
+  try {
+    const calendars = await appleProvider.listCalendars(session.user.id);
+    return NextResponse.json({ calendars });
+  } catch (e) {
+    const code = appleProvider.classifyError(e);
+    if (code === "auth_invalid") {
+      // 401 검출 시 lastError 갱신 — 다음 hasValidAuth 호출이 즉시 false 반환
+      await prisma.appleCalendarCredential.update({
+        where: { userId: session.user.id },
+        data: { lastError: code },
+      });
+      return NextResponse.json(
+        { error: "auth_invalid" },
+        { status: 401 },
+      );
+    }
+    return NextResponse.json(
+      { error: code ?? "unknown" },
+      { status: 502 },
+    );
+  }
+}

--- a/src/app/api/v2/calendar/apple/validate/route.ts
+++ b/src/app/api/v2/calendar/apple/validate/route.ts
@@ -1,0 +1,89 @@
+/**
+ * spec 025 (#417) — Apple iCloud CalDAV 자격증명 검증·저장 라우트.
+ *
+ * POST /api/v2/calendar/apple/validate
+ *   body: { appleId: string, appPassword: string }
+ *
+ * 1. tsdav createDAVClient + fetchCalendars로 PROPFIND 검증
+ * 2. 성공 시 AppleCalendarCredential upsert (AES-256-GCM 암호화)
+ * 3. 실패 시 401(auth_invalid) / 502(transient_failure) 분류
+ *
+ * 본 라우트는 위자드 Step 3에서 호출. 성공 후 위자드는 connect 라우트로 진입.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { createAppleClient } from "@/lib/calendar/provider/apple-client";
+import { encryptPassword } from "@/lib/calendar/provider/apple-crypto";
+import { appleProvider } from "@/lib/calendar/provider/apple";
+
+interface ValidateBody {
+  appleId?: unknown;
+  appPassword?: unknown;
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+
+  let body: ValidateBody;
+  try {
+    body = (await req.json()) as ValidateBody;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const appleId = typeof body.appleId === "string" ? body.appleId.trim() : "";
+  const appPassword =
+    typeof body.appPassword === "string" ? body.appPassword.replace(/\s+/g, "") : "";
+  if (!appleId || !appPassword) {
+    return NextResponse.json(
+      { error: "missing_fields", fields: ["appleId", "appPassword"] },
+      { status: 400 },
+    );
+  }
+  // 16자리 (Apple app-specific password format) 검증은 사용자 안내용 hint만 — Apple이 변경할
+  // 가능성 대비 길이 강제 안 함. 401 응답으로 자연 실패하도록 둔다.
+
+  let valid = false;
+  let errorCode: string | null = null;
+  try {
+    const client = await createAppleClient({ appleId, appPassword });
+    await client.fetchCalendars();
+    valid = true;
+  } catch (e) {
+    errorCode = appleProvider.classifyError(e);
+  }
+
+  if (!valid) {
+    return NextResponse.json(
+      { valid: false, error: errorCode ?? "unknown" },
+      { status: errorCode === "auth_invalid" ? 401 : 502 },
+    );
+  }
+
+  const { ciphertext, iv } = encryptPassword(appPassword);
+  await prisma.appleCalendarCredential.upsert({
+    where: { userId: session.user.id },
+    create: {
+      userId: session.user.id,
+      appleId,
+      encryptedPassword: ciphertext,
+      iv,
+      lastValidatedAt: new Date(),
+      lastError: null,
+    },
+    update: {
+      appleId,
+      encryptedPassword: ciphertext,
+      iv,
+      lastValidatedAt: new Date(),
+      lastError: null,
+    },
+  });
+
+  return NextResponse.json({ valid: true }, { status: 200 });
+}

--- a/src/app/api/v2/trips/[id]/calendar/apple/connect/route.ts
+++ b/src/app/api/v2/trips/[id]/calendar/apple/connect/route.ts
@@ -1,0 +1,30 @@
+/**
+ * spec 025 (#417) — Apple iCloud 공유 캘린더 연결.
+ *
+ * POST /api/v2/trips/[id]/calendar/apple/connect
+ *
+ * 사전 조건: validate 라우트로 AppleCalendarCredential 저장 완료.
+ * 흐름: service.connectAppleCalendar 위임. capability "manual"로 멤버 ACL 자동 부여 0회 +
+ * `manualAclGuidance` 응답 포함.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { connectAppleCalendar } from "@/lib/calendar/service";
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+  const tripId = Number((await params).id);
+  if (!Number.isFinite(tripId)) {
+    return NextResponse.json({ error: "bad_trip_id" }, { status: 400 });
+  }
+
+  const result = await connectAppleCalendar({ userId: session.user.id, tripId });
+  return NextResponse.json(result.body, { status: result.status });
+}

--- a/src/lib/calendar/service.ts
+++ b/src/lib/calendar/service.ts
@@ -411,6 +411,108 @@ export async function connectCalendar(
   return ok(body);
 }
 
+/**
+ * Apple iCloud CalDAV 전용 연결 (spec 025 #417).
+ *
+ * Google과 분리한 이유:
+ *  - Apple은 capability `manual`이라 멤버 ACL 자동 부여 단계 0
+ *  - 자격증명 입력 흐름이 OAuth가 아닌 위자드 → 별도 진입점이 자연스러움
+ *  - createCalendar의 calendar-home URL 추정 등 Google과 동작 분기가 큼
+ *
+ * 사전 조건: validate 라우트로 AppleCalendarCredential row가 이미 저장되어 있어야 한다.
+ */
+export async function connectAppleCalendar(
+  caller: CallerCtx,
+): Promise<
+  CalendarServiceResult<
+    TripCalendarLinkResponse & { manualAclGuidance?: string }
+  >
+> {
+  const member = await getTripMember(caller.tripId, caller.userId);
+  if (!member) return err(403, { error: "not_a_member" });
+  if (member.role !== TripRole.OWNER) return err(403, { error: "owner_only" });
+
+  const provider = getProvider("APPLE");
+  const hasAuth = await provider.hasValidAuth(caller.userId);
+  if (!hasAuth) {
+    return err(409, {
+      error: "apple_not_authenticated",
+      reauthUrl: `/trips/${caller.tripId}/calendar/connect-apple`,
+    });
+  }
+
+  const trip = await prisma.trip.findUnique({
+    where: { id: caller.tripId },
+    select: { id: true, title: true },
+  });
+  if (!trip) return err(404, { error: "trip_not_found" });
+
+  let link = await prisma.tripCalendarLink.findUnique({
+    where: { tripId: caller.tripId },
+  });
+
+  if (!link) {
+    let createdRef;
+    try {
+      createdRef = await provider.createCalendar(
+        caller.userId,
+        dedicatedCalendarName(trip.title),
+      );
+    } catch (e) {
+      const code = provider.classifyError(e);
+      if (code === "auth_invalid") {
+        return err(409, {
+          error: "apple_not_authenticated",
+          reauthUrl: `/trips/${caller.tripId}/calendar/connect-apple`,
+        });
+      }
+      return err(502, {
+        error: "calendar_create_failed",
+        reason: code ?? "unknown",
+      });
+    }
+    link = await prisma.tripCalendarLink.create({
+      data: {
+        tripId: caller.tripId,
+        ownerId: caller.userId,
+        provider: "APPLE",
+        calendarId: createdRef.calendarId,
+        calendarName: createdRef.displayName,
+      },
+    });
+  } else if (link.provider !== "APPLE") {
+    return err(409, {
+      error: "already_linked_other_provider",
+      currentProvider: link.provider,
+    });
+  }
+
+  // capability "manual" — 멤버 ACL 자동 부여 0회. 안내 텍스트만 응답에 포함.
+  const members = await loadMembersWithEmails(caller.tripId);
+  const otherMemberEmails = members
+    .filter((m) => m.role !== TripRole.OWNER && m.user.email)
+    .map((m) => m.user.email!);
+
+  const guidance =
+    otherMemberEmails.length > 0
+      ? `Apple Calendar 앱에서 [${otherMemberEmails.join(", ")}]을 캘린더 공유로 직접 초대해 주세요.`
+      : undefined;
+
+  const body: TripCalendarLinkResponse & { manualAclGuidance?: string } = {
+    status: "ok",
+    link: toLinkState(link),
+    members: members.map((m) => ({
+      userId: m.userId,
+      email: m.user.email ?? "",
+      role: m.role,
+      aclRole: mapRoleToAcl(m.role),
+      aclStatus: "granted",
+    })),
+    ...(guidance ? { manualAclGuidance: guidance } : {}),
+  };
+  return ok(body);
+}
+
 export async function disconnectCalendar(
   caller: CallerCtx,
 ): Promise<CalendarServiceResult<{ status: "ok" }>> {

--- a/tests/unit/calendar/service-manual-acl-branch.test.ts
+++ b/tests/unit/calendar/service-manual-acl-branch.test.ts
@@ -1,0 +1,239 @@
+/**
+ * spec 025 (#417) — service.connectAppleCalendar의 capability "manual" 분기 검증.
+ *
+ * Apple link 연결 시:
+ *  - 멤버 ACL 자동 호출(provider.upsertMemberAcl) 0회
+ *  - manualAclGuidance 텍스트가 응답 body에 포함
+ *  - members 배열은 "granted"로 표기되지만 실제 ACL은 사용자가 직접 처리
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TripRole } from "@prisma/client";
+
+// 외부 의존 mock
+vi.mock("tsdav", () => ({ createDAVClient: vi.fn() }));
+vi.mock("@/lib/gcal/client", () => ({
+  getCalendarClient: vi.fn(),
+  classifyError: vi.fn(),
+  getStatus: vi.fn(),
+}));
+vi.mock("@/lib/gcal/auth", () => ({
+  hasCalendarScope: vi.fn(),
+  buildConsentRedirectUrl: vi.fn(),
+}));
+vi.mock("@/lib/gcal/acl", () => ({
+  upsertAcl: vi.fn(),
+  deleteAcl: vi.fn(),
+  mapRoleToAcl: (r: TripRole) =>
+    r === TripRole.OWNER ? "owner" : r === TripRole.HOST ? "writer" : "reader",
+}));
+vi.mock("@/lib/gcal/format", () => ({
+  dedicatedCalendarName: (t: string) => `${t} (trip-planner)`,
+}));
+vi.mock("@/lib/gcal/sync", () => ({ syncActivities: vi.fn() }));
+
+// Prisma mock
+const tripCalendarLinkFindUnique = vi.fn();
+const tripCalendarLinkCreate = vi.fn();
+const tripFindUnique = vi.fn();
+const tripMemberFindMany = vi.fn();
+const appleCredFindUnique = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    tripCalendarLink: {
+      findUnique: (...a: unknown[]) => tripCalendarLinkFindUnique(...a),
+      create: (...a: unknown[]) => tripCalendarLinkCreate(...a),
+      findFirst: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+    trip: { findUnique: (...a: unknown[]) => tripFindUnique(...a) },
+    tripMember: {
+      findMany: (...a: unknown[]) => tripMemberFindMany(...a),
+      findUnique: vi.fn(),
+    },
+    user: { findUnique: vi.fn() },
+    memberCalendarSubscription: { findUnique: vi.fn(), upsert: vi.fn() },
+    appleCalendarCredential: {
+      findUnique: (...a: unknown[]) => appleCredFindUnique(...a),
+      update: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth-helpers", () => ({ getTripMember: vi.fn() }));
+
+// appleProvider 일부 메서드 mock — capability·createCalendar·hasValidAuth만 stub
+vi.mock("@/lib/calendar/provider/apple", () => ({
+  appleProvider: {
+    id: "APPLE",
+    capabilities: {
+      autoMemberAcl: "manual",
+      supportsCalendarCreation: true,
+      supportsCalendarSelection: true,
+    },
+    hasValidAuth: vi.fn(),
+    createCalendar: vi.fn(),
+    upsertMemberAcl: vi.fn(),
+    revokeMemberAcl: vi.fn(),
+    classifyError: vi.fn(),
+  },
+}));
+
+import { connectAppleCalendar } from "@/lib/calendar/service";
+import { getTripMember } from "@/lib/auth-helpers";
+import { appleProvider } from "@/lib/calendar/provider/apple";
+
+const getTripMemberMock = vi.mocked(getTripMember);
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  // appleProvider.capabilities는 vi.resetAllMocks가 건드리지 않는 plain object
+  Object.assign(appleProvider, {
+    id: "APPLE",
+    capabilities: {
+      autoMemberAcl: "manual",
+      supportsCalendarCreation: true,
+      supportsCalendarSelection: true,
+    },
+  });
+});
+
+describe("connectAppleCalendar — capability manual 분기", () => {
+  it("OWNER 아님 → owner_only 403", async () => {
+    getTripMemberMock.mockResolvedValue({
+      id: 1,
+      tripId: 1,
+      userId: "u1",
+      role: TripRole.HOST,
+    } as Awaited<ReturnType<typeof getTripMember>>);
+    const r = await connectAppleCalendar({ userId: "u1", tripId: 1 });
+    expect(r.status).toBe(403);
+    expect(r.body).toEqual({ error: "owner_only" });
+  });
+
+  it("hasValidAuth false → apple_not_authenticated 409 + reauthUrl", async () => {
+    getTripMemberMock.mockResolvedValue({
+      id: 1,
+      tripId: 1,
+      userId: "u1",
+      role: TripRole.OWNER,
+    } as Awaited<ReturnType<typeof getTripMember>>);
+    vi.mocked(appleProvider.hasValidAuth).mockResolvedValue(false);
+    const r = await connectAppleCalendar({ userId: "u1", tripId: 1 });
+    expect(r.status).toBe(409);
+    expect((r.body as { error: string }).error).toBe("apple_not_authenticated");
+    expect((r.body as { reauthUrl?: string }).reauthUrl).toContain(
+      "/trips/1/calendar/connect-apple",
+    );
+  });
+
+  it("멤버 2명 trip 첫 연결 → manualAclGuidance 포함, upsertMemberAcl 호출 0회", async () => {
+    getTripMemberMock.mockResolvedValue({
+      id: 1,
+      tripId: 1,
+      userId: "u1",
+      role: TripRole.OWNER,
+    } as Awaited<ReturnType<typeof getTripMember>>);
+    vi.mocked(appleProvider.hasValidAuth).mockResolvedValue(true);
+    tripFindUnique.mockResolvedValue({ id: 1, title: "신혼여행" });
+    tripCalendarLinkFindUnique.mockResolvedValue(null);
+    vi.mocked(appleProvider.createCalendar).mockResolvedValue({
+      calendarId: "https://caldav.icloud.com/u1/calendars/trip-planner-abc/",
+      displayName: "신혼여행 (trip-planner)",
+      components: ["VEVENT"],
+    });
+    tripCalendarLinkCreate.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+      id: 100,
+      tripId: 1,
+      ownerId: "u1",
+      provider: "APPLE",
+      calendarId: data.calendarId,
+      calendarName: data.calendarName,
+      lastSyncedAt: null,
+      lastError: null,
+      skippedCount: 0,
+    }));
+    tripMemberFindMany.mockResolvedValue([
+      { userId: "u1", role: TripRole.OWNER, user: { id: "u1", email: "owner@example.com" } },
+      { userId: "u2", role: TripRole.HOST, user: { id: "u2", email: "host@example.com" } },
+      { userId: "u3", role: TripRole.GUEST, user: { id: "u3", email: "guest@example.com" } },
+    ]);
+
+    const r = await connectAppleCalendar({ userId: "u1", tripId: 1 });
+
+    expect(r.status).toBe(200);
+    const body = r.body as {
+      status: string;
+      manualAclGuidance?: string;
+      members: Array<{ email: string }>;
+    };
+    expect(body.status).toBe("ok");
+    expect(body.manualAclGuidance).toContain("host@example.com");
+    expect(body.manualAclGuidance).toContain("guest@example.com");
+    // upsertMemberAcl이 절대 호출되지 않는지 검증 (capability manual 핵심)
+    expect(appleProvider.upsertMemberAcl).not.toHaveBeenCalled();
+  });
+
+  it("이미 GOOGLE link 존재 → already_linked_other_provider 409", async () => {
+    getTripMemberMock.mockResolvedValue({
+      id: 1,
+      tripId: 1,
+      userId: "u1",
+      role: TripRole.OWNER,
+    } as Awaited<ReturnType<typeof getTripMember>>);
+    vi.mocked(appleProvider.hasValidAuth).mockResolvedValue(true);
+    tripFindUnique.mockResolvedValue({ id: 1, title: "신혼여행" });
+    tripCalendarLinkFindUnique.mockResolvedValue({
+      id: 50,
+      tripId: 1,
+      provider: "GOOGLE",
+      calendarId: "google-cal-id",
+      calendarName: "기존",
+      ownerId: "u1",
+      lastSyncedAt: null,
+      lastError: null,
+      skippedCount: 0,
+    });
+    const r = await connectAppleCalendar({ userId: "u1", tripId: 1 });
+    expect(r.status).toBe(409);
+    expect((r.body as { error: string }).error).toBe("already_linked_other_provider");
+    expect((r.body as { currentProvider: string }).currentProvider).toBe("GOOGLE");
+  });
+
+  it("멤버 0명 (오너 단독) → manualAclGuidance 부재", async () => {
+    getTripMemberMock.mockResolvedValue({
+      id: 1,
+      tripId: 1,
+      userId: "u1",
+      role: TripRole.OWNER,
+    } as Awaited<ReturnType<typeof getTripMember>>);
+    vi.mocked(appleProvider.hasValidAuth).mockResolvedValue(true);
+    tripFindUnique.mockResolvedValue({ id: 1, title: "혼자여행" });
+    tripCalendarLinkFindUnique.mockResolvedValue(null);
+    vi.mocked(appleProvider.createCalendar).mockResolvedValue({
+      calendarId: "https://caldav.icloud.com/u1/calendars/trip-planner-solo/",
+      displayName: "혼자여행 (trip-planner)",
+      components: ["VEVENT"],
+    });
+    tripCalendarLinkCreate.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+      id: 101,
+      tripId: 1,
+      ownerId: "u1",
+      provider: "APPLE",
+      calendarId: data.calendarId,
+      calendarName: data.calendarName,
+      lastSyncedAt: null,
+      lastError: null,
+      skippedCount: 0,
+    }));
+    tripMemberFindMany.mockResolvedValue([
+      { userId: "u1", role: TripRole.OWNER, user: { id: "u1", email: "owner@example.com" } },
+    ]);
+    const r = await connectAppleCalendar({ userId: "u1", tripId: 1 });
+    expect(r.status).toBe(200);
+    const body = r.body as { manualAclGuidance?: string };
+    expect(body.manualAclGuidance).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

위자드(다음 PR) 진입점. spec 025 (#417 apple-caldav-provider)의 백엔드 라우트와 service 분기 완성.

## 신규 라우트

| 메서드 | 경로 | 설명 |
|---|---|---|
| `POST` | `/api/v2/calendar/apple/validate` | `appleId+appPassword` 검증 + `AppleCalendarCredential` AES-256-GCM 암호화 upsert |
| `GET` | `/api/v2/calendar/apple/calendars` | `listCalendars` (VEVENT 자동 필터) |
| `POST` | `/api/v2/trips/[id]/calendar/apple/connect` | `service.connectAppleCalendar` 위임 |

## service.connectAppleCalendar

- OWNER만 허용 (`owner_only` 403)
- `provider.hasValidAuth` 검증 → 실패 시 `apple_not_authenticated` 409 + `reauthUrl`
- `provider.createCalendar`로 MKCALENDAR (실패 시 `calendar_create_failed` 502)
- 멤버 ACL 자동 호출 **0회** (capability `manual` 분기)
- 응답 body에 `manualAclGuidance` 텍스트
- 이미 다른 provider link 존재 시 `already_linked_other_provider` 409

## 테스트 (전체 56 통과)

`service-manual-acl-branch.test.ts` 5 cases — OWNER 검증 / hasValidAuth false / manualAclGuidance / already_linked / 멤버 0명.

## Out of Scope (후속 PR)

- 위자드 UI (T011, T018~T023)
- sync-engine 분해 (T030~T032)
- 401 UI 배너 + 재인증 (T024~T026)
- VTODO + Google 회귀 통합 테스트 (T027, T033)

## 관련

- Issue #417 / spec 025 — T014~T017, T028, T029 완료
- Milestone v2.11.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)