### PR TITLE
fix: Apple 진입 카드 표시 조건 분기 (1 provider 정책 반영)

### DIFF
--- a/changes/447.fix.md
+++ b/changes/447.fix.md
@@ -1,0 +1,1 @@
+**Apple 진입 카드 표시 조건 분기** — 이미 다른 provider(Google)에 연결된 trip에서는 Apple 카드를 자동으로 hide. 왜: spec 024 Clarification 6의 "한 trip = 1 provider" 정책에도 불구하고 카드가 노출되어 사용자가 위자드를 끝까지 진행한 뒤에야 `already_linked_other_provider` 차단을 만나는 좌절이 있었다(2026-04-28 dev 피드백). Apple 연결된 trip에는 "연결됨" 안내 카드 표시. Google 패널과의 통합·해제 UI는 v2.12 후속.

--- a/src/app/trips/[id]/page.tsx
+++ b/src/app/trips/[id]/page.tsx
@@ -46,7 +46,7 @@ async function DbTripPage({ tripId }: { tripId: number }) {
   const session = await auth();
   if (!session?.user?.id) redirect("/auth/signin");
 
-  const [member, trip] = await Promise.all([
+  const [member, trip, calendarLink] = await Promise.all([
     prisma.tripMember.findUnique({
       where: { tripId_userId: { tripId, userId: session.user.id } },
     }),
@@ -55,6 +55,10 @@ async function DbTripPage({ tripId }: { tripId: number }) {
       include: {
         days: { orderBy: { date: "asc" } },
       },
+    }),
+    prisma.tripCalendarLink.findUnique({
+      where: { tripId },
+      select: { provider: true },
     }),
   ]);
   if (!member || !trip) notFound();
@@ -108,7 +112,11 @@ async function DbTripPage({ tripId }: { tripId: number }) {
 
       <GCalLinkPanel tripId={tripId} role={member.role} />
 
-      <AppleEntryCard tripId={tripId} role={member.role} />
+      <AppleEntryCard
+        tripId={tripId}
+        role={member.role}
+        currentProvider={calendarLink?.provider ?? null}
+      />
 
       <MemberList tripId={tripId} />
 

--- a/src/components/calendar/AppleEntryCard.tsx
+++ b/src/components/calendar/AppleEntryCard.tsx
@@ -1,26 +1,56 @@
 "use client";
 
 /**
- * spec 025 (#417, hotfix v2.11.1) — trip 페이지에 Apple 캘린더 위자드 진입 카드.
+ * spec 025 (#417, hotfix v2.11.1+v2.11.4) — trip 페이지의 Apple 캘린더 진입 카드.
  *
- * 위자드 페이지 자체(`/trips/[id]/calendar/connect-apple`)는 v2.11.0에서 도입됐지만
- * 진입 UI가 없어 사용자가 직접 URL을 입력해야 했다. 본 카드를 trip 페이지에 노출해
- * OWNER가 한 번에 진입할 수 있도록 한다.
+ * 표시 분기 (spec 024 Clarification 6 — 한 trip = 1 provider 정책):
+ *  - 미연결 (currentProvider == null) + OWNER → "Apple 캘린더 연결 (Beta)" 버튼
+ *  - GOOGLE 연결됨 → 카드 자체를 hide (사용자가 Google 패널에서 먼저 해제하도록 유도)
+ *  - APPLE 연결됨 → "Apple 캘린더 연결됨" 안내 카드 (해제 UI는 v2.12 후속)
+ *  - GUEST/HOST → 카드 hide (connectAppleCalendar는 OWNER 전용)
  *
- * 연결 후 상태 표시·해제 UI는 v2.12에서 정식 패널로 분리 예정.
+ * v2.12 통합: Google·Apple 패널을 단일 컴포넌트로 통합 + 해제·전환 흐름 일원화 예정.
  */
 
 import Link from "next/link";
 import { Card } from "@/components/ui/card";
-import type { TripRole } from "@prisma/client";
+import type { CalendarProviderId, TripRole } from "@prisma/client";
 
 interface AppleEntryCardProps {
   tripId: number;
   role: TripRole;
+  /** 해당 trip의 현재 link.provider. 미연결이면 null. */
+  currentProvider: CalendarProviderId | null;
 }
 
-export default function AppleEntryCard({ tripId, role }: AppleEntryCardProps) {
+export default function AppleEntryCard({
+  tripId,
+  role,
+  currentProvider,
+}: AppleEntryCardProps) {
   if (role !== "OWNER") return null;
+
+  // 다른 provider(GOOGLE)에 이미 연결됨 → 카드 hide.
+  // 사용자는 Google 패널에서 해제 후 Apple 시도. 같은 trip 페이지에 두 가지 진입을
+  // 동시에 노출하면 spec 024 Clarification 6의 "1 provider" 정책과 사용자 기대가
+  // 어긋난다(2026-04-28 dev 검증 피드백 — already_linked_other_provider 좌절).
+  if (currentProvider && currentProvider !== "APPLE") {
+    return null;
+  }
+
+  if (currentProvider === "APPLE") {
+    return (
+      <Card className="p-4">
+        <div className="space-y-1">
+          <h3 className="text-sm font-medium">Apple 캘린더 연결됨</h3>
+          <p className="text-xs text-muted-foreground">
+            iPhone·iPad·Mac Calendar 앱에서 본 여행 일정을 확인할 수 있습니다.
+            연결 해제·재인증 UI는 후속 회차에서 제공 예정입니다.
+          </p>
+        </div>
+      </Card>
+    );
+  }
 
   return (
     <Card className="p-4">


### PR DESCRIPTION
## Problem
이미 GOOGLE에 연결된 trip에서도 Apple 진입 카드가 노출 → 사용자가 위자드 Step 3까지 진행 후 `already_linked_other_provider`로 차단되는 좌절 경로(2026-04-28 dev 검증 피드백).

## Fix
trip 페이지에서 `link.provider` server-side 조회 후 `AppleEntryCard`에 prop 전달. 분기:
- 미연결 + OWNER → "Apple 캘린더 연결 (Beta)" 버튼
- GOOGLE 연결됨 → 카드 hide
- APPLE 연결됨 → "Apple 캘린더 연결됨" 안내
- GUEST/HOST → hide

## Out of Scope (v2.12)
- Google·Apple 패널 통합 (provider 선택·해제·전환 단일 흐름)
- Apple 연결됨 카드의 해제·재인증 버튼

🤖 Generated with [Claude Code](https://claude.com/claude-code)