### PR TITLE
fix(466): drift-audit — 자동 커밋 제거, errors>0 시 이슈 생성

### DIFF
--- a/.github/workflows/drift-audit.yml
+++ b/.github/workflows/drift-audit.yml
@@ -2,6 +2,12 @@ name: Drift Audit
 
 # speckit 하네스의 tasks ↔ artifact drift 감사 주기 실행.
 # spec 010 FR-004, PR #204. 설정: .specify/config/harness.json .driftAudit
+#
+# 동작 (#466 변경):
+#   1) 리포트 생성 → workflow artifact로 업로드 (보존 90일)
+#   2) total errors > 0 일 때만 GitHub Issue 자동 생성 (라벨: drift-audit)
+#   3) 동일 라벨의 열린 이슈가 있으면 중복 생성 스킵
+#   4) main 직접 push는 하지 않음 (보호 정책 + 자동 적용 회피)
 
 on:
   schedule:
@@ -9,11 +15,13 @@ on:
     - cron: "0 0 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   audit:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v6
 
@@ -23,21 +31,75 @@ jobs:
       - name: drift audit 실행
         id: audit
         run: |
-          bash .specify/scripts/bash/validate-drift.sh --audit
-          # 파일 경로 추출 (stdout 마지막 blob)
+          set -o pipefail
+          bash .specify/scripts/bash/validate-drift.sh --audit 2>&1 | tee audit.log
           REPORT=$(ls -t docs/audits/drift/*.md | head -1)
-          echo "report=$REPORT" >> "$GITHUB_OUTPUT"
 
-      - name: 리포트 커밋 (변경 있을 때만)
+          # 리포트 본문에 기재되어 있는 정본 카운트를 파싱
+          ERRORS=$(grep -m1 -oP 'total errors:\s*\K\d+' "$REPORT" || echo 0)
+          WARNINGS=$(grep -m1 -oP 'total warnings:\s*\K\d+' "$REPORT" || echo 0)
+
+          {
+            echo "report=$REPORT"
+            echo "errors=$ERRORS"
+            echo "warnings=$WARNINGS"
+            echo "date=$(date +%Y-%m-%d)"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "::notice::drift audit — errors=$ERRORS warnings=$WARNINGS report=$REPORT"
+
+      - name: 리포트 artifact 업로드
+        uses: actions/upload-artifact@v4
+        with:
+          name: drift-report-${{ steps.audit.outputs.date }}
+          path: ${{ steps.audit.outputs.report }}
+          retention-days: 90
+
+      - name: 열린 drift 이슈 조회
+        id: existing
+        if: steps.audit.outputs.errors != '0'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add docs/audits/drift/
-          if git diff --cached --quiet; then
-            echo "변경 없음 — 커밋 스킵"
-          else
-            git commit -m "chore(audit): drift 리포트 $(date +%Y-%m-%d) (자동)"
-            git push
+          NUM=$(gh issue list --label drift-audit --state open --json number --jq '.[0].number // empty')
+          echo "issue=$NUM" >> "$GITHUB_OUTPUT"
+          if [ -n "$NUM" ]; then
+            echo "::notice::기존 열린 drift 이슈 #$NUM — 신규 생성 스킵"
           fi
+
+      - name: 이슈 생성 (errors > 0 & 중복 없음)
+        if: steps.audit.outputs.errors != '0' && steps.existing.outputs.issue == ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPORT: ${{ steps.audit.outputs.report }}
+          ERRORS: ${{ steps.audit.outputs.errors }}
+          WARNINGS: ${{ steps.audit.outputs.warnings }}
+          DATE: ${{ steps.audit.outputs.date }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          BODY=$(mktemp)
+          {
+            echo "## Drift Audit 결과 — $DATE"
+            echo
+            echo "- **errors**: $ERRORS"
+            echo "- **warnings**: $WARNINGS"
+            echo "- **워크플로우 실행**: $RUN_URL"
+            echo "- **리포트 artifact**: \`drift-report-$DATE\` (위 실행 페이지 → Artifacts)"
+            echo
+            echo "## 리포트 본문"
+            echo
+            echo '<details>'
+            echo '<summary>리포트 펼치기</summary>'
+            echo
+            cat "$REPORT"
+            echo
+            echo '</details>'
+            echo
+            echo "---"
+            echo "1인 개발 환경 정책에 따라 자동 수정 없음. 항목 검토 후 해결/클로즈는 사용자 결정."
+          } > "$BODY"
+
+          gh issue create \
+            --title "drift audit $DATE: errors=$ERRORS warnings=$WARNINGS" \
+            --label drift-audit \
+            --body-file "$BODY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,15 +123,15 @@ develop ──●──●──●───●──●──●──●──
 - `merge-tasks-to-issues.sh` — tasks.md → 하위 이슈 초안(`[why]` 그룹 + 8h 분할 + 마일스톤, dry-run)
 - `enforce-speckit.sh` — Edit/Write PreToolUse 훅. 피처 브랜치(NNN-*)에서 산출물 존재 강제
 - `.github/workflows/speckit-gate.yml` — PR 단계 자동 검증
-- `.github/workflows/drift-audit.yml` — 주간 drift 리포트 생성·자동 커밋
+- `.github/workflows/drift-audit.yml` — 주간 drift 리포트 생성. `total errors > 0`이면 GitHub Issue(라벨 `drift-audit`) 자동 생성(중복 방지). 리포트는 workflow artifact(90일) 보존. main 직접 커밋 없음(#466)
 
 #### rollout phase
 
 `.specify/config/harness.json`의 `rollout.phase`가 `expand`/`migrate`/`contract` 세 단계 중 하나. 각 단계 동작:
 
-- **expand** (현재): validator 경고만, 머지 차단 없음. 신규 피처 도입기.
+- **expand**: validator 경고만, 머지 차단 없음. 신규 피처 도입기.
 - **migrate**: 기존 활성 피처(004/006/007 등) 메타태그 소급 적용. 경고 여전히 비차단.
-- **contract**: quickstart-evidence / migration-meta / drift error가 머지 차단. Phase B 완료 + 1주 관찰 후 전환.
+- **contract** (현재): quickstart-evidence / migration-meta / drift error가 머지 차단. Phase B 완료 + 1주 관찰 후 전환됨.
 
 전환 조건·스냅샷은 `docs/audits/drift/2026-04-migration.md` 참조.
 

--- a/changes/466.fix.md
+++ b/changes/466.fix.md
@@ -1,0 +1,1 @@
+**drift-audit 워크플로우 보고 방식 전환** — main 직접 커밋 대신 errors>0 시 GitHub Issue 자동 생성(중복 방지) + 리포트 artifact 보존. 왜: main 보호 정책 충돌로 도입 후 4주 연속 실패 + 1인 개발에서 자동 적용은 정본을 흐림.


### PR DESCRIPTION
Closes #466

## Summary
- main 직접 push로 4주 연속 실패하던 `drift-audit.yml`을 **이슈 보고 방식**으로 전환
- `total errors > 0` 일 때만 GitHub Issue 자동 생성 (라벨 `drift-audit`, 중복 방지)
- 리포트는 workflow artifact(90일 보존)로 이동, main에 자동 커밋하지 않음
- `CLAUDE.md`의 rollout phase 설명 stale 정정 (실제는 `contract`)

## 정책 배경

1인 개발 + 다중 워크트리/AI 보조 병렬 작업 환경에서:
- speckit 하네스 정본은 spec/tasks (사람 의도) → 자동 동기화는 정본을 흐림
- 자동 변경 PR은 별도 이슈 작업 중 충돌 비용이 점검 비용보다 큼
- 자동화의 적절한 위치는 "발견·계산"이며 "결정·적용"은 사람 손을 거쳐야 함

## Test plan
- [ ] PR CI 통과 (towncrier-fragment-check 포함 — `466.fix.md` 단편 추가)
- [ ] develop 머지 후 `workflow_dispatch`로 수동 실행하여 동작 확인
  - errors=0이면 artifact만 업로드되고 이슈 생성 안 됨
  - errors>0이면 이슈 1건 생성, 재실행 시 중복 생성 안 됨