### PR TITLE
fix: dev OAuth 콜백 후 무한 로그인 루프 — jwt callback prisma 실패 가드

### DIFF
--- a/changes/441.fix.md
+++ b/changes/441.fix.md
@@ -1,0 +1,1 @@
+**dev 환경 OAuth 콜백 후 무한 로그인 루프 fix** — `auth.ts`의 jwt callback에서 prisma `user.findUnique` 호출을 try/catch로 감싸 일시적 prisma 실패(connection 타임아웃·schema mismatch 등) 시 token을 무효화하지 않고 통과시키도록 변경. 왜: v2.11.0 머지 후 dev에서 OAuth 인증 직후 token이 무효화되어 /auth/signin으로 재진입하는 무한 루프가 발생. 단일 prisma 실패가 정상 사용자 세션까지 끊는 fail-closed 정책을 fail-open으로 완화 — #328 stale 감지(user 부재 시 무효화)는 정상 응답에서만 발동하도록 좁힘.

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -11,12 +11,23 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       if (user?.id) token.id = user.id;
       // DB 분리·이관·데이터 초기화 등으로 쿠키의 userId가 현재 DB에 존재하지 않을 수
       // 있다(#328). 쿠키가 stale이면 세션을 무효화하여 재로그인으로 흐르게 한다.
+      //
+      // v2.11.2 fix: prisma 일시 실패(connection 타임아웃·schema mismatch 등)로
+      // findUnique가 throw하면 token을 무효화해서는 안 된다. 무효화 시 OAuth 콜백
+      // 직후 정상 사용자도 즉시 세션이 끊겨 /auth/signin으로 재진입하는 무한 루프가
+      // 발생한다(2026-04-28 dev 보고). throw는 token 통과로 안전 측 분기.
       if (token.id) {
-        const exists = await prisma.user.findUnique({
-          where: { id: token.id as string },
-          select: { id: true },
-        });
-        if (!exists) return null;
+        try {
+          const exists = await prisma.user.findUnique({
+            where: { id: token.id as string },
+            select: { id: true },
+          });
+          if (!exists) return null;
+        } catch (err) {
+          console.warn(
+            `[auth] jwt callback prisma.user.findUnique failed — keeping token. id=${String(token.id)} err=${err instanceof Error ? err.message : err}`,
+          );
+        }
       }
       return token;
     },


### PR DESCRIPTION
## Problem
v2.11.0 머지 후 dev에서 OAuth 인증 직후 `/auth/signin` 무한 루프.

## Hypothesis (probable root cause)
`auth.ts`의 jwt callback에서 `prisma.user.findUnique`가 일시 실패(connection timeout · schema race · 함수 cold start 영향)하면 catch 없이 throw되어 #328 stale 감지가 정상 사용자 token까지 무효화. 사용자가 즉시 /auth/signin으로 재진입 → OAuth 콜백 다시 → token 다시 무효화 → 무한 루프.

## Fix
jwt callback의 prisma 호출을 try/catch로 감싸 fail-open 처리. throw 시 token 통과. #328의 stale 감지는 prisma가 정상 응답으로 null을 반환하는 케이스에만 발동.

## 관련
- v2.11.0 (#436), v2.11.1 (#439) 후속
- past fix: #328, #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)