### PR TITLE
fix: 캘린더 연결 UX 일괄 개선 (provider 선택 + 위자드 단축)

### DIFF
--- a/src/app/trips/[id]/calendar/connect-apple/page.tsx
+++ b/src/app/trips/[id]/calendar/connect-apple/page.tsx
@@ -2,9 +2,10 @@
  * spec 025 (#417) — Apple 캘린더 연결 위자드 진입 페이지.
  *
  * /trips/[id]/calendar/connect-apple
- *   ?apple_reauth=1 → 재인증 모드 (Step 3부터, 캘린더 재생성 안 함)
+ *   ?apple_reauth=1 → 재인증 모드 (Apple ID 필드 disabled, 캘린더 재생성 안 함)
  *
- * 권한 검증·redirect는 layout 또는 미들웨어에 위임. 본 페이지는 위자드 컴포넌트를 렌더만.
+ * 사용자 세션 이메일을 prefillEmail로 위자드에 전달. 위자드는 단일 화면 +
+ * collapsible 가이드 + dash 자동 포맷팅 + toast 완료(v2.11.5).
  */
 
 import { redirect } from "next/navigation";
@@ -31,7 +32,11 @@ export default async function ConnectAppleCalendarPage({
 
   return (
     <main className="container mx-auto py-8">
-      <AppleConnectWizard tripId={tripId} reauth={isReauth} />
+      <AppleConnectWizard
+        tripId={tripId}
+        prefillEmail={session.user.email ?? undefined}
+        reauth={isReauth}
+      />
     </main>
   );
 }

--- a/src/app/trips/[id]/page.tsx
+++ b/src/app/trips/[id]/page.tsx
@@ -11,6 +11,7 @@ import LeaveTripButton from "@/components/LeaveTripButton";
 import MemberList from "@/components/MemberList";
 import GCalLinkPanel from "@/components/GCalLinkPanel";
 import AppleEntryCard from "@/components/calendar/AppleEntryCard";
+import CalendarProviderChoice from "@/components/calendar/CalendarProviderChoice";
 import AddDayButton from "@/components/AddDayButton";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { remark } from "remark";
@@ -30,19 +31,29 @@ export const dynamic = "force-dynamic";
 
 export default async function TripDetailPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams: Promise<{ provider?: string }>;
 }) {
   const { id } = await params;
   const tripId = parseInt(id);
+  const sp = await searchParams;
+  const providerHint = sp.provider === "google" ? "google" : null;
 
   if (isNaN(tripId)) notFound();
-  return <DbTripPage tripId={tripId} />;
+  return <DbTripPage tripId={tripId} providerHint={providerHint} />;
 }
 
 /* ── DB 기반 여행 상세 ── */
 
-async function DbTripPage({ tripId }: { tripId: number }) {
+async function DbTripPage({
+  tripId,
+  providerHint,
+}: {
+  tripId: number;
+  providerHint: "google" | null;
+}) {
   const session = await auth();
   if (!session?.user?.id) redirect("/auth/signin");
 
@@ -110,13 +121,18 @@ async function DbTripPage({ tripId }: { tripId: number }) {
         </Card>
       )}
 
-      <GCalLinkPanel tripId={tripId} role={member.role} />
-
-      <AppleEntryCard
-        tripId={tripId}
-        role={member.role}
-        currentProvider={calendarLink?.provider ?? null}
-      />
+      {/* spec 024 Clarification 6: 한 trip = 1 provider · 1 외부 캘린더.
+          - 미연결 + OWNER + provider 미선택 → CalendarProviderChoice (Apple 권장 + Google 안내)
+          - GOOGLE 연결됨 OR providerHint=google 강제 노출 → GCalLinkPanel
+          - APPLE 연결됨 → AppleEntryCard
+          - 호스트/게스트 미연결 → 카드 없음 (선택권 없음) */}
+      {!calendarLink && member.role === "OWNER" && !providerHint && (
+        <CalendarProviderChoice tripId={tripId} />
+      )}
+      {(calendarLink?.provider === "GOOGLE" || providerHint === "google") && (
+        <GCalLinkPanel tripId={tripId} role={member.role} />
+      )}
+      {calendarLink?.provider === "APPLE" && <AppleEntryCard />}
 
       <MemberList tripId={tripId} />
 

--- a/src/components/calendar/AppleConnectWizard.tsx
+++ b/src/components/calendar/AppleConnectWizard.tsx
@@ -1,40 +1,45 @@
 "use client";
 
 /**
- * spec 025 (#417) — Apple iCloud CalDAV 연결 위자드.
+ * spec 025 (#417, hotfix v2.11.5) — Apple iCloud CalDAV 연결 단일 화면.
  *
- * 4단계 stepper:
- *  Step 1 — 사전 안내 (2FA 활성 + 패스키 또는 비밀번호 인증 가능 여부)
- *  Step 2 — appleid.apple.com 외부 링크 + 가이드 (캡쳐 3장)
- *  Step 3 — Apple ID + 16자리 앱 암호 입력 + /validate 호출
- *  Step 4 — connectAppleCalendar 결과 + 첫 sync 안내
+ * 4단계 stepper(v2.11.0) → 단일 화면 + collapsible 가이드 + prefill +
+ * dash 자동 포맷팅 + toast 완료(2026-04-28 사용자 피드백 — 4단계 허들 큼).
  *
- * 한 컴포넌트에 모든 단계 — Step 별 분리 컴포넌트 분해는 후속 회차에서 검토.
+ * 진입:
+ *  - 신규: prefill된 이메일(session.user.email) + 빈 암호 → 16자리 입력 → "연결"
+ *  - 재인증(`?apple_reauth=1`): Apple ID 필드 disabled + 새 16자리만 받기, 캘린더
+ *    재생성 0회
  */
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card } from "@/components/ui/card";
 
-type WizardStep = 1 | 2 | 3 | 4;
+interface AppleConnectWizardProps {
+  tripId: number;
+  /** 사용자 세션 이메일 — Apple ID에 자동 prefill. 사용자가 수정 가능. */
+  prefillEmail?: string;
+  /** 재인증 모드 — true면 Apple ID 필드 disabled + 캘린더 재생성 안 함. */
+  reauth?: boolean;
+}
 
 /**
  * connect 라우트의 에러 코드를 사용자가 읽을 수 있는 한국어로 매핑.
- * 코드 그대로 노출되면 의미 전달 실패(2026-04-28 사용자 피드백).
  */
 function mapConnectError(
   code: string | undefined,
-  data: { currentProvider?: string; reauthUrl?: string; reason?: string },
+  data: { currentProvider?: string; reason?: string },
 ): string {
   switch (code) {
     case "already_linked_other_provider":
       return data.currentProvider === "GOOGLE"
-        ? "이 여행은 이미 구글 캘린더에 연결되어 있습니다. 기존 구글 캘린더 패널에서 연결 해제 후 다시 시도해 주세요."
+        ? "이 여행은 이미 구글 캘린더에 연결되어 있습니다. 기존 구글 패널에서 해제 후 다시 시도해 주세요."
         : "이 여행은 이미 다른 캘린더에 연결되어 있습니다. 기존 연결을 해제 후 다시 시도해 주세요.";
     case "owner_only":
       return "주인만 캘린더를 연결할 수 있습니다.";
@@ -43,7 +48,7 @@ function mapConnectError(
     case "trip_not_found":
       return "여행 정보를 찾을 수 없습니다.";
     case "apple_not_authenticated":
-      return "Apple 자격증명이 만료되었거나 누락되었습니다. 위자드 처음부터 다시 시도해 주세요.";
+      return "Apple 자격증명이 만료되었습니다. 다시 시도해 주세요.";
     case "calendar_create_failed":
       return `iCloud 캘린더 생성에 실패했습니다. 잠시 후 다시 시도해 주세요. (${data.reason ?? "unknown"})`;
     default:
@@ -53,75 +58,76 @@ function mapConnectError(
   }
 }
 
-interface AppleConnectWizardProps {
-  tripId: number;
-  /** 위자드 종료 시 호출. UI는 모달 또는 별도 페이지 둘 다 지원. */
-  onClose?: () => void;
-  /** 재인증 모드 — true면 Step 3부터 시작, 캘린더 재생성 안 함. */
-  reauth?: boolean;
+/**
+ * Apple 16자리 앱 암호의 표준 표기는 `xxxx-xxxx-xxxx-xxxx`. 사용자가 어떻게
+ * 입력하든(공백·dash 혼재) 영문/숫자만 추려서 4자리마다 dash로 재구성.
+ * 검증·저장은 dash 제거 후 16자만.
+ */
+function formatAppPassword(input: string): string {
+  const cleaned = input.replace(/[^a-zA-Z0-9]/g, "").slice(0, 16);
+  return cleaned.replace(/(.{4})(?=.)/g, "$1-");
 }
 
 export default function AppleConnectWizard({
   tripId,
-  onClose,
+  prefillEmail,
   reauth = false,
 }: AppleConnectWizardProps) {
   const router = useRouter();
-  const [step, setStep] = useState<WizardStep>(reauth ? 3 : 1);
-  const [appleId, setAppleId] = useState("");
+  const [appleId, setAppleId] = useState(prefillEmail ?? "");
   const [appPassword, setAppPassword] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [validateError, setValidateError] = useState<string | null>(null);
-  const [connectResult, setConnectResult] = useState<{
-    calendarName?: string | null;
-    manualAclGuidance?: string;
-  } | null>(null);
+  const [guideOpen, setGuideOpen] = useState(false);
 
-  async function handleValidate() {
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
     setValidateError(null);
     setSubmitting(true);
     try {
-      const res = await fetch("/api/v2/calendar/apple/validate", {
+      // dash 제거하고 16자만 보냄 (백엔드는 \s+만 strip하므로 dash 사전 제거 필요).
+      const cleanPassword = appPassword.replace(/[^a-zA-Z0-9]/g, "");
+      const validateRes = await fetch("/api/v2/calendar/apple/validate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ appleId, appPassword }),
+        body: JSON.stringify({ appleId, appPassword: cleanPassword }),
       });
-      if (res.status === 401) {
+      if (validateRes.status === 401) {
         setValidateError(
           "암호가 잘못되었습니다 — appleid.apple.com에서 폐기·재발급 후 다시 시도해 주세요.",
         );
         return;
       }
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        setValidateError(`검증에 실패했습니다 (${data.error ?? res.status})`);
+      if (!validateRes.ok) {
+        const data = await validateRes.json().catch(() => ({}));
+        setValidateError(`검증에 실패했습니다 (${data.error ?? validateRes.status})`);
         return;
       }
 
       if (reauth) {
         toast.success("Apple 자격증명이 갱신되었습니다.");
-        onClose?.();
+        router.push(`/trips/${tripId}`);
         router.refresh();
         return;
       }
 
-      // 정상 흐름: Step 4로 이동하면서 connect 호출
       const connectRes = await fetch(
         `/api/v2/trips/${tripId}/calendar/apple/connect`,
         { method: "POST" },
       );
       const connectData = await connectRes.json().catch(() => ({}));
       if (!connectRes.ok) {
-        const code = connectData.error as string | undefined;
-        const msg = mapConnectError(code, connectData);
-        setValidateError(msg);
+        setValidateError(mapConnectError(connectData.error, connectData));
         return;
       }
-      setConnectResult({
-        calendarName: connectData.link?.calendarName ?? null,
-        manualAclGuidance: connectData.manualAclGuidance,
-      });
-      setStep(4);
+      toast.success(
+        `Apple 캘린더 "${connectData.link?.calendarName ?? "trip-planner"}"가 생성되었습니다. iPhone Calendar 앱에서 곧 표시됩니다.`,
+      );
+      if (connectData.manualAclGuidance) {
+        toast.info(connectData.manualAclGuidance);
+      }
+      router.push(`/trips/${tripId}`);
+      router.refresh();
     } catch (e) {
       setValidateError(
         e instanceof Error ? e.message : "네트워크 오류가 발생했습니다.",
@@ -131,84 +137,45 @@ export default function AppleConnectWizard({
     }
   }
 
-  const stepLabels = [
-    "1. 사전 확인",
-    "2. 앱 암호 발급",
-    "3. 입력 · 검증",
-    "4. 연결 완료",
-  ];
-
   return (
-    <Card className="mx-auto max-w-2xl space-y-6 p-6">
-      <header className="space-y-2">
-        <h2 className="text-xl font-semibold">Apple 캘린더 연결</h2>
-        <ol className="flex flex-wrap gap-2 text-sm text-muted-foreground">
-          {stepLabels.map((label, i) => {
-            const n = (i + 1) as WizardStep;
-            const active = n === step;
-            const done = n < step;
-            return (
-              <li
-                key={label}
-                className={
-                  active
-                    ? "rounded bg-primary px-2 py-1 font-medium text-primary-foreground"
-                    : done
-                      ? "rounded px-2 py-1 line-through opacity-60"
-                      : "rounded px-2 py-1"
-                }
-              >
-                {label}
-              </li>
-            );
-          })}
-        </ol>
+    <Card className="mx-auto max-w-xl space-y-5 p-6">
+      <header className="space-y-1">
+        <h2 className="text-lg font-semibold">Apple 캘린더 연결</h2>
+        <p className="text-sm text-muted-foreground">
+          Apple ID에 2단계 인증(2FA)이 활성화되어 있어야 하고,{" "}
+          <a
+            href="https://appleid.apple.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary underline underline-offset-2"
+          >
+            appleid.apple.com
+          </a>
+          에서 16자리 앱 전용 암호가 필요합니다.
+        </p>
+        <button
+          type="button"
+          onClick={() => setGuideOpen((o) => !o)}
+          className="text-xs font-medium text-muted-foreground hover:text-foreground"
+        >
+          {guideOpen ? "▾ 발급 가이드 닫기" : "▸ 발급 가이드 보기"}
+        </button>
       </header>
 
-      {step === 1 && (
-        <section className="space-y-4">
-          <h3 className="font-medium">사전 확인</h3>
-          <ul className="list-inside list-disc space-y-1 text-sm">
-            <li>Apple ID에 <strong>2단계 인증(2FA)</strong>이 활성화되어 있어야 합니다.</li>
-            <li>패스키 또는 비밀번호 어느 쪽으로 로그인하든 무관합니다.</li>
+      {guideOpen && (
+        <section className="space-y-3 rounded-md border border-dashed border-input bg-muted/30 p-3 text-sm">
+          <ol className="list-inside list-decimal space-y-1 text-xs">
             <li>
-              본 흐름은 Apple의{" "}
-              <strong>앱 전용 암호(app-specific password)</strong>를 발급받아 사용합니다.
-              일반 Apple ID 비밀번호는 입력하지 않습니다.
+              appleid.apple.com 로그인 → &ldquo;로그인 및 보안&rdquo; →{" "}
+              &ldquo;앱 암호&rdquo; → &ldquo;만들기&rdquo;
             </li>
-          </ul>
-          <div className="flex justify-end gap-2">
-            {onClose && (
-              <Button variant="ghost" onClick={onClose}>
-                취소
-              </Button>
-            )}
-            <Button onClick={() => setStep(2)}>다음</Button>
-          </div>
-        </section>
-      )}
-
-      {step === 2 && (
-        <section className="space-y-4">
-          <h3 className="font-medium">앱 전용 암호 발급</h3>
-          <ol className="list-inside list-decimal space-y-2 text-sm">
             <li>
-              <a
-                href="https://appleid.apple.com"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-primary underline"
-              >
-                appleid.apple.com
-              </a>
-              에 로그인 → &ldquo;로그인 및 보안&rdquo; → &ldquo;앱 암호&rdquo;.
+              라벨 <code>trip-planner</code> 입력
             </li>
-            <li>&ldquo;앱 암호 만들기&rdquo; 버튼을 클릭합니다.</li>
-            <li>라벨에 <code>trip-planner</code>를 입력합니다.</li>
-            <li>Apple이 표시한 16자리 암호를 복사합니다 (XXXX-XXXX-XXXX-XXXX 형태).</li>
+            <li>표시된 16자리 암호 복사 (한 번만 표시되니 즉시 입력)</li>
           </ol>
-          <div className="grid gap-3 sm:grid-cols-3">
-            <figure className="space-y-1">
+          <div className="grid grid-cols-3 gap-2">
+            <figure>
               <Image
                 src="/research/apple-caldav-screenshots/step-4-create-button.png"
                 alt="앱 암호 만들기 버튼"
@@ -216,11 +183,8 @@ export default function AppleConnectWizard({
                 height={200}
                 className="rounded border"
               />
-              <figcaption className="text-xs text-muted-foreground">
-                &ldquo;만들기&rdquo; 버튼
-              </figcaption>
             </figure>
-            <figure className="space-y-1">
+            <figure>
               <Image
                 src="/research/apple-caldav-screenshots/step-5-label.png"
                 alt="라벨 입력"
@@ -228,11 +192,8 @@ export default function AppleConnectWizard({
                 height={200}
                 className="rounded border"
               />
-              <figcaption className="text-xs text-muted-foreground">
-                라벨 trip-planner
-              </figcaption>
             </figure>
-            <figure className="space-y-1">
+            <figure>
               <Image
                 src="/research/apple-caldav-screenshots/step-6-password.png"
                 alt="16자리 암호 표시"
@@ -240,110 +201,72 @@ export default function AppleConnectWizard({
                 height={200}
                 className="rounded border"
               />
-              <figcaption className="text-xs text-muted-foreground">
-                16자리 암호 복사
-              </figcaption>
             </figure>
           </div>
           <p className="text-xs text-muted-foreground">
-            ⚠️ Apple은 이 16자리 암호를 한 번만 보여줍니다. 잃어버리면 폐기 후 재발급해야 합니다.
-            저희 서버는 이 값을 AES-256-GCM으로 암호화해 보관합니다.
+            ⚠️ 16자리 암호는 한 번만 표시됩니다. 분실 시 폐기 후 재발급이 필요합니다.
+            본 서버는 입력값을 AES-256-GCM으로 암호화해 보관합니다.
           </p>
-          <div className="flex justify-end gap-2">
-            <Button variant="ghost" onClick={() => setStep(1)}>
-              이전
-            </Button>
-            <Button onClick={() => setStep(3)}>다음</Button>
-          </div>
         </section>
       )}
 
-      {step === 3 && (
-        <section className="space-y-4">
-          <h3 className="font-medium">자격증명 입력</h3>
-          <div className="space-y-3">
-            <div className="space-y-1">
-              <Label htmlFor="apple-id">Apple ID (이메일)</Label>
-              <Input
-                id="apple-id"
-                type="email"
-                value={appleId}
-                onChange={(e) => setAppleId(e.target.value)}
-                placeholder="you@icloud.com"
-                autoComplete="username"
-                disabled={submitting}
-              />
-            </div>
-            <div className="space-y-1">
-              <Label htmlFor="app-password">앱 전용 암호 (16자리)</Label>
-              <Input
-                id="app-password"
-                type="password"
-                value={appPassword}
-                onChange={(e) => setAppPassword(e.target.value)}
-                placeholder="xxxx-xxxx-xxxx-xxxx"
-                autoComplete="current-password"
-                disabled={submitting}
-              />
-              <p className="text-xs text-muted-foreground">
-                appleid.apple.com에서 발급한 16자리 앱 전용 암호. 일반 Apple ID 비밀번호 아님.
-              </p>
-            </div>
-            {validateError && (
-              <p className="text-sm text-destructive" role="alert">
-                {validateError}
-              </p>
-            )}
-          </div>
-          <div className="flex justify-end gap-2">
-            {!reauth && (
-              <Button
-                variant="ghost"
-                onClick={() => setStep(2)}
-                disabled={submitting}
-              >
-                이전
-              </Button>
-            )}
-            <Button
-              onClick={handleValidate}
-              disabled={submitting || !appleId || !appPassword}
-            >
-              {submitting ? "검증 중…" : reauth ? "재인증" : "검증 후 연결"}
-            </Button>
-          </div>
-        </section>
-      )}
-
-      {step === 4 && (
-        <section className="space-y-4">
-          <h3 className="font-medium">연결 완료</h3>
-          <p className="text-sm">
-            Apple 캘린더 <strong>{connectResult?.calendarName ?? "trip-planner"}</strong>가
-            iCloud에 생성되었습니다. iPhone Calendar 앱에서 곧 표시됩니다(동기화에 수십 초 소요).
-          </p>
-          {connectResult?.manualAclGuidance && (
-            <div className="rounded border-l-4 border-amber-500 bg-amber-50 p-3 text-sm">
-              <p className="font-medium">동행자에게 캘린더 공유 안내</p>
-              <p className="mt-1">{connectResult.manualAclGuidance}</p>
-              <p className="mt-2 text-xs text-muted-foreground">
-                Apple은 trip-planner가 자동으로 멤버를 초대할 수 없는 구조입니다.
-                Calendar 앱 → 본 캘린더 → 캘린더 공유에서 직접 초대해 주세요.
-              </p>
-            </div>
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <div className="space-y-1">
+          <Label htmlFor="apple-id">Apple ID (이메일)</Label>
+          <Input
+            id="apple-id"
+            type="email"
+            value={appleId}
+            onChange={(e) => setAppleId(e.target.value)}
+            placeholder="you@icloud.com"
+            autoComplete="username"
+            disabled={submitting || reauth}
+            required
+          />
+          {reauth && (
+            <p className="text-xs text-muted-foreground">
+              재인증 모드 — Apple ID는 변경할 수 없습니다.
+            </p>
           )}
-          <div className="flex justify-end gap-2">
-            <Button
-              onClick={() => {
-                onClose?.();
-                router.refresh();
-              }}
-            >
-              닫기
-            </Button>
-          </div>
-        </section>
-      )}
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor="app-password">앱 전용 암호 (16자리)</Label>
+          <Input
+            id="app-password"
+            type="text"
+            inputMode="text"
+            value={appPassword}
+            onChange={(e) => setAppPassword(formatAppPassword(e.target.value))}
+            placeholder="xxxx-xxxx-xxxx-xxxx"
+            autoComplete="off"
+            spellCheck={false}
+            autoFocus={!!prefillEmail || reauth}
+            disabled={submitting}
+            required
+          />
+          <p className="text-xs text-muted-foreground">
+            appleid.apple.com에서 발급한 16자리 앱 전용 암호. 일반 Apple ID 비밀번호
+            아님. 입력 시 자동으로 4자리마다 dash로 정렬됩니다.
+          </p>
+        </div>
+        {validateError && (
+          <p className="text-sm text-destructive" role="alert">
+            {validateError}
+          </p>
+        )}
+        <div className="flex justify-end gap-2 pt-1">
+          <Button
+            type="submit"
+            disabled={
+              submitting ||
+              !appleId.trim() ||
+              appPassword.replace(/[^a-zA-Z0-9]/g, "").length !== 16
+            }
+          >
+            {submitting ? "검증 중…" : reauth ? "재인증" : "검증 후 연결"}
+          </Button>
+        </div>
+      </form>
     </Card>
   );
 }

--- a/src/components/calendar/AppleEntryCard.tsx
+++ b/src/components/calendar/AppleEntryCard.tsx
@@ -1,73 +1,23 @@
-"use client";
-
 /**
- * spec 025 (#417, hotfix v2.11.1+v2.11.4) — trip 페이지의 Apple 캘린더 진입 카드.
+ * spec 025 (#417, hotfix v2.11.5) — Apple 연결된 trip의 상태 카드.
  *
- * 표시 분기 (spec 024 Clarification 6 — 한 trip = 1 provider 정책):
- *  - 미연결 (currentProvider == null) + OWNER → "Apple 캘린더 연결 (Beta)" 버튼
- *  - GOOGLE 연결됨 → 카드 자체를 hide (사용자가 Google 패널에서 먼저 해제하도록 유도)
- *  - APPLE 연결됨 → "Apple 캘린더 연결됨" 안내 카드 (해제 UI는 v2.12 후속)
- *  - GUEST/HOST → 카드 hide (connectAppleCalendar는 OWNER 전용)
+ * v2.11.5에서 미연결 케이스는 CalendarProviderChoice가 담당. 본 카드는
+ * link.provider === "APPLE"일 때만 표시.
  *
- * v2.12 통합: Google·Apple 패널을 단일 컴포넌트로 통합 + 해제·전환 흐름 일원화 예정.
+ * 해제·재인증 UI는 v2.12 통합 패널에서 제공 예정.
  */
 
-import Link from "next/link";
 import { Card } from "@/components/ui/card";
-import type { CalendarProviderId, TripRole } from "@prisma/client";
 
-interface AppleEntryCardProps {
-  tripId: number;
-  role: TripRole;
-  /** 해당 trip의 현재 link.provider. 미연결이면 null. */
-  currentProvider: CalendarProviderId | null;
-}
-
-export default function AppleEntryCard({
-  tripId,
-  role,
-  currentProvider,
-}: AppleEntryCardProps) {
-  if (role !== "OWNER") return null;
-
-  // 다른 provider(GOOGLE)에 이미 연결됨 → 카드 hide.
-  // 사용자는 Google 패널에서 해제 후 Apple 시도. 같은 trip 페이지에 두 가지 진입을
-  // 동시에 노출하면 spec 024 Clarification 6의 "1 provider" 정책과 사용자 기대가
-  // 어긋난다(2026-04-28 dev 검증 피드백 — already_linked_other_provider 좌절).
-  if (currentProvider && currentProvider !== "APPLE") {
-    return null;
-  }
-
-  if (currentProvider === "APPLE") {
-    return (
-      <Card className="p-4">
-        <div className="space-y-1">
-          <h3 className="text-sm font-medium">Apple 캘린더 연결됨</h3>
-          <p className="text-xs text-muted-foreground">
-            iPhone·iPad·Mac Calendar 앱에서 본 여행 일정을 확인할 수 있습니다.
-            연결 해제·재인증 UI는 후속 회차에서 제공 예정입니다.
-          </p>
-        </div>
-      </Card>
-    );
-  }
-
+export default function AppleEntryCard() {
   return (
     <Card className="p-4">
-      <div className="flex items-start justify-between gap-3">
-        <div className="space-y-1">
-          <h3 className="text-sm font-medium">Apple 캘린더 연결 (Beta)</h3>
-          <p className="text-xs text-muted-foreground">
-            iPhone·iPad·Mac Calendar 앱에서 여행 일정을 보고 싶다면 Apple ID + 16자리
-            앱 전용 암호로 연결할 수 있습니다. 위자드가 발급·입력을 안내합니다.
-          </p>
-        </div>
-        <Link
-          href={`/trips/${tripId}/calendar/connect-apple`}
-          className="inline-flex shrink-0 items-center justify-center whitespace-nowrap rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-        >
-          Apple 연결
-        </Link>
+      <div className="space-y-1">
+        <h3 className="text-sm font-medium">Apple 캘린더 연결됨</h3>
+        <p className="text-xs text-muted-foreground">
+          iPhone·iPad·Mac Calendar 앱에서 본 여행 일정을 확인할 수 있습니다.
+          연결 해제·재인증 UI는 후속 회차에서 제공 예정입니다.
+        </p>
       </div>
     </Card>
   );

--- a/src/components/calendar/CalendarProviderChoice.tsx
+++ b/src/components/calendar/CalendarProviderChoice.tsx
@@ -1,0 +1,97 @@
+/**
+ * spec 025 (#417, hotfix v2.11.5) — 미연결 trip의 캘린더 provider 선택 카드.
+ *
+ * 표시 조건: link 부재 + OWNER (호출 측에서 처리).
+ * 옵션:
+ *  - Apple iCloud (권장) — 위자드 진입
+ *  - Google Calendar (개발자 등록 필요) — Testing 모드 제약 안내 + 등록 사용자만
+ *    `?provider=google` 쿼리로 진입 → trip 페이지가 GCalLinkPanel 노출
+ *
+ * spec 024 Clarification 6 정책: 한 trip = 1 provider · 1 외부 캘린더.
+ */
+
+import Link from "next/link";
+import { Card } from "@/components/ui/card";
+import { GCAL_DISCUSSIONS_URL } from "@/lib/gcal/unregistered";
+
+interface CalendarProviderChoiceProps {
+  tripId: number;
+}
+
+export default function CalendarProviderChoice({
+  tripId,
+}: CalendarProviderChoiceProps) {
+  return (
+    <Card className="p-4">
+      <div className="space-y-1">
+        <h3 className="text-sm font-medium">캘린더 연결</h3>
+        <p className="text-xs text-muted-foreground">
+          모바일 Calendar 앱에서 여행 일정을 보려면 캘린더를 연결하세요. 한 여행은
+          1개 캘린더만 연결할 수 있습니다.
+        </p>
+      </div>
+
+      <div className="mt-4 space-y-3">
+        {/* Apple — 권장 */}
+        <Link
+          href={`/trips/${tripId}/calendar/connect-apple`}
+          className="block rounded-lg border-2 border-primary/40 bg-primary/5 p-3 transition-colors hover:bg-primary/10"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div className="space-y-0.5">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium">🍎 Apple iCloud</span>
+                <span className="rounded bg-primary px-1.5 py-0.5 text-[10px] font-medium text-primary-foreground">
+                  권장
+                </span>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                iPhone·iPad·Mac Calendar 앱 사용자에게 권장. 앱 전용 암호 1번 발급
+                후 즉시 사용.
+              </p>
+            </div>
+            <span className="shrink-0 text-sm font-medium text-primary">
+              연결 →
+            </span>
+          </div>
+        </Link>
+
+        {/* Google — Testing 모드 제약 */}
+        <div className="rounded-lg border border-input bg-muted/30 p-3">
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium text-muted-foreground">
+                📅 Google Calendar
+              </span>
+              <span className="rounded border border-amber-300 bg-amber-50 px-1.5 py-0.5 text-[10px] font-medium text-amber-900">
+                개발자 등록 필요
+              </span>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Google Cloud Testing 모드 — 개발자가 직접 등록한 사용자만 사용
+              가능합니다. 등록을 원하시면 토론 채널로 문의해 주세요.
+            </p>
+            <div className="flex flex-wrap items-center gap-2 pt-1">
+              <a
+                href={GCAL_DISCUSSIONS_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 rounded-md border border-amber-300 bg-amber-50 px-2 py-1 text-xs font-medium text-amber-900 hover:bg-amber-100"
+              >
+                개발자 등록 문의
+                <span aria-hidden>↗</span>
+              </a>
+              <Link
+                href={`/trips/${tripId}?provider=google`}
+                scroll={false}
+                className="inline-flex items-center justify-center rounded-md border border-input bg-background px-2 py-1 text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+              >
+                Google 연결 시도
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary

미연결 trip에 provider 선택 카드 도입 + Apple 위자드 4단계 → 1단계 단축.

## 변경

### CalendarProviderChoice (신규)
- 미연결 + OWNER에게만 노출
- Apple iCloud (권장 badge + 강조 border) → 위자드 진입
- Google Calendar (개발자 등록 필요 badge + 외부 링크 + 보조 버튼)
- spec 024 Clarification 6 "한 trip = 1 provider" 정책 명시

### trip page 분기
| 상태 | 표시 |
|---|---|
| 미연결 + OWNER + provider 미선택 | CalendarProviderChoice |
| GOOGLE 연결됨 또는 ?provider=google | GCalLinkPanel |
| APPLE 연결됨 | AppleEntryCard |
| HOST/GUEST 미연결 | 없음 |

### AppleConnectWizard 단축
- 4단계 stepper → 단일 화면 form
- collapsible 가이드 (default closed)
- session.user.email로 Apple ID prefill
- 16자리 암호 자동 dash 포맷팅
- 성공 시 trip 페이지 redirect + toast
- reauth 모드: Apple ID disabled, 캘린더 재생성 0회

## Out of Scope (v2.12)
- Google·Apple 패널 통합
- Apple 연결됨 카드의 해제·재인증 버튼

🤖 Generated with [Claude Code](https://claude.com/claude-code)