### PR TITLE
feat(512,514): OpenAPI 스펙 LLM 친화도 보강 — operationId·Activity 시간/타임존

### DIFF
--- a/changes/512.feat.md
+++ b/changes/512.feat.md
@@ -1,0 +1,1 @@
+**OpenAPI 스펙에 operationId 21개·요청 example·Error 코드 필드·N+1 호출 규약·정렬 규약 추가**. 왜: LLM/MCP/SDK 코드젠이 안정 식별자로 매핑 가능해지고, `GET /api/trips/{id}` 응답이 activities를 포함하지 않는다는 사실과 활동 정렬 기준(startTime 우선, sortOrder 동률 보조)이 스펙에 명시됐다.

--- a/changes/514.feat.md
+++ b/changes/514.feat.md
@@ -1,0 +1,1 @@
+**Activity `startTime`/`endTime`을 ISO 8601 datetime으로 정정 + `startTimezone`/`endTimezone`(IANA) 필드 명세 추가**. 왜: 실제 동작은 ISO datetime + IANA timezone이지만 스펙은 `HH:mm` 문자열만 기재해 클라이언트가 시간 입력 방식·타임존 처리 규약을 알 수 없었다.

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -7,8 +7,22 @@ export const openApiSpec = {
   info: {
     title: "Trip Planner API",
     version: "2.1.0",
-    description:
+    description: [
       "여행 일정 관리 API. 세션 인증(웹 브라우저) 또는 PAT 인증(외부 클라이언트)을 지원합니다.",
+      "",
+      "## 인증",
+      "- **Personal Access Token (PAT)**: 발급 페이지 [`/settings/tokens`](/settings/tokens). `Authorization: Bearer <token>` 헤더로 사용. 토큰 원문은 발급 시 1회만 노출됩니다.",
+      "- **Session Cookie**: `next-auth.session-token`. 웹 브라우저에서 자동 처리.",
+      "",
+      "## AI CLI / MCP 연동",
+      "trip MCP 서버는 GitHub 저장소(`https://github.com/idean3885/trip-planner`)의 `mcp/` 디렉토리에서 확인할 수 있습니다. Claude Code 등 AI CLI에서 PAT로 직접 호출하거나 MCP 서버로 연결하여 사용합니다.",
+      "",
+      "## 시간 표기 규약",
+      "Activity의 `startTime`/`endTime`은 ISO 8601 datetime 문자열로 저장·응답됩니다(UTC 직렬화). 요청 시 `+09:00` 같은 offset을 포함해 보내면 서버가 UTC로 정규화하여 저장합니다. 원본 타임존을 보존하려면 `startTimezone`/`endTimezone`에 IANA 식별자(`Asia/Seoul`, `Europe/Lisbon` 등)를 함께 전달하세요.",
+      "",
+      "## 정렬 규약",
+      "활동 목록은 `startTime` 오름차순을 1차 정렬, `sortOrder`를 동률 보조 정렬로 사용합니다. 신규 활동을 POST 할 때 `sortOrder`를 지정하지 않으면 0이 부여되므로, 시간 정보를 함께 보내는 것을 권장합니다.",
+    ].join("\n"),
   },
   servers: [
     { url: "https://trip.idean.me", description: "Production" },
@@ -20,7 +34,8 @@ export const openApiSpec = {
       BearerAuth: {
         type: "http",
         scheme: "bearer",
-        description: "Personal Access Token (설정 페이지에서 생성)",
+        description:
+          "Personal Access Token. 발급 페이지: `/settings/tokens`. `Authorization: Bearer <token>` 헤더로 사용합니다. 토큰 원문은 발급 시 1회만 노출되므로 즉시 안전한 곳에 보관하세요.",
       },
       SessionAuth: {
         type: "apiKey",
@@ -86,24 +101,65 @@ export const openApiSpec = {
         properties: {
           id: { type: "integer" },
           dayId: { type: "integer" },
-          category: { type: "string", enum: ["SIGHTSEEING", "DINING", "TRANSPORT", "ACCOMMODATION", "SHOPPING", "OTHER"] },
+          category: {
+            type: "string",
+            enum: ["SIGHTSEEING", "DINING", "TRANSPORT", "ACCOMMODATION", "SHOPPING", "OTHER"],
+          },
           title: { type: "string" },
-          startTime: { type: "string", nullable: true, description: "HH:mm" },
-          endTime: { type: "string", nullable: true, description: "HH:mm" },
+          startTime: {
+            type: "string",
+            format: "date-time",
+            nullable: true,
+            description: "ISO 8601 datetime (UTC 직렬화). 요청 시 offset 포함 가능.",
+          },
+          startTimezone: {
+            type: "string",
+            nullable: true,
+            description: "IANA timezone 식별자 (예: `Asia/Seoul`, `Europe/Lisbon`).",
+          },
+          endTime: {
+            type: "string",
+            format: "date-time",
+            nullable: true,
+            description: "ISO 8601 datetime (UTC 직렬화).",
+          },
+          endTimezone: {
+            type: "string",
+            nullable: true,
+            description: "IANA timezone 식별자.",
+          },
           location: { type: "string", nullable: true },
           memo: { type: "string", nullable: true },
-          cost: { type: "number", nullable: true },
+          cost: {
+            type: "string",
+            nullable: true,
+            description:
+              "비용 (DB Decimal). 응답은 항상 정수 문자열로 직렬화됩니다. 요청에는 number도 허용됩니다.",
+          },
           currency: { type: "string", default: "EUR" },
-          reservationStatus: { type: "string", nullable: true, enum: ["REQUIRED", "RECOMMENDED", "ON_SITE", "NOT_NEEDED"] },
-          sortOrder: { type: "integer" },
+          reservationStatus: {
+            type: "string",
+            nullable: true,
+            enum: ["REQUIRED", "RECOMMENDED", "ON_SITE", "NOT_NEEDED"],
+          },
+          sortOrder: {
+            type: "integer",
+            description: "정렬 보조키. startTime 동률 시 사용. POST 시 미지정하면 0 부여.",
+          },
           createdAt: { type: "string", format: "date-time" },
           updatedAt: { type: "string", format: "date-time" },
         },
       },
       Error: {
         type: "object",
+        required: ["error"],
         properties: {
-          error: { type: "string" },
+          error: { type: "string", description: "에러 메시지" },
+          code: {
+            type: "string",
+            nullable: true,
+            description: "에러 코드 (선택). 클라이언트가 분기 처리할 때 사용.",
+          },
         },
       },
     },
@@ -111,6 +167,7 @@ export const openApiSpec = {
   paths: {
     "/api/trips": {
       get: {
+        operationId: "listTrips",
         tags: ["Trips"],
         summary: "여행 목록 조회",
         description: "현재 사용자가 멤버로 참여 중인 여행 목록을 반환한다.",
@@ -123,6 +180,7 @@ export const openApiSpec = {
         },
       },
       post: {
+        operationId: "createTrip",
         tags: ["Trips"],
         summary: "여행 생성",
         requestBody: {
@@ -139,31 +197,40 @@ export const openApiSpec = {
                   endDate: { type: "string", format: "date-time" },
                 },
               },
+              example: {
+                title: "포르투갈·스페인 신혼여행",
+                description: "리스본→포르투→마드리드→세비야→바르셀로나",
+                startDate: "2026-06-07T00:00:00.000Z",
+                endDate: "2026-06-21T00:00:00.000Z",
+              },
             },
           },
         },
         responses: {
           "201": { description: "생성된 여행", content: { "application/json": { schema: { $ref: "#/components/schemas/Trip" } } } },
-          "401": { description: "미인증" },
+          "401": { description: "미인증", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
         },
       },
     },
     "/api/trips/{id}": {
       parameters: [{ name: "id", in: "path", required: true, schema: { type: "integer" } }],
       get: {
+        operationId: "getTrip",
         tags: ["Trips"],
         summary: "여행 상세 조회",
-        description: "여행 상세 정보, 일자 목록, 멤버 목록을 반환한다.",
+        description:
+          "여행 상세 정보, 일자 목록, 멤버 목록을 반환한다. **활동(activities)은 포함되지 않는다** — 일자별로 `GET /api/trips/{id}/days/{dayId}/activities`를 호출해야 한다.",
         responses: {
           "200": { description: "여행 상세" },
-          "401": { description: "미인증" },
-          "403": { description: "멤버가 아님" },
+          "401": { description: "미인증", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+          "403": { description: "멤버가 아님", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
         },
       },
       put: {
+        operationId: "updateTrip",
         tags: ["Trips"],
         summary: "여행 수정",
-        description: "HOST 이상 권한 필요.",
+        description: "HOST 이상 권한 필요. 전달된 필드만 업데이트.",
         requestBody: {
           content: {
             "application/json": {
@@ -181,30 +248,33 @@ export const openApiSpec = {
         },
         responses: {
           "200": { description: "수정된 여행" },
-          "403": { description: "권한 부족" },
+          "403": { description: "권한 부족", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
         },
       },
       delete: {
+        operationId: "deleteTrip",
         tags: ["Trips"],
         summary: "여행 삭제",
         description: "OWNER만 삭제 가능. 모든 일자와 멤버가 함께 삭제된다.",
         responses: {
           "200": { description: "삭제 완료" },
-          "403": { description: "OWNER가 아님" },
+          "403": { description: "OWNER가 아님", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
         },
       },
     },
     "/api/trips/{id}/days": {
       parameters: [{ name: "id", in: "path", required: true, schema: { type: "integer" } }],
       get: {
+        operationId: "listDays",
         tags: ["Days"],
         summary: "일자 목록 조회",
         responses: {
           "200": { description: "일자 목록", content: { "application/json": { schema: { type: "array", items: { $ref: "#/components/schemas/Day" } } } } },
-          "403": { description: "멤버가 아님" },
+          "403": { description: "멤버가 아님", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
         },
       },
       post: {
+        operationId: "createDay",
         tags: ["Days"],
         summary: "일자 추가",
         description: "HOST 이상 권한 필요.",
@@ -222,12 +292,17 @@ export const openApiSpec = {
                   sortOrder: { type: "integer" },
                 },
               },
+              example: {
+                date: "2026-06-07T00:00:00.000Z",
+                title: "리스본 (도착)",
+                content: "공항 픽업 + 호텔 체크인",
+              },
             },
           },
         },
         responses: {
           "201": { description: "생성된 일자" },
-          "403": { description: "권한 부족" },
+          "403": { description: "권한 부족", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
         },
       },
     },
@@ -237,6 +312,7 @@ export const openApiSpec = {
         { name: "dayId", in: "path", required: true, schema: { type: "integer" } },
       ],
       put: {
+        operationId: "updateDay",
         tags: ["Days"],
         summary: "일자 수정",
         description: "HOST 이상 권한 필요.",
@@ -257,16 +333,17 @@ export const openApiSpec = {
         },
         responses: {
           "200": { description: "수정된 일자" },
-          "403": { description: "권한 부족" },
+          "403": { description: "권한 부족", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
         },
       },
       delete: {
+        operationId: "deleteDay",
         tags: ["Days"],
         summary: "일자 삭제",
         description: "HOST 이상 권한 필요.",
         responses: {
           "200": { description: "삭제 완료" },
-          "403": { description: "권한 부족" },
+          "403": { description: "권한 부족", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
         },
       },
     },
@@ -276,19 +353,22 @@ export const openApiSpec = {
         { name: "dayId", in: "path", required: true, schema: { type: "integer" } },
       ],
       get: {
+        operationId: "listActivities",
         tags: ["Activities"],
         summary: "활동 목록 조회",
-        description: "일자의 활동 목록을 시간순/정렬순으로 반환한다.",
+        description:
+          "일자의 활동 목록을 반환한다. **정렬 권장**: `startTime` 오름차순 1차, 동일 시간 시 `sortOrder` 보조.",
         responses: {
           "200": { description: "활동 목록", content: { "application/json": { schema: { type: "array", items: { $ref: "#/components/schemas/Activity" } } } } },
-          "401": { description: "미인증" },
-          "403": { description: "멤버가 아님" },
+          "401": { description: "미인증", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+          "403": { description: "멤버가 아님", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
         },
       },
       post: {
+        operationId: "createActivity",
         tags: ["Activities"],
         summary: "활동 추가",
-        description: "HOST 이상 권한 필요.",
+        description: "HOST 이상 권한 필요. `sortOrder`를 지정하지 않으면 0이 부여된다.",
         requestBody: {
           required: true,
           content: {
@@ -299,30 +379,46 @@ export const openApiSpec = {
                 properties: {
                   category: { type: "string", enum: ["SIGHTSEEING", "DINING", "TRANSPORT", "ACCOMMODATION", "SHOPPING", "OTHER"] },
                   title: { type: "string" },
-                  startTime: { type: "string", description: "HH:mm" },
-                  endTime: { type: "string", description: "HH:mm" },
+                  startTime: { type: "string", format: "date-time", description: "ISO 8601 datetime (offset 포함 가능)" },
+                  startTimezone: { type: "string", description: "IANA timezone (예: `Asia/Seoul`)" },
+                  endTime: { type: "string", format: "date-time" },
+                  endTimezone: { type: "string", description: "IANA timezone" },
                   location: { type: "string" },
                   memo: { type: "string" },
-                  cost: { type: "number" },
+                  cost: { type: "number", description: "비용 정수. 응답에서는 문자열로 직렬화." },
                   currency: { type: "string" },
                   reservationStatus: { type: "string", enum: ["REQUIRED", "RECOMMENDED", "ON_SITE", "NOT_NEEDED"] },
                   sortOrder: { type: "integer" },
                 },
+              },
+              example: {
+                category: "TRANSPORT",
+                title: "포르투-마드리드 Ryanair",
+                startTime: "2026-06-14T14:50:00+01:00",
+                startTimezone: "Europe/Lisbon",
+                endTime: "2026-06-14T17:05:00+02:00",
+                endTimezone: "Europe/Madrid",
+                location: "포르투(OPO) → 마드리드(MAD)",
+                cost: 645870,
+                currency: "KRW",
+                reservationStatus: "REQUIRED",
+                sortOrder: 2,
               },
             },
           },
         },
         responses: {
           "201": { description: "생성된 활동", content: { "application/json": { schema: { $ref: "#/components/schemas/Activity" } } } },
-          "400": { description: "필수 필드 누락" },
-          "403": { description: "권한 부족" },
-          "404": { description: "일자 없음" },
+          "400": { description: "필수 필드 누락", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+          "403": { description: "권한 부족", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+          "404": { description: "일자 없음", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
         },
       },
       patch: {
+        operationId: "reorderActivities",
         tags: ["Activities"],
         summary: "활동 순서 변경",
-        description: "HOST 이상 권한 필요.",
+        description: "HOST 이상 권한 필요. `orderedIds` 배열에 명시된 순서대로 `sortOrder`가 1부터 재부여된다.",
         requestBody: {
           required: true,
           content: {
@@ -334,13 +430,14 @@ export const openApiSpec = {
                   orderedIds: { type: "array", items: { type: "integer" }, description: "새 순서의 활동 ID 배열" },
                 },
               },
+              example: { orderedIds: [26, 27, 28, 92] },
             },
           },
         },
         responses: {
           "200": { description: "순서 변경 완료" },
-          "400": { description: "orderedIds 누락" },
-          "403": { description: "권한 부족" },
+          "400": { description: "orderedIds 누락", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+          "403": { description: "권한 부족", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
         },
       },
     },
@@ -351,6 +448,7 @@ export const openApiSpec = {
         { name: "activityId", in: "path", required: true, schema: { type: "integer" } },
       ],
       put: {
+        operationId: "updateActivity",
         tags: ["Activities"],
         summary: "활동 수정",
         description: "HOST 이상 권한 필요. 전달된 필드만 업데이트.",
@@ -362,8 +460,10 @@ export const openApiSpec = {
                 properties: {
                   category: { type: "string", enum: ["SIGHTSEEING", "DINING", "TRANSPORT", "ACCOMMODATION", "SHOPPING", "OTHER"] },
                   title: { type: "string" },
-                  startTime: { type: "string" },
-                  endTime: { type: "string" },
+                  startTime: { type: "string", format: "date-time" },
+                  startTimezone: { type: "string", description: "IANA timezone" },
+                  endTime: { type: "string", format: "date-time" },
+                  endTimezone: { type: "string", description: "IANA timezone" },
                   location: { type: "string" },
                   memo: { type: "string" },
                   cost: { type: "number" },
@@ -377,22 +477,24 @@ export const openApiSpec = {
         },
         responses: {
           "200": { description: "수정된 활동", content: { "application/json": { schema: { $ref: "#/components/schemas/Activity" } } } },
-          "403": { description: "권한 부족" },
+          "403": { description: "권한 부족", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
         },
       },
       delete: {
+        operationId: "deleteActivity",
         tags: ["Activities"],
         summary: "활동 삭제",
         description: "HOST 이상 권한 필요.",
         responses: {
           "200": { description: "삭제 완료" },
-          "403": { description: "권한 부족" },
+          "403": { description: "권한 부족", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
         },
       },
     },
     "/api/trips/{id}/members": {
       parameters: [{ name: "id", in: "path", required: true, schema: { type: "integer" } }],
       get: {
+        operationId: "listMembers",
         tags: ["Members"],
         summary: "멤버 목록 조회",
         responses: {
@@ -400,6 +502,7 @@ export const openApiSpec = {
         },
       },
       patch: {
+        operationId: "changeMemberRole",
         tags: ["Members"],
         summary: "멤버 역할 변경",
         description: "promote(GUEST→HOST): HOST 필요, demote(HOST→GUEST): OWNER 필요.",
@@ -420,6 +523,7 @@ export const openApiSpec = {
         responses: { "200": { description: "역할 변경 완료" } },
       },
       delete: {
+        operationId: "removeMember",
         tags: ["Members"],
         summary: "멤버 제거",
         parameters: [{ name: "memberId", in: "query", required: true, schema: { type: "integer" } }],
@@ -429,6 +533,7 @@ export const openApiSpec = {
     "/api/trips/{id}/invite": {
       parameters: [{ name: "id", in: "path", required: true, schema: { type: "integer" } }],
       post: {
+        operationId: "createInvite",
         tags: ["Members"],
         summary: "초대 링크 생성",
         description: "HOST 이상 권한 필요. JWT 기반 7일 유효 초대 토큰 발급.",
@@ -454,6 +559,7 @@ export const openApiSpec = {
     "/api/trips/{id}/transfer": {
       parameters: [{ name: "id", in: "path", required: true, schema: { type: "integer" } }],
       post: {
+        operationId: "transferOwnership",
         tags: ["Members"],
         summary: "소유권 이전",
         description: "OWNER만 가능. 대상은 HOST여야 한다.",
@@ -470,6 +576,7 @@ export const openApiSpec = {
     "/api/trips/{id}/leave": {
       parameters: [{ name: "id", in: "path", required: true, schema: { type: "integer" } }],
       post: {
+        operationId: "leaveTrip",
         tags: ["Members"],
         summary: "여행 탈퇴",
         description: "OWNER는 탈퇴 불가 (소유권 이전 후 가능).",
@@ -478,6 +585,7 @@ export const openApiSpec = {
     },
     "/api/tokens": {
       get: {
+        operationId: "listTokens",
         tags: ["Tokens"],
         summary: "토큰 목록 조회",
         description: "세션 인증 필수. 본인의 PAT 목록을 반환한다.",
@@ -490,6 +598,7 @@ export const openApiSpec = {
         },
       },
       post: {
+        operationId: "createToken",
         tags: ["Tokens"],
         summary: "토큰 수동 생성",
         description: "세션 인증 필수. 생성된 토큰 원문은 이 응답에서만 노출된다. 권장 경로는 `install.sh`의 OAuth CLI 자동 발급이며, 본 엔드포인트는 웹 전용 사용자의 수동 발급용으로 유지된다.",
@@ -506,6 +615,7 @@ export const openApiSpec = {
                   expiresAt: { type: "string", format: "date-time", nullable: true },
                 },
               },
+              example: { name: "claude-cli-2026-05", expiresAt: null },
             },
           },
         },
@@ -534,14 +644,15 @@ export const openApiSpec = {
     "/api/tokens/{id}": {
       parameters: [{ name: "id", in: "path", required: true, schema: { type: "integer" } }],
       delete: {
+        operationId: "deleteToken",
         tags: ["Tokens"],
         summary: "토큰 삭제",
         description: "세션 인증 필수. 본인 토큰만 삭제 가능. 즉시 무효화.",
         security: [{ SessionAuth: [] }],
         responses: {
           "200": { description: "삭제 완료" },
-          "403": { description: "타인 토큰" },
-          "404": { description: "존재하지 않음" },
+          "403": { description: "타인 토큰", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+          "404": { description: "존재하지 않음", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
         },
       },
     },


### PR DESCRIPTION
## 작업 내용
OpenAPI 스펙(`src/lib/openapi.ts`)에 LLM/AI CLI/SDK 코드젠 친화 메타와 실응답 정합 정정 일괄 적용.

## 변경 사항

### #512 (스펙 친화도)
- **operationId 21개 부여** — `listTrips`, `createActivity`, `reorderActivities` 등 안정 식별자
- **요청 example 추가** — `createTrip`, `createDay`, `createActivity`, `reorderActivities`, `createToken` 등 주요 엔드포인트
- **Error 스키마 보강** — `code` 필드(선택) 추가, 주요 4xx 응답에 `$ref` 적용
- **GET /api/trips/{id} description**: activities 미포함 + N+1 호출 안내
- **listActivities/createActivity description**: 정렬 규약 명시 (startTime 우선, sortOrder 보조)
- **info.description**: PAT 발급 페이지(`/settings/tokens`) + AI CLI/MCP 연동 + 시간/정렬 규약 안내
- **BearerAuth.description**: `/settings/tokens` URL 명시

### #514 (Activity 시간/타임존)
- `startTime`/`endTime`: HH:mm 명세 → ISO 8601 datetime + UTC 직렬화 명시
- `startTimezone`/`endTimezone`(IANA) 필드 추가 — 응답 스키마·POST/PUT 본문 모두
- `cost`: number 입력 / string 응답 직렬화 명시
- `sortOrder` description: startTime 동률 시 보조키로 정의

## 자가 검증
| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ⬜ 해당없음 | 데이터 변경 없는 스펙 보강 — Vercel preview 빌드로 검증 예정 |
| 테스트 | ⬜ 해당없음 | 기존 코드 동작 변경 없음 |
| 문서 동기화 | ✅ 완료 | `changes/512.feat.md`, `changes/514.feat.md` 단편 추가 |

## 검증 기준 (이슈 본문 발췌)
- [x] `openapi-typescript` 같은 코드젠 도구로 SDK 생성 시 함수명 의미 있게 나옴 (operationId 부여)
- [x] LLM에 스펙만 던져도 시간/타임존 필드 의미 파악 가능
- [x] 4xx 응답이 일관된 Error 객체 구조 (`code` 추가)
- [x] timezone 명세 보강으로 클라이언트가 의도대로 시간 저장 가능

## Follow-up
- operation별 `security` 명시 (현재는 글로벌 + Tokens만)
- 모든 4xx 응답에 Error schema 적용 (현재는 주요 응답만)
- 가이드 페이지 추가 — #513 별도 PR

Closes #512
Closes #514