### PR TITLE
fix(460): Apple sync UID 불일치 — update 시 중복·실패 fix

### DIFF
--- a/changes/460.fix.md
+++ b/changes/460.fix.md
@@ -1,0 +1,1 @@
+**Apple sync UID 불일치 버그 수정** — sync-apple의 update 분기가 ICS UID를 `"placeholder"` 문자열로 잘못 설정해 모든 활동이 동일 UID로 PUT되던 버그. iCloud가 UID 불일치를 새 객체 생성/reject로 처리해 활동 1개 추가·sync 시 캘린더에 2개 생성, 후속 sync에서 UNKNOWN/실패 발생. 신규 PUT은 명시적 `randomUUID()` 생성, update는 mapping URL 마지막 segment에서 UID 추출. apple.ts::putEvent의 filename도 ICS UID와 일치하도록 정렬해 CalDAV 일관성 보장.

--- a/src/lib/calendar/provider/apple.ts
+++ b/src/lib/calendar/provider/apple.ts
@@ -10,9 +10,11 @@
  * - 에러 vocabulary: 401→auth_invalid, 412→precondition_failed, 5xx/network→transient_failure
  */
 
+import { randomUUID } from "node:crypto";
 import { prisma } from "@/lib/prisma";
 import { createAppleClient, type AppleDAVClient } from "./apple-client";
 import { decryptPassword } from "./apple-crypto";
+import { extractIcsUid } from "../ics";
 import type {
   CalendarErrorCode,
   CalendarProvider,
@@ -193,7 +195,10 @@ export const appleProvider: CalendarProvider = {
     if (!client) {
       throw new Error("Apple CalDAV client unavailable for user");
     }
-    const filename = `trip-planner-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}.ics`;
+    // CalDAV 일관성: filename = ICS의 UID (#460 fix). 호출자가 ICS UID를 명시
+    // 했다면 같은 값을 filename에 사용해 update·delete 시 URL 추정이 가능.
+    const uid = extractIcsUid(ics) ?? randomUUID();
+    const filename = `${uid}.ics`;
     const res = await client.createCalendarObject({
       calendar: { url: calendarId } as Parameters<typeof client.createCalendarObject>[0]["calendar"],
       filename,

--- a/src/lib/calendar/sync-apple.ts
+++ b/src/lib/calendar/sync-apple.ts
@@ -11,11 +11,29 @@
  *  - 다음 sync에서 GET을 통한 ETag 갱신 시도(본 회차는 단순화 — 잔여 분기는 후속 회차)
  */
 
+import { randomUUID } from "node:crypto";
 import { prisma } from "@/lib/prisma";
 import { appleProvider } from "./provider/apple";
-import { formatActivityAsIcs, extractIcsUid } from "./ics";
+import { formatActivityAsIcs } from "./ics";
 import type { Activity, Trip, TripCalendarEventMapping } from "@prisma/client";
 import type { FailureReason } from "@/types/gcal";
+
+/**
+ * Apple put 결과 URL의 마지막 segment에서 UID를 추출.
+ * iCloud는 PUT URL을 `<calendar>/<uid>.ics`로 보관하므로, update·delete 시 같은
+ * UID를 ICS 안에 다시 사용하면 CalDAV 일관성이 유지된다(2026-04-28 dev 보고: UID
+ * 불일치로 update가 새 객체 생성·reject되던 버그 #460 fix).
+ */
+function uidFromExternalEventId(url: string): string {
+  const last = url.replace(/\/$/, "").split("/").pop() ?? "";
+  let decoded = last;
+  try {
+    decoded = decodeURIComponent(last);
+  } catch {
+    /* keep raw */
+  }
+  return decoded.replace(/\.ics$/i, "") || randomUUID();
+}
 
 export interface AppleSyncContext {
   tripCalendarLinkId: number;
@@ -74,7 +92,13 @@ export async function syncAppleActivities(
     const mapping = mapByActivity.get(a.id);
     try {
       if (!mapping) {
-        const ics = formatActivityAsIcs(a, ctx.trip, { tripUrl: ctx.tripUrl });
+        // 신규 — 명시적 UUID 생성. ICS UID와 filename(provider 내부)을 일치시켜
+        // 후속 update/delete가 같은 객체를 정확히 가리키게 한다.
+        const uid = randomUUID();
+        const ics = formatActivityAsIcs(a, ctx.trip, {
+          tripUrl: ctx.tripUrl,
+          uid,
+        });
         const ref = await appleProvider.putEvent(ctx.ownerId, ctx.calendarId, ics);
         await prisma.tripCalendarEventMapping.create({
           data: {
@@ -87,10 +111,13 @@ export async function syncAppleActivities(
         });
         result.created++;
       } else {
-        // update — 기존 UID 재사용
+        // update — mapping URL에서 UID 추출해 ICS UID로 동일 사용 (#460 fix).
+        // 이전엔 extractIcsUid("UID:placeholder")가 "placeholder" 문자열을 반환해
+        // ICS UID가 매번 잘못된 값으로 PUT → iCloud가 새 객체로 인식하거나 reject.
+        const uid = uidFromExternalEventId(mapping.googleEventId);
         const ics = formatActivityAsIcs(a, ctx.trip, {
           tripUrl: ctx.tripUrl,
-          uid: extractIcsUid("UID:placeholder") ?? undefined, // best-effort, 새 UUID 생성도 OK
+          uid,
         });
         const ref = await appleProvider.updateEvent(
           ctx.ownerId,


### PR DESCRIPTION
Closes #460.

## Symptom (2026-04-28 dev)
- 활동 1개 추가 + sync → 캘린더에 2개 생성
- 두 번째 sync → UNKNOWN
- 세 번째 sync → 갱신 1 / 실패 1

## Root cause
`sync-apple.ts` update 분기의 `extractIcsUid("UID:placeholder")`가 "placeholder" 문자열을 그대로 ICS UID로 사용 → iCloud가 UID 불일치를 새 객체/reject로 처리.

## Fix
- sync-apple.ts 신규 PUT: `randomUUID()` 명시적 UID
- sync-apple.ts update: mapping URL에서 UID 추출 (`uidFromExternalEventId`)
- apple.ts::putEvent: filename = ICS UID

🤖 Generated with [Claude Code](https://claude.com/claude-code)