### PR TITLE
release: v2.12.2 — GCal sync 진단 로그 (#481)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## [2.12.2] - 2026-05-26
+
+### Chore
+
+- **GCal sync 실패 시 raw Google 에러를 prod logs에 노출** (#481 진단 보강). 왜: v2.12.1 fix 후에도 17/17 실패가 재현되어 reason 분류 외 raw status·message·payload를 추적해야 함. ([#481](https://github.com/idean3885/trip-planner/issues/481))
+
+
 ## [2.12.1] - 2026-05-26
 
 ### Fixed

--- a/changes/481.chore.md
+++ b/changes/481.chore.md
@@ -1,1 +1,0 @@
-**GCal sync 실패 시 raw Google 에러를 prod logs에 노출** (#481 진단 보강). 왜: v2.12.1 fix 후에도 17/17 실패가 재현되어 reason 분류 외 raw status·message·payload를 추적해야 함.

--- a/changes/481.chore.md
+++ b/changes/481.chore.md
@@ -1,0 +1,1 @@
+**GCal sync 실패 시 raw Google 에러를 prod logs에 노출** (#481 진단 보강). 왜: v2.12.1 fix 후에도 17/17 실패가 재현되어 reason 분류 외 raw status·message·payload를 추적해야 함.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trip-planner-mcp"
-version = "2.12.1"
+version = "2.12.2"
 description = "여행 숙소, 항공편, 관광지 검색 + 구조화 활동 관리 MCP 서버 (20개 도구)"
 requires-python = ">=3.10"
 license = "MIT"

--- a/src/lib/gcal/sync.ts
+++ b/src/lib/gcal/sync.ts
@@ -133,6 +133,17 @@ export async function syncActivities(
         await prisma.tripCalendarEventMapping.delete({ where: { id: mapping.id } });
       } else {
         const { reason } = classifyError(err);
+        // #481 진단 — raw status·message·payload를 prod logs에 남겨 원인 분류 회귀 추적.
+        const e = err as { code?: number; status?: number; message?: string; response?: { status?: number; data?: unknown } };
+        console.error(
+          `[gcal/sync] activity ${a.id} ${mapping ? "patch" : "insert"} failed`,
+          {
+            classifiedReason: reason,
+            httpStatus: e.code ?? e.status ?? e.response?.status,
+            message: e.message,
+            googleError: e.response?.data,
+          }
+        );
         result.failed.push({ activityId: a.id, reason });
       }
     }

--- a/uv.lock
+++ b/uv.lock
@@ -1015,7 +1015,7 @@ wheels = [
 
 [[package]]
 name = "trip-planner-mcp"
-version = "2.12.1"
+version = "2.12.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- v2.12.1 fix 후에도 17/17 실패가 재현되어 raw Google API 에러를 prod logs에 노출
- root cause 식별 위한 진단 보강 (실제 fix는 후속 PR)

Refs #481 #485

## Release notes

[CHANGELOG.md v2.12.2](https://github.com/idean3885/trip-planner/blob/release/v2.12.2/CHANGELOG.md#2122---2026-05-26)

## Test plan

- [x] vitest 91/91 pass
- [ ] main 머지 → prod 배포 → 사용자 sync 트리거 → vercel logs 캡처