### PR TITLE
fix(481): invalid_grant를 REVOKED로 분류 — UI 재연결 흐름 발동

### DIFF
--- a/changes/481.fix.md
+++ b/changes/481.fix.md
@@ -1,0 +1,1 @@
+**Google OAuth refresh 실패(`invalid_grant`)를 REVOKED로 정확히 분류**. 왜: refresh_token이 만료·회수되면 Google이 HTTP 400 + `invalid_grant`로 응답하는데 기존 분류기는 401/403만 REVOKED로 매핑해 17/17 sync 실패가 lastError UNKNOWN으로 묻혀 UI에서 "다시 연결하기" 분기가 발동되지 않았다.

--- a/src/lib/gcal/errors.ts
+++ b/src/lib/gcal/errors.ts
@@ -64,12 +64,26 @@ function extractErrorText(err: unknown): string {
   return parts.join(" ");
 }
 
+/**
+ * Google OAuth refresh 단계에서 토큰이 회수·만료된 경우 응답은 HTTP 400 + 본문
+ * `error: "invalid_grant"`로 내려온다(#481). 401/403이 아니므로 일반 status 매핑에
+ * 잡히지 않아 unknown으로 분류되던 갭을 메운다. 본 분기는 events API 응답이 아닌
+ * google-auth-library의 refresh 실패가 events.insert 호출 스택을 통해 throw된 케이스.
+ */
+export function isInvalidGrantError(err: unknown): boolean {
+  const text = extractErrorText(err).toLowerCase();
+  return text.includes("invalid_grant");
+}
+
 export function classifyError(err: unknown): {
   reason: FailureReason;
   lastError: GCalLastError;
 } {
   if (isUnregisteredError(err)) {
     return { reason: "unregistered", lastError: "UNREGISTERED" };
+  }
+  if (isInvalidGrantError(err)) {
+    return { reason: "forbidden", lastError: "REVOKED" };
   }
   const status = getStatus(err);
   if (status === 401 || status === 403)

--- a/tests/lib/gcal/errors.test.ts
+++ b/tests/lib/gcal/errors.test.ts
@@ -58,4 +58,35 @@ describe("classifyError — spec 021 UNREGISTERED 분류", () => {
   it("isUnregisteredError — 500은 대상 아님(권한 범주 외)", () => {
     expect(isUnregisteredError({ code: 500, message: "access_denied" })).toBe(false);
   });
+
+  // #481 — Google OAuth refresh 실패가 400 + invalid_grant로 내려와 unknown으로 묻히던 회귀.
+  it("400 + 'invalid_grant' (refresh_token 만료·회수) → REVOKED", () => {
+    const err = {
+      code: 400,
+      message: "invalid_grant",
+      response: {
+        status: 400,
+        data: {
+          error: "invalid_grant",
+          error_description: "Token has been expired or revoked.",
+        },
+      },
+    };
+    expect(classifyError(err)).toEqual({
+      reason: "forbidden",
+      lastError: "REVOKED",
+    });
+  });
+
+  it("400 + 일반 Bad Request (invalid_grant 아님) → unknown 유지", () => {
+    const err = {
+      code: 400,
+      message: "Invalid argument",
+      response: { status: 400, data: { error: { code: 400, message: "Bad Request" } } },
+    };
+    expect(classifyError(err)).toEqual({
+      reason: "unknown",
+      lastError: "UNKNOWN",
+    });
+  });
 });


### PR DESCRIPTION
Closes #481

## What

`classifyError`(src/lib/gcal/errors.ts)에 `isInvalidGrantError` 추가. 400 + 본문에 `invalid_grant` 검출 시 `reason=forbidden` + `lastError=REVOKED` 매핑.

## Why — root cause (prod logs로 확정)

trip.idean.me prod에서 17/17 활동 sync 실패. v2.12.3 진단 로그로 root cause 확정:

\`\`\`
[gcal/sync] activity 14 insert caught {
  httpStatus: 400,
  message: 'invalid_grant',
  googleError: { error: 'invalid_grant', error_description: 'Token has been expired or revoked.' }
}
\`\`\`

Owner의 OAuth refresh_token이 만료·회수되어 google-auth-library가 refresh 시도 시 400 + invalid_grant 응답. 기존 분류기는 401/403만 REVOKED로 매핑하므로 400은 unknown 분기 → lastError=UNKNOWN으로 묻혀 GCalLinkPanel의 isRevoked 분기가 false → 사용자가 "다시 연결하기" 버튼을 볼 수 없고 같은 sync만 반복 시도.

## 사용자 측 정상화 흐름 (fix 후)

1. prod 배포 → 다음 sync 호출
2. `lastError = REVOKED` 저장
3. 모달 헤더가 "구글 캘린더 권한 회수됨" + 안내 문구로 전환
4. "다시 연결하기" 버튼 노출 → `/api/gcal/consent` 진입 → `prompt=consent` + `access_type=offline` OAuth flow → 새 refresh_token 발급 + Account row 업데이트(auth.ts signIn callback)

## Test plan

- [x] vitest 93/93 pass (errors.test.ts +2 케이스: invalid_grant → REVOKED, 일반 400 → unknown 회귀 방지)
- [ ] develop 머지 → release/v2.12.4 → main → prod 배포
- [ ] 사용자 trip.idean.me 페이지 새로고침 → 모달에 "권한 회수됨" 표시 확인 → "다시 연결하기" → sync 재시도 → 17→0 확인

## 후속 (별도 이슈 권장)

- Google이 두 번째 OAuth grant에서 refresh_token을 발급하지 않는 경우 대비: signIn callback에서 access_type=offline + prompt=consent를 일반 sign-in에도 명시 검토
- UI에 failure reason 표시 (현재는 개수만)
- 진단 console.error는 의도적으로 유지 — 향후 회귀 진단 자산