### PR TITLE
fix(481): GCal sync 17/17 실패 — events payload 방어 (location null, end<=start)

### DIFF
--- a/changes/481.fix.md
+++ b/changes/481.fix.md
@@ -1,0 +1,1 @@
+**Google Calendar sync 실패(events.insert 400)** 수정. 왜: `location: null` 그대로 전달과 `endTime` 미지정 시 zero-duration 이벤트가 Google API에 의해 일괄 거부되어 17/17 활동 sync 실패가 재현됐다.

--- a/src/lib/gcal/format.ts
+++ b/src/lib/gcal/format.ts
@@ -29,7 +29,12 @@ const RESERVATION_LABEL: Record<string, string> = {
 export interface FormattedEvent {
   summary: string;
   description: string;
-  location: string | null;
+  /**
+   * Google Calendar API events.insert/patch는 location 필드에 null이 들어오면
+   * "Invalid value at 'event.location'" 400을 응답한다. 값이 없을 때는 키 자체를
+   * 보내지 않도록 optional로 둔다 (#481).
+   */
+  location?: string;
   start: { dateTime: string; timeZone: string };
   end: { dateTime: string; timeZone: string };
 }
@@ -70,18 +75,27 @@ export function formatActivityAsEvent(
   descLines.push(`여행 상세: ${opts.tripUrl}`);
 
   // 시간이 없는 활동에도 안전하게 — 시작 없으면 UTC 00:00, 끝 없으면 시작과 동일
-  const startIso = (activity.startTime ?? new Date()).toISOString();
-  const endIso = (activity.endTime ?? activity.startTime ?? new Date()).toISOString();
+  const startDate = activity.startTime ?? new Date();
+  // Google Calendar API는 end <= start (zero-duration·역순) 이벤트를 400으로 거부한다.
+  // endTime이 없거나 startTime과 같거나 더 이르면 +1h 보정 (#481).
+  const endCandidate = activity.endTime ?? activity.startTime ?? new Date();
+  const endDate =
+    endCandidate.getTime() <= startDate.getTime()
+      ? new Date(startDate.getTime() + 60 * 60 * 1000)
+      : endCandidate;
+  const startIso = startDate.toISOString();
+  const endIso = endDate.toISOString();
   const startZone = activity.startTimezone || "UTC";
   const endZone = activity.endTimezone || activity.startTimezone || "UTC";
 
-  return {
+  const event: FormattedEvent = {
     summary,
     description: descLines.join("\n"),
-    location: activity.location,
     start: { dateTime: startIso, timeZone: startZone },
     end: { dateTime: endIso, timeZone: endZone },
   };
+  if (activity.location) event.location = activity.location;
+  return event;
 }
 
 export function dedicatedCalendarName(tripTitle: string): string {

--- a/tests/lib/gcal/format.test.ts
+++ b/tests/lib/gcal/format.test.ts
@@ -63,9 +63,35 @@ describe("formatActivityAsEvent", () => {
     expect(event.end.timeZone).toBe("UTC");
   });
 
-  it("endTime이 없으면 startTime으로 폴백(0분 이벤트 가능성 허용)", () => {
+  it("endTime이 없으면 startTime + 1시간으로 보정 (Google API zero-duration 400 회피, #481)", () => {
     const event = formatActivityAsEvent(baseActivity({ endTime: null }), TRIP, URL_OPTS);
-    expect(event.end.dateTime).toBe(event.start.dateTime);
+    const startMs = new Date(event.start.dateTime).getTime();
+    const endMs = new Date(event.end.dateTime).getTime();
+    expect(endMs - startMs).toBe(60 * 60 * 1000);
+  });
+
+  it("endTime이 startTime보다 이르면 +1시간으로 보정", () => {
+    const event = formatActivityAsEvent(
+      baseActivity({
+        startTime: new Date("2026-06-07T11:00:00.000Z"),
+        endTime: new Date("2026-06-07T10:00:00.000Z"),
+      }),
+      TRIP,
+      URL_OPTS
+    );
+    const startMs = new Date(event.start.dateTime).getTime();
+    const endMs = new Date(event.end.dateTime).getTime();
+    expect(endMs - startMs).toBe(60 * 60 * 1000);
+  });
+
+  it("location이 null이면 event.location 키 자체를 제외 (Google API null reject 회피, #481)", () => {
+    const event = formatActivityAsEvent(baseActivity({ location: null }), TRIP, URL_OPTS);
+    expect("location" in event).toBe(false);
+  });
+
+  it("location이 있으면 그대로 전달", () => {
+    const event = formatActivityAsEvent(baseActivity({ location: "Torre de Belém" }), TRIP, URL_OPTS);
+    expect(event.location).toBe("Torre de Belém");
   });
 
   it("memo가 있으면 설명란에 포함", () => {


### PR DESCRIPTION
Closes #481

## What

`formatActivityAsEvent`(src/lib/gcal/format.ts)에서 Google Calendar API가 400으로 거부하는 두 페이로드 패턴을 방어한다.

- `location: null` → requestBody에서 키 자체를 제외
- `endTime` 미지정 또는 `endTime <= startTime` → `startTime + 1h`로 보정

## Why

trip.idean.me prod에서 `/api/v2/trips/[id]/calendar/sync` 호출이 "부분 반영 · 건너뜀 0 · 실패 17" 토스트로 17개 활동 모두 실패. DB `TripCalendarLink.lastError = "UNKNOWN"` → REVOKED/RATE_LIMITED/NETWORK 아님. 캘린더 ID 자체는 살아있음(GET 응답·실제 GCal 일치) → 페이로드 거부 가능성 가장 큼.

`@googleapis/calendar` 직렬화 동작: `undefined`는 키 제거하지만 `null`은 그대로 전달 → Google이 `Invalid value at 'event.location'` 400 응답. zero-duration 이벤트도 일부 캘린더에서 400.

## Changes

- src/lib/gcal/format.ts
  - `FormattedEvent.location: string | null` → `location?: string`
  - location 있을 때만 키 설정
  - end가 start 이하면 `startMs + 60min`으로 보정
- tests/lib/gcal/format.test.ts
  - 기존 "0분 이벤트 가능성 허용" 케이스를 +1h 보정 검증으로 교체
  - 역순(end<start) 보정 케이스 추가
  - location null → 키 제외 검증 추가

## Test plan

- [x] `npx vitest run tests/lib/gcal tests/unit/calendar tests/api/v2-gcal-sync.test.ts` — 91 passed
- [x] `npx tsc --noEmit` clean
- [ ] develop 머지 → dev.trip.idean.me 자동 배포 → 가능하면 동일 데이터 재현 후 sync 호출 → failed 0 확인 (prod 데이터는 dev에 없으므로 prod 릴리즈 후 사용자 검증)
- [ ] release/v2.12.1 → main → prod 릴리즈 후 사용자 trip.idean.me에서 sync 재시도 → 17→0 확인

## 후속 (별도 이슈 권장)

- sync 응답·DB에 failed의 raw reason을 분리 보존 (현 inferLastError는 첫 1건만 단순 매핑)
- UI에 failure reason 표시 (현재는 개수만)