### PR TITLE
release: v2.12.4 — invalid_grant를 REVOKED로 분류 (#481)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## [2.12.4] - 2026-05-26
+
+### Fixed
+
+- **Google OAuth refresh 실패(`invalid_grant`)를 REVOKED로 정확히 분류**. 왜: refresh_token이 만료·회수되면 Google이 HTTP 400 + `invalid_grant`로 응답하는데 기존 분류기는 401/403만 REVOKED로 매핑해 17/17 sync 실패가 lastError UNKNOWN으로 묻혀 UI에서 "다시 연결하기" 분기가 발동되지 않았다. ([#481](https://github.com/idean3885/trip-planner/issues/481))
+
+
 ## [2.12.3] - 2026-05-26
 
 ### Chore

--- a/changes/481.fix.md
+++ b/changes/481.fix.md
@@ -1,1 +1,0 @@
-**Google OAuth refresh 실패(`invalid_grant`)를 REVOKED로 정확히 분류**. 왜: refresh_token이 만료·회수되면 Google이 HTTP 400 + `invalid_grant`로 응답하는데 기존 분류기는 401/403만 REVOKED로 매핑해 17/17 sync 실패가 lastError UNKNOWN으로 묻혀 UI에서 "다시 연결하기" 분기가 발동되지 않았다.

--- a/changes/481.fix.md
+++ b/changes/481.fix.md
@@ -1,0 +1,1 @@
+**Google OAuth refresh 실패(`invalid_grant`)를 REVOKED로 정확히 분류**. 왜: refresh_token이 만료·회수되면 Google이 HTTP 400 + `invalid_grant`로 응답하는데 기존 분류기는 401/403만 REVOKED로 매핑해 17/17 sync 실패가 lastError UNKNOWN으로 묻혀 UI에서 "다시 연결하기" 분기가 발동되지 않았다.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trip-planner-mcp"
-version = "2.12.3"
+version = "2.12.4"
 description = "여행 숙소, 항공편, 관광지 검색 + 구조화 활동 관리 MCP 서버 (20개 도구)"
 requires-python = ">=3.10"
 license = "MIT"

--- a/src/lib/gcal/errors.ts
+++ b/src/lib/gcal/errors.ts
@@ -64,12 +64,26 @@ function extractErrorText(err: unknown): string {
   return parts.join(" ");
 }
 
+/**
+ * Google OAuth refresh 단계에서 토큰이 회수·만료된 경우 응답은 HTTP 400 + 본문
+ * `error: "invalid_grant"`로 내려온다(#481). 401/403이 아니므로 일반 status 매핑에
+ * 잡히지 않아 unknown으로 분류되던 갭을 메운다. 본 분기는 events API 응답이 아닌
+ * google-auth-library의 refresh 실패가 events.insert 호출 스택을 통해 throw된 케이스.
+ */
+export function isInvalidGrantError(err: unknown): boolean {
+  const text = extractErrorText(err).toLowerCase();
+  return text.includes("invalid_grant");
+}
+
 export function classifyError(err: unknown): {
   reason: FailureReason;
   lastError: GCalLastError;
 } {
   if (isUnregisteredError(err)) {
     return { reason: "unregistered", lastError: "UNREGISTERED" };
+  }
+  if (isInvalidGrantError(err)) {
+    return { reason: "forbidden", lastError: "REVOKED" };
   }
   const status = getStatus(err);
   if (status === 401 || status === 403)

--- a/tests/lib/gcal/errors.test.ts
+++ b/tests/lib/gcal/errors.test.ts
@@ -58,4 +58,35 @@ describe("classifyError — spec 021 UNREGISTERED 분류", () => {
   it("isUnregisteredError — 500은 대상 아님(권한 범주 외)", () => {
     expect(isUnregisteredError({ code: 500, message: "access_denied" })).toBe(false);
   });
+
+  // #481 — Google OAuth refresh 실패가 400 + invalid_grant로 내려와 unknown으로 묻히던 회귀.
+  it("400 + 'invalid_grant' (refresh_token 만료·회수) → REVOKED", () => {
+    const err = {
+      code: 400,
+      message: "invalid_grant",
+      response: {
+        status: 400,
+        data: {
+          error: "invalid_grant",
+          error_description: "Token has been expired or revoked.",
+        },
+      },
+    };
+    expect(classifyError(err)).toEqual({
+      reason: "forbidden",
+      lastError: "REVOKED",
+    });
+  });
+
+  it("400 + 일반 Bad Request (invalid_grant 아님) → unknown 유지", () => {
+    const err = {
+      code: 400,
+      message: "Invalid argument",
+      response: { status: 400, data: { error: { code: 400, message: "Bad Request" } } },
+    };
+    expect(classifyError(err)).toEqual({
+      reason: "unknown",
+      lastError: "UNKNOWN",
+    });
+  });
 });

--- a/uv.lock
+++ b/uv.lock
@@ -1015,7 +1015,7 @@ wheels = [
 
 [[package]]
 name = "trip-planner-mcp"
-version = "2.12.3"
+version = "2.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
OAuth refresh 실패(400 + invalid_grant)를 REVOKED로 정확히 분류해 UI "다시 연결하기" 흐름이 발동되도록 함. Refs #491.