### PR TITLE
chore(481): GCal sync 실패 시 raw Google 에러를 prod logs에 노출 (진단 보강)

### DIFF
--- a/changes/481.chore.md
+++ b/changes/481.chore.md
@@ -1,0 +1,1 @@
+**GCal sync 실패 시 raw Google 에러를 prod logs에 노출** (#481 진단 보강). 왜: v2.12.1 fix 후에도 17/17 실패가 재현되어 reason 분류 외 raw status·message·payload를 추적해야 함.

--- a/src/lib/gcal/sync.ts
+++ b/src/lib/gcal/sync.ts
@@ -133,6 +133,17 @@ export async function syncActivities(
         await prisma.tripCalendarEventMapping.delete({ where: { id: mapping.id } });
       } else {
         const { reason } = classifyError(err);
+        // #481 진단 — raw status·message·payload를 prod logs에 남겨 원인 분류 회귀 추적.
+        const e = err as { code?: number; status?: number; message?: string; response?: { status?: number; data?: unknown } };
+        console.error(
+          `[gcal/sync] activity ${a.id} ${mapping ? "patch" : "insert"} failed`,
+          {
+            classifiedReason: reason,
+            httpStatus: e.code ?? e.status ?? e.response?.status,
+            message: e.message,
+            googleError: e.response?.data,
+          }
+        );
         result.failed.push({ activityId: a.id, reason });
       }
     }


### PR DESCRIPTION
Refs #481 #482 — v2.12.1 fix 후에도 17/17 실패가 재현되어 root cause 추적용 진단 로그 추가.

## What

`src/lib/gcal/sync.ts` 의 activity 단위 catch 분기에 `console.error` 1개 추가:
- classifiedReason (현 매핑 결과)
- httpStatus (code/status/response.status 중 첫 hit)
- message
- googleError (e.response.data — Google API의 원본 error payload)

## Why

v2.12.1 (#482) 머지 후 prod 검증에서 GET /api/v2/trips/[id]/calendar 응답의 `lastError = "UNKNOWN"` 그대로 → location:null·zero-duration 두 가설 모두 빗나감. reason 자체는 응답에 노출되지 않고 첫 1건만 UNKNOWN으로 단순화되어 brower 측에서 root cause 식별 불가. prod logs로 raw payload 노출이 가장 빠른 진단 경로.

## Test plan

- [x] vitest 91/91 pass
- [ ] develop 머지 후 release/v2.12.2 → main → prod 배포
- [ ] 사용자 trip.idean.me "다시 반영하기" 트리거 → `vercel logs trip.idean.me` 에서 `[gcal/sync] activity N ... failed` 라인 캡처
- [ ] 캡처된 googleError로 진짜 원인 분기(권한·payload·calendar trashed 등) 후 본 fix 별도 PR

## 후속

진단 결과 확정 후 본 console.error는 유지(앞으로 회귀 진단 자산) 또는 정리 — 추가 PR에서 결정.