### PR TITLE
chore(468): actions/upload-artifact v4 → v7

### DIFF
--- a/.github/workflows/drift-audit.yml
+++ b/.github/workflows/drift-audit.yml
@@ -49,7 +49,7 @@ jobs:
           echo "::notice::drift audit — errors=$ERRORS warnings=$WARNINGS report=$REPORT"
 
       - name: 리포트 artifact 업로드
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: drift-report-${{ steps.audit.outputs.date }}
           path: ${{ steps.audit.outputs.report }}


### PR DESCRIPTION
Closes #468

## Summary
- `actions/upload-artifact`를 v4 → v7.0.1로 갱신 (Node.js 20 deprecation 대응)
- 사용처는 `drift-audit.yml` 1곳, 옵션 변경 없음 (`name`/`path`/`retention-days`만 사용)

## 배경
2026-06-02부터 GitHub Actions가 Node.js 24를 강제. 다음 dependabot github-actions 사이클(monthly)이 강제 전환 시점과 빠듯해 직접 갱신.

## Test plan
- [ ] PR CI 통과
- [ ] develop 머지 후 `workflow_dispatch`로 `drift-audit.yml` 재실행 → artifact 업로드 정상 확인