### PR TITLE
feat(527): 외부 캘린더 import — Google·Apple → ActivityDraft 단방향

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,8 @@ develop ──●──●──●───●──●──●──●──
 - Neon Postgres — **신규 테이블 1종 추가**, 기존 테이블 2종 유지. Prisma migration 1건. (022-gcal-legacy-contract)
 - TypeScript 5.x, Node.js 20+ + Next.js 16 (App Router · Turbopack), React 19, Tailwind CSS v4 (`@theme` CSS-first), shadcn/ui (vendored), `class-variance-authority`, `tailwind-merge`, `clsx`, `lucide-react`, `tailwindcss-animate`, Style Dictionary v4. 본 피처에서 **신규 의존성 도입 없음** — spec 012/013/014 Active Technologies 승계. (026-responsive-layout)
 - N/A (UI 전용. 데이터 스키마 변경 없음.) (026-responsive-layout)
+- TypeScript 5.x, Node.js 20+ (Next.js 16). Python 3.10+ (MCP — 본 피처 영향 없음). + Next.js 16 (App Router · Turbopack), React 19, Prisma 7 (Neon Postgres adapter), Auth.js v5, `@googleapis/calendar`(Google), 기존 CalDAV 클라이언트 모듈(`src/lib/caldav/*`, v2.11.0 도입). shadcn/ui (vendored), Radix UI primitives, Tailwind CSS v4. **본 피처 신규 의존성 도입 없음** — v2.14.1 Active Technologies 승계. (027-external-calendar-import)
+- Neon Postgres (Production `neondb` / Preview·Dev `neondb_dev`). Prisma 마이그레이션 1건(schema-only): `ActivityDraft` 추가 + `(calendarId, externalEventId)` 유니크 인덱스. (027-external-calendar-import)
 
 ## Recent Changes
 - 001-ax-travel-planning: Added Python 3.14 + FastMCP, httpx, python-dotenv, pytes

--- a/changes/527.feat.md
+++ b/changes/527.feat.md
@@ -1,0 +1,3 @@
+- 외부 캘린더에 쌓아둔 일정을 trip으로 가져오는 수동 import 흐름 추가. trip 상세 사이드 패널의 "외부 캘린더에서 일정 가져오기"에서 Google 캘린더 1개를 선택하면 trip 기간과 겹치는 이벤트가 ActivityDraft로 들어오고 "외부 캘린더에서 가져옴" 배지로 표시된다. 같은 이벤트는 다시 실행해도 중복으로 들어오지 않는다(멱등성).
+  - Why: 사용자가 본인의 다른 캘린더에 이미 쌓아둔 여행 일정을 trip-planner에 다시 입력하지 않고 가져오기 위해. ADR 0006 외부 → 내부 단방향 정책. trip 캘린더 정본(ADR 0003)은 변경 없음.
+  - 본 릴리즈는 Google 캘린더만 지원. Apple 캘린더 import + draft → 정식 Activity 승격 UX는 v2.15.1+ 후속 마일스톤(#527의 [why: draft-promote] / [why: provider-fetch:apple] 추적).

--- a/docs/adr/0006-external-calendar-import-policy.md
+++ b/docs/adr/0006-external-calendar-import-policy.md
@@ -1,0 +1,73 @@
+# ADR 0006: 외부 캘린더 import 정책
+
+- **Status**: Accepted (2026-05-27, v2.15.0)
+- **Context**: Epic [#527](https://github.com/idean3885/trip-planner/issues/527), 마일스톤 [v2.15.0](https://github.com/idean3885/trip-planner/milestone/36)
+- **Related**: ADR 0003 per-trip-shared-calendar (유지)
+
+## Context
+
+사용자가 trip-planner 밖 캘린더(Google·Apple)에 여행 일정을 이미 쌓아둔 경우, 그것을 다시 입력하지 않고 trip-planner Activity로 가져오고 싶다는 요구가 있다. 현재(v2.14.1)는 trip-planner가 만든 캘린더로의 단방향 push만 지원하므로, 외부에 있는 일정은 옮길 수단이 없다.
+
+이 갭을 해소할 때 두 가지 큰 방향이 있다.
+
+1. 사용자 외부 캘린더 자체를 trip의 캘린더로 사용(link).
+2. 외부 캘린더에서 이벤트를 읽어 trip-planner Activity로 import.
+
+## Decision
+
+**(2) 방향만 채택한다.** 외부 캘린더는 데이터 원천으로만 쓰고, trip의 캘린더 정본은 ADR 0003(per-trip-shared-calendar) 모델 그대로 trip-planner가 만든 캘린더가 유지한다.
+
+세부 결정:
+
+- **외부 → 내부 단방향 import.** 양방향 sync는 본 ADR 범위 외.
+- **사용자 수동 트리거.** 자동 polling·webhook 없음.
+- **매핑 가능 필드만 자동 채움.** 외부 이벤트의 제목·시작·종료·장소 문자열·설명·종일 여부·timezone(있을 때)만 옮긴다.
+- **매핑 불가 필드는 `ActivityDraft`로 분리 보관.** activity category, hotel·attraction 참조, reservation status, 명시 timezone은 사용자가 trip-planner UI에서 입력하기 전까지 비워둔다.
+- **draft → 정식 Activity 승격은 사용자 명시 작업.** 승격 후에야 정식 Activity가 만들어지고 ADR 0003 push 경로에 합류한다.
+- **멱등성.** `(provider, externalCalendarId, externalEventId)` 키로 중복 import를 차단한다. "다시 가져오기"는 사용자 명시 선택 시에만 매핑 가능 필드를 덮어쓰며, 매핑 불가 필드(사용자 입력)는 보존한다.
+- **권한.** 외부 캘린더 import는 trip의 OWNER·HOST에게만 허용. GUEST는 403. 헌법 VI Permission Matrix에 행 추가.
+
+## Why this shape
+
+- **사용자 자산 보호.** 사용자가 본인 캘린더에 사적인 이벤트를 함께 둔 경우, 그 캘린더를 trip의 공유 캘린더로 사용하면 게스트에게 노출된다. 외부 캘린더는 절대 trip의 source of truth로 채택하지 않는다.
+- **삭제 영역 분리.** trip 삭제 시 trip-planner는 자체 모델만 cascade로 정리하고, 사용자 외부 캘린더의 이벤트는 손대지 않는다. 외부 캘린더에서 사용자가 이벤트를 지워도 trip-planner draft는 사용자가 명시 작업할 때까지 그대로 유지된다.
+- **승격 단계의 의도.** 외부 이벤트는 의미 필드를 안 가지므로 자동으로 정식 Activity로 만들면 잘못 매핑이 누적된다. draft에서 머무르다 사용자가 검토·승격하는 흐름이 데이터 품질을 지킨다.
+- **멱등성으로 운영 안정.** 사용자가 import 버튼을 여러 번 눌러도, 외부 provider가 일시 오류로 재시도해도 draft가 중복 쌓이지 않는다.
+
+## Rejected alternatives
+
+1. **외부 캘린더 자체를 trip 캘린더로 link(안 A)** — 사용자 사적 이벤트 노출·삭제 위험. 사용자 자산을 trip-planner가 수정·삭제하게 되는 경계 문제. 기각.
+2. **양방향 sync** — 외부 캘린더 변경의 자동 반영. webhook 채널 관리·삭제 race·conflict 정책이 복잡. 후속 마일스톤 별도 평가.
+3. **AI 기반 자동 draft 필드 보강** — 외부 title·description에서 hotelId·attractionId·category를 추정. 정확도·비용·헌법 II Minimum Cost 위반. 별도 ADR 후 검토.
+
+## Consequences
+
+**Positive**:
+
+- 사용자가 외부에 쌓아둔 일정을 trip-planner에 옮기는 경로가 생긴다.
+- ADR 0003 모델·기존 push 경로 변경 0. 회귀 표면 작음.
+- 멱등성으로 운영 안전(같은 import 반복 안전).
+
+**Negative / Trade-offs**:
+
+- 사용자가 draft 승격을 안 하면 정식 Activity 흐름과 단절된 상태가 누적될 수 있다. trip 삭제 시 cascade로 정리되므로 영구 고아는 없다.
+- 외부 이벤트의 자유 텍스트(description)에 사적 내용이 있을 수 있어 import 시 그대로 draft에 들어간다. draft는 trip 멤버 ACL(OWNER·HOST·GUEST의 GUEST는 읽기 허용)에 따라 노출된다. 사용자에게 import 전 안내 문구로 고지한다.
+- 양방향 sync 미지원이라 외부에서 수정·삭제한 변경은 사용자가 "다시 가져오기" 또는 draft 삭제로 명시 처리해야 한다.
+
+## Permission Matrix (헌법 VI 갱신 항목)
+
+| 행위 | OWNER | HOST | GUEST |
+|------|-------|------|-------|
+| 외부 캘린더 import | O | O | X |
+| draft 승격(=Activity 생성) | O | O | X |
+| draft "다시 가져오기" | O | O | X |
+| draft 삭제 | O | O | X |
+
+draft 조회는 trip 조회 권한에 흡수(GUEST 포함 멤버 전체 가능).
+
+## Related
+
+- Spec: [`specs/027-external-calendar-import/spec.md`](../../specs/027-external-calendar-import/spec.md)
+- Plan: [`specs/027-external-calendar-import/plan.md`](../../specs/027-external-calendar-import/plan.md)
+- Data Model: [`specs/027-external-calendar-import/data-model.md`](../../specs/027-external-calendar-import/data-model.md)
+- ADR 0003 per-trip-shared-calendar — 유지

--- a/prisma/migrations/20260527000000_add_activity_draft/migration.sql
+++ b/prisma/migrations/20260527000000_add_activity_draft/migration.sql
@@ -1,0 +1,76 @@
+-- [migration-type: schema-only]
+-- spec 027 (#527) — 외부 캘린더 import용 ActivityDraft + ImportRun 테이블.
+-- ADR 0006 외부 → 내부 단방향. trip 캘린더 정본(ADR 0003)은 변경 없음.
+-- 매핑 가능 필드는 채워서 받고, 매핑 불가 필드는 사용자가 승격 단계에서 입력.
+-- 멱등성: (provider, external_calendar_id, external_event_id) 3-tuple 유니크.
+
+-- 1) enum: ActivityDraftStatus
+CREATE TYPE "ActivityDraftStatus" AS ENUM ('PENDING', 'PROMOTED', 'DELETED');
+
+-- 2) ImportRun — import 1회 실행 메타. ActivityDraft가 FK로 참조하므로 먼저 생성.
+CREATE TABLE "import_runs" (
+    "id" SERIAL NOT NULL,
+    "trip_id" INTEGER NOT NULL,
+    "triggered_by_user_id" TEXT NOT NULL,
+    "provider" "CalendarProviderId" NOT NULL,
+    "external_calendar_id" TEXT NOT NULL,
+    "imported_count" INTEGER NOT NULL DEFAULT 0,
+    "skipped_count" INTEGER NOT NULL DEFAULT 0,
+    "failed_count" INTEGER NOT NULL DEFAULT 0,
+    "failed_titles" TEXT[],
+    "started_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "finished_at" TIMESTAMPTZ(3),
+
+    CONSTRAINT "import_runs_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "import_runs_trip_id_started_at_idx" ON "import_runs"("trip_id", "started_at");
+
+ALTER TABLE "import_runs" ADD CONSTRAINT "import_runs_trip_id_fkey"
+    FOREIGN KEY ("trip_id") REFERENCES "trips"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "import_runs" ADD CONSTRAINT "import_runs_triggered_by_user_id_fkey"
+    FOREIGN KEY ("triggered_by_user_id") REFERENCES "users"("id") ON DELETE NO ACTION ON UPDATE CASCADE;
+
+-- 3) ActivityDraft — 외부 이벤트에서 만들어진 일정 초안.
+CREATE TABLE "activity_drafts" (
+    "id" SERIAL NOT NULL,
+    "trip_id" INTEGER NOT NULL,
+    "day_id" INTEGER,
+    "provider" "CalendarProviderId" NOT NULL,
+    "external_calendar_id" TEXT NOT NULL,
+    "external_event_id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "start_time" TIMESTAMPTZ(3) NOT NULL,
+    "end_time" TIMESTAMPTZ(3) NOT NULL,
+    "is_all_day" BOOLEAN NOT NULL DEFAULT false,
+    "location_text" TEXT,
+    "description" TEXT,
+    "start_timezone" VARCHAR(40),
+    "end_timezone" VARCHAR(40),
+    "status" "ActivityDraftStatus" NOT NULL DEFAULT 'PENDING',
+    "promoted_to_activity_id" INTEGER,
+    "import_run_id" INTEGER NOT NULL,
+    "last_refreshed_at" TIMESTAMPTZ(3),
+    "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3) NOT NULL,
+
+    CONSTRAINT "activity_drafts_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "activity_drafts_promoted_to_activity_id_key" ON "activity_drafts"("promoted_to_activity_id");
+CREATE UNIQUE INDEX "activity_drafts_provider_external_calendar_id_external_event_id_key"
+    ON "activity_drafts"("provider", "external_calendar_id", "external_event_id");
+CREATE INDEX "activity_drafts_trip_id_status_idx" ON "activity_drafts"("trip_id", "status");
+
+ALTER TABLE "activity_drafts" ADD CONSTRAINT "activity_drafts_trip_id_fkey"
+    FOREIGN KEY ("trip_id") REFERENCES "trips"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "activity_drafts" ADD CONSTRAINT "activity_drafts_day_id_fkey"
+    FOREIGN KEY ("day_id") REFERENCES "days"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "activity_drafts" ADD CONSTRAINT "activity_drafts_promoted_to_activity_id_fkey"
+    FOREIGN KEY ("promoted_to_activity_id") REFERENCES "activities"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "activity_drafts" ADD CONSTRAINT "activity_drafts_import_run_id_fkey"
+    FOREIGN KEY ("import_run_id") REFERENCES "import_runs"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,7 @@ model User {
   ownedCalendarLinks          TripCalendarLink[]           @relation("TripCalendarLinkOwner")
   memberCalendarSubscriptions MemberCalendarSubscription[] @relation("MemberCalendarSubscriptionUser")
   appleCalendarCredential     AppleCalendarCredential?     @relation("AppleCalendarCredentialUser")
+  triggeredImportRuns         ImportRun[]                  @relation("ImportRunTriggeredByUser")
 
   @@map("users")
 }
@@ -93,6 +94,8 @@ model Trip {
   tripMembers    TripMember[]
   gcalLinks      GCalLink[]
   calendarLink   TripCalendarLink?
+  activityDrafts ActivityDraft[]
+  importRuns     ImportRun[]
 
   @@map("trips")
 }
@@ -104,8 +107,9 @@ model Day {
   title   String?
   content String?  @db.Text
 
-  trip       Trip       @relation(fields: [tripId], references: [id], onDelete: Cascade)
-  activities Activity[]
+  trip           Trip            @relation(fields: [tripId], references: [id], onDelete: Cascade)
+  activities     Activity[]
+  activityDrafts ActivityDraft[]
 
   @@unique([tripId, date])
   @@index([tripId, date])
@@ -150,9 +154,10 @@ model Activity {
   createdAt         DateTime           @default(now()) @map("created_at") @db.Timestamptz(3)
   updatedAt         DateTime           @updatedAt @map("updated_at") @db.Timestamptz(3)
 
-  day                      Day                        @relation(fields: [dayId], references: [id], onDelete: Cascade)
-  gcalEventMappings        GCalEventMapping[]
+  day                       Day                        @relation(fields: [dayId], references: [id], onDelete: Cascade)
+  gcalEventMappings         GCalEventMapping[]
   tripCalendarEventMappings TripCalendarEventMapping[] @relation("TripCalendarEventMappingActivity")
+  promotedFromDraft         ActivityDraft?             @relation("ActivityDraftPromoted")
 
   @@index([dayId, startTime])
   @@index([dayId, sortOrder])
@@ -298,7 +303,7 @@ model AppleCalendarCredential {
   userId            String    @id @map("user_id")
   appleId           String    @map("apple_id")
   encryptedPassword String    @map("encrypted_password") // base64(ciphertext + auth tag)
-  iv                String                               // base64(12바이트 random)
+  iv                String // base64(12바이트 random)
   lastValidatedAt   DateTime? @map("last_validated_at") @db.Timestamptz(3)
   lastError         String?   @map("last_error")
   createdAt         DateTime  @default(now()) @map("created_at") @db.Timestamptz(3)
@@ -324,6 +329,84 @@ model MemberCalendarSubscription {
   @@unique([linkId, userId])
   @@index([userId])
   @@map("member_calendar_subscriptions")
+}
+
+// ============================================================
+// Personal Access Token (외부 클라이언트 API 인증)
+// ============================================================
+
+// ============================================================
+// 외부 캘린더 import (spec 027, ADR 0006, v2.15.0)
+// 외부 → 내부 단방향. trip 캘린더 정본(ADR 0003)은 그대로 유지.
+// ============================================================
+
+enum ActivityDraftStatus {
+  PENDING
+  PROMOTED
+  DELETED
+}
+
+model ActivityDraft {
+  id     Int  @id @default(autoincrement())
+  tripId Int  @map("trip_id")
+  dayId  Int? @map("day_id")
+
+  // 외부 출처 식별
+  provider           CalendarProviderId
+  externalCalendarId String             @map("external_calendar_id")
+  externalEventId    String             @map("external_event_id")
+
+  // 매핑 가능 필드 (외부 → 자동 채움)
+  title        String
+  startTime    DateTime @map("start_time") @db.Timestamptz(3)
+  endTime      DateTime @map("end_time") @db.Timestamptz(3)
+  isAllDay     Boolean  @default(false) @map("is_all_day")
+  locationText String?  @map("location_text")
+  description  String?  @db.Text
+
+  // 매핑 불가 필드 (사용자 보강 대상)
+  startTimezone String? @map("start_timezone") @db.VarChar(40)
+  endTimezone   String? @map("end_timezone") @db.VarChar(40)
+
+  // 상태
+  status               ActivityDraftStatus @default(PENDING)
+  promotedToActivityId Int?                @unique @map("promoted_to_activity_id")
+
+  // 메타
+  importRunId     Int       @map("import_run_id")
+  lastRefreshedAt DateTime? @map("last_refreshed_at") @db.Timestamptz(3)
+  createdAt       DateTime  @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt       DateTime  @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  trip               Trip      @relation(fields: [tripId], references: [id], onDelete: Cascade)
+  day                Day?      @relation(fields: [dayId], references: [id], onDelete: SetNull)
+  promotedToActivity Activity? @relation("ActivityDraftPromoted", fields: [promotedToActivityId], references: [id], onDelete: SetNull)
+  importRun          ImportRun @relation(fields: [importRunId], references: [id], onDelete: Restrict)
+
+  @@unique([provider, externalCalendarId, externalEventId])
+  @@index([tripId, status])
+  @@map("activity_drafts")
+}
+
+model ImportRun {
+  id                 Int                @id @default(autoincrement())
+  tripId             Int                @map("trip_id")
+  triggeredByUserId  String             @map("triggered_by_user_id")
+  provider           CalendarProviderId
+  externalCalendarId String             @map("external_calendar_id")
+  importedCount      Int                @default(0) @map("imported_count")
+  skippedCount       Int                @default(0) @map("skipped_count")
+  failedCount        Int                @default(0) @map("failed_count")
+  failedTitles       String[]           @map("failed_titles")
+  startedAt          DateTime           @default(now()) @map("started_at") @db.Timestamptz(3)
+  finishedAt         DateTime?          @map("finished_at") @db.Timestamptz(3)
+
+  trip            Trip            @relation(fields: [tripId], references: [id], onDelete: Cascade)
+  triggeredByUser User            @relation("ImportRunTriggeredByUser", fields: [triggeredByUserId], references: [id])
+  drafts          ActivityDraft[]
+
+  @@index([tripId, startedAt])
+  @@map("import_runs")
 }
 
 // ============================================================

--- a/specs/027-external-calendar-import/checklists/requirements.md
+++ b/specs/027-external-calendar-import/checklists/requirements.md
@@ -1,0 +1,66 @@
+# Specification Quality Checklist: 외부 캘린더 import
+
+**Purpose**: spec 완성도와 품질을 plan 단계 전에 검증한다
+**Created**: 2026-05-27
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Validation Notes
+
+### Content Quality 점검
+
+- **No implementation details**: spec 본문에 Prisma·Next.js·Google Calendar API 같은 구체 기술명을 직접 명령하는 표현 없음. "OAuth", "CalDAV"는 Assumptions에서 v2.14.1 시점 기존 연동을 그대로 쓴다는 컨텍스트로만 등장(어떤 라이브러리·API를 호출할지는 plan에서 결정).
+- **User value focus**: User Stories가 "사용자가 외부 캘린더에 이미 쌓아둔 일정을 옮긴다"라는 사용자 가치 중심으로 작성됨. Why 항목에 가치 근거 명시.
+- **Non-technical stakeholders**: FR-001~FR-016 모두 "시스템이 무엇을 한다" 수준. 구체 API 시그니처·DB 컬럼 없음.
+- **All mandatory sections completed**: Clarifications, User Scenarios, Requirements, Key Entities, Success Criteria, Assumptions, Out of Scope 모두 작성됨.
+
+### Requirement Completeness 점검
+
+- **No [NEEDS CLARIFICATION] markers**: spec 전체 grep 결과 0건. 사용자가 사전에 인/아웃 스코프와 결정 사항을 명시했으므로 informed guess로 모든 모호점 봉합.
+- **Testable and unambiguous**: 각 FR이 "MUST" 조건절로 검증 가능. 예: FR-006(멱등성)은 "같은 외부 이벤트를 두 번 이상 import할 때 새 draft를 만들지 않는다"로 결과 관측 가능.
+- **Success criteria measurable**: SC-001(1분 이내), SC-002(100%), SC-003(draft 수 ≤ 1), SC-004(5필드 이내), SC-005(100%), SC-006(100%) 모두 정량.
+- **Success criteria technology-agnostic**: SC-001은 사용자 체감 시간, SC-002~006은 비율·건수. 구체 기술 언급 없음.
+- **All acceptance scenarios defined**: US1(3개), US2(3개), US3(2개)로 Given/When/Then 형식.
+- **Edge cases identified**: 종일·반복·trip 기간 부분 겹침·외부 API 부분 실패·trip 삭제·draft 직접 삭제 등 8건.
+- **Scope clearly bounded**: Out of Scope 5항목으로 양방향 sync·외부 캘린더 직접 사용·AI 자동 추정·ACL 변경·push 경로 변경 모두 명시 제외.
+- **Dependencies and assumptions identified**: Assumptions 5항목(기존 OAuth·CalDAV 연동 재사용, trip 기간 기준, 외부 이벤트 ID 안정성, location 자유 텍스트, 50건 기준).
+
+### Feature Readiness 점검
+
+- **FR에 acceptance criteria 연결**: FR-001~003은 US1, FR-006~007은 US3, FR-009~010은 US2에 acceptance scenario로 연결됨. FR-011(미연결 사용자), FR-013(trip 삭제), FR-014(요약 결과)는 Edge Cases·SC에 검증 경로 있음.
+- **User scenarios cover primary flows**: import → draft → 승격 → push (US1→US2)이 본 흐름. 멱등성(US3)이 운영 품질.
+- **Feature meets SC**: SC-001~006 모두 US1·US2·US3의 acceptance scenarios로 관측 가능.
+- **No implementation leak**: ADR 0003 참조는 "어떤 모델을 유지하는가"라는 정책 결정 인용으로 사용. 구현 수단 명시 아님.
+
+## Status
+
+전체 항목 통과. spec은 plan 단계로 진행 가능.
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+- 본 마일스톤은 [NEEDS CLARIFICATION] 0개로 작성됨 — speckit.clarify는 선택적, 바로 speckit.plan으로 갈 수 있음

--- a/specs/027-external-calendar-import/contracts/activity-draft.openapi.yaml
+++ b/specs/027-external-calendar-import/contracts/activity-draft.openapi.yaml
@@ -1,0 +1,239 @@
+openapi: 3.1.0
+info:
+  title: Trip Planner — Activity Draft API
+  version: 0.1.0
+  description: |
+    외부 캘린더에서 import된 draft 일정을 조회·승격·갱신·삭제한다.
+    Spec: specs/027-external-calendar-import/spec.md
+
+servers:
+  - url: https://trip.idean.me/api
+    description: production
+  - url: https://dev.trip.idean.me/api
+    description: dev
+
+security:
+  - sessionCookie: []
+
+paths:
+  /trips/{tripId}/drafts:
+    get:
+      operationId: listTripDrafts
+      summary: trip의 draft 목록
+      parameters:
+        - in: path
+          name: tripId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [PENDING, PROMOTED, DELETED]
+            default: PENDING
+      responses:
+        "200":
+          description: draft 목록
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  drafts:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ActivityDraft"
+        "401":
+          description: 미인증
+        "403":
+          description: trip 비멤버
+        "404":
+          description: trip 없음
+
+  /trips/{tripId}/drafts/{draftId}/promote:
+    post:
+      operationId: promoteDraftToActivity
+      summary: draft를 정식 Activity로 승격
+      description: |
+        매핑 불가 필드(activity type, hotel·attraction 참조, reservation status, timezone)를
+        사용자 입력으로 채워 정식 Activity로 전환. 승격 후 trip 캘린더(ADR 0003 모델) push 경로에
+        자동 연결. 필수 필드 누락 시 422.
+      parameters:
+        - in: path
+          name: tripId
+          required: true
+          schema: { type: string }
+        - in: path
+          name: draftId
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PromoteRequest"
+      responses:
+        "200":
+          description: 승격 완료
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [activityId]
+                properties:
+                  activityId:
+                    type: integer
+        "401": { description: 미인증 }
+        "403": { description: 권한 부족 — GUEST 또는 trip 비멤버 }
+        "404": { description: draft 없음 또는 이미 PROMOTED }
+        "422":
+          description: 필수 필드 누락
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationError"
+
+  /trips/{tripId}/drafts/{draftId}/refresh:
+    post:
+      operationId: refreshDraftFromExternal
+      summary: 외부 최신 값으로 draft의 매핑 가능 필드 덮어쓰기
+      description: |
+        매핑 가능 필드(title·startTime·endTime·locationText·description·isAllDay)만 외부 최신 값으로
+        업데이트. 매핑 불가 필드(사용자가 채운 timezone 등)는 보존. PROMOTED 상태 draft에 대해서는 거부(409).
+      parameters:
+        - in: path
+          name: tripId
+          required: true
+          schema: { type: string }
+        - in: path
+          name: draftId
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: 덮어쓰기 완료
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivityDraft"
+        "404": { description: draft 없음 또는 외부 이벤트가 사라짐 }
+        "409":
+          description: PROMOTED 상태 draft는 refresh 불가
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /trips/{tripId}/drafts/{draftId}:
+    delete:
+      operationId: deleteDraft
+      summary: draft 단건 삭제 (외부 캘린더에는 영향 없음)
+      parameters:
+        - in: path
+          name: tripId
+          required: true
+          schema: { type: string }
+        - in: path
+          name: draftId
+          required: true
+          schema: { type: string }
+      responses:
+        "204": { description: 삭제 완료 — 멱등 처리이므로 대상이 없어도 204 반환 }
+
+components:
+  securitySchemes:
+    sessionCookie:
+      type: apiKey
+      in: cookie
+      name: authjs.session-token
+
+  schemas:
+    ActivityDraft:
+      type: object
+      required: [id, tripId, provider, externalCalendarId, externalEventId, title, startTime, endTime, isAllDay, status]
+      properties:
+        id: { type: integer }
+        tripId: { type: integer }
+        dayId:
+          type: integer
+          nullable: true
+        provider:
+          type: string
+          enum: [GOOGLE, APPLE]
+        externalCalendarId: { type: string }
+        externalEventId: { type: string }
+        title: { type: string }
+        startTime:
+          type: string
+          format: date-time
+        endTime:
+          type: string
+          format: date-time
+        isAllDay: { type: boolean }
+        locationText:
+          type: string
+          nullable: true
+        description:
+          type: string
+          nullable: true
+        startTimezone:
+          type: string
+          nullable: true
+        endTimezone:
+          type: string
+          nullable: true
+        status:
+          type: string
+          enum: [PENDING, PROMOTED, DELETED]
+        promotedToActivityId:
+          type: integer
+          nullable: true
+        lastRefreshedAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+
+    PromoteRequest:
+      type: object
+      required: [category, reservationStatus, startTimezone, endTimezone]
+      properties:
+        category:
+          type: string
+          description: Prisma `ActivityCategory` enum과 동일.
+          enum: [SIGHTSEEING, DINING, TRANSPORT, ACCOMMODATION, SHOPPING, OTHER]
+        reservationStatus:
+          type: string
+          enum: [REQUIRED, RECOMMENDED, ON_SITE, NOT_NEEDED]
+        startTimezone:
+          type: string
+          description: IANA timezone (예 "Asia/Seoul")
+        endTimezone:
+          type: string
+        location:
+          type: string
+          nullable: true
+          description: location 문자열을 수정할 경우. 누락 시 draft.locationText를 그대로 사용.
+
+    ValidationError:
+      type: object
+      required: [code, message, fields]
+      properties:
+        code:
+          type: string
+          example: MISSING_REQUIRED_FIELDS
+        message: { type: string }
+        fields:
+          type: array
+          items: { type: string }
+
+    Error:
+      type: object
+      required: [code, message]
+      properties:
+        code: { type: string }
+        message: { type: string }

--- a/specs/027-external-calendar-import/contracts/calendar-import.openapi.yaml
+++ b/specs/027-external-calendar-import/contracts/calendar-import.openapi.yaml
@@ -1,0 +1,159 @@
+openapi: 3.1.0
+info:
+  title: Trip Planner — Calendar Import API
+  version: 0.1.0
+  description: |
+    외부 캘린더(Google·Apple)의 이벤트를 trip-planner의 draft activity로 가져온다.
+    Spec: specs/027-external-calendar-import/spec.md
+
+servers:
+  - url: https://trip.idean.me/api
+    description: production
+  - url: https://dev.trip.idean.me/api
+    description: dev
+
+security:
+  - sessionCookie: []
+
+paths:
+  /trips/{tripId}/calendar-import:
+    post:
+      operationId: importTripFromExternalCalendar
+      summary: 외부 캘린더에서 trip으로 일정 import (수동 트리거)
+      description: |
+        호출자가 선택한 외부 캘린더의 이벤트들을 trip 기간과 겹치는 범위에서
+        `ActivityDraft`로 가져온다. 멱등성 보장: (provider, externalCalendarId,
+        externalEventId) 키로 기존 draft가 있으면 새로 만들지 않고 skip 카운트만 증가.
+        권한: trip의 OWNER 또는 HOST. GUEST는 403.
+      parameters:
+        - in: path
+          name: tripId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CalendarImportRequest"
+      responses:
+        "200":
+          description: import 완료. 결과 요약 반환.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CalendarImportResult"
+        "400":
+          description: 잘못된 요청 (provider/calendarId 누락 등)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: 미인증
+        "403":
+          description: 권한 부족 (GUEST 또는 trip 비멤버)
+        "404":
+          description: trip 또는 외부 캘린더를 찾을 수 없음
+        "409":
+          description: 외부 계정 미연결 — /settings/calendars로 안내
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /users/me/external-calendars:
+    get:
+      operationId: listMyExternalCalendars
+      summary: 사용자가 연결한 외부 계정의 캘린더 목록
+      description: |
+        Google·Apple 모두 합쳐서 반환. trip-planner가 만든 캘린더는 제외(`isManagedByTripPlanner=true`인
+        캘린더 제외). 본 API의 결과를 캘린더 선택 모달에 표시한다.
+      responses:
+        "200":
+          description: 외부 캘린더 목록
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  calendars:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ExternalCalendar"
+        "401":
+          description: 미인증
+
+components:
+  securitySchemes:
+    sessionCookie:
+      type: apiKey
+      in: cookie
+      name: authjs.session-token
+
+  schemas:
+    CalendarImportRequest:
+      type: object
+      required: [provider, externalCalendarId]
+      properties:
+        provider:
+          type: string
+          enum: [GOOGLE, APPLE]
+        externalCalendarId:
+          type: string
+          description: 외부 캘린더 식별자. Google calendarId 또는 Apple CalDAV href.
+
+    CalendarImportResult:
+      type: object
+      required: [importRunId, importedCount, skippedCount, failedCount]
+      properties:
+        importRunId:
+          type: integer
+        importedCount:
+          type: integer
+          description: 신규 생성된 draft 수
+        skippedCount:
+          type: integer
+          description: 이미 draft가 존재해 건너뛴 외부 이벤트 수
+        failedCount:
+          type: integer
+          description: fetch·매핑 실패 이벤트 수
+        failedTitles:
+          type: array
+          maxItems: 3
+          items:
+            type: string
+          description: 실패 이벤트의 외부 제목 첫 3건(privacy 고려해 title만)
+
+    ExternalCalendar:
+      type: object
+      required: [provider, externalCalendarId, name]
+      properties:
+        provider:
+          type: string
+          enum: [GOOGLE, APPLE]
+        externalCalendarId:
+          type: string
+        name:
+          type: string
+          description: 외부 캘린더 이름(사용자가 본 그대로)
+        accountLabel:
+          type: string
+          description: 어느 외부 계정에 속하는지(예: "user@gmail.com")
+        isManagedByTripPlanner:
+          type: boolean
+          description: trip-planner가 만든 캘린더인지. true면 import 대상에서 제외.
+
+    Error:
+      type: object
+      required: [code, message]
+      properties:
+        code:
+          type: string
+          example: EXTERNAL_ACCOUNT_NOT_LINKED
+        message:
+          type: string
+        details:
+          type: object
+          additionalProperties: true

--- a/specs/027-external-calendar-import/data-model.md
+++ b/specs/027-external-calendar-import/data-model.md
@@ -1,0 +1,199 @@
+# Data Model: 외부 캘린더 import
+
+**Branch**: `027-external-calendar-import` · **Date**: 2026-05-27 · **Spec**: [spec.md](./spec.md)
+
+본 문서는 spec FR-001~016 + research.md 결정에 따른 Prisma 스키마 변경과 도메인 entity 관계를 정의한다. 마이그레이션은 schema-only 1건.
+
+## Entity 요약
+
+| Entity | 신규/변경 | 소유 도메인 | 역할 |
+|--------|-----------|-------------|------|
+| `ActivityDraft` | 신규 | 일정 편성 | 외부 이벤트로부터 만든 일정 초안 |
+| `ImportRun` | 신규 | 일정 편성 | import 1회 실행의 결과 메타 |
+| `Activity` | 변경 없음 | 일정 편성 | draft 승격 시 신규 row 생성 (기존 흐름 재사용) |
+| `Trip` | 변경 없음 | 일정 편성 | `ActivityDraft`·`ImportRun`의 부모 |
+
+## ActivityDraft
+
+외부 이벤트에서 만들어진 일정의 초안. 정식 `Activity`로 승격되기 전까지 별도 테이블에 보관한다.
+
+### Prisma 스키마(개념)
+
+```prisma
+model ActivityDraft {
+  id                  Int      @id @default(autoincrement())
+  tripId              String
+  trip                Trip     @relation(fields: [tripId], references: [id], onDelete: Cascade)
+  dayId               String?
+  day                 Day?     @relation(fields: [dayId], references: [id], onDelete: SetNull)
+
+  // 외부 출처 식별
+  provider            CalendarProvider   // enum: GOOGLE | APPLE
+  externalCalendarId  String
+  externalEventId     String
+
+  // 매핑 가능 필드 (외부 → 자동 채움)
+  title               String
+  startTime           DateTime
+  endTime             DateTime
+  isAllDay            Boolean  @default(false)
+  locationText        String?
+  description         String?
+
+  // 매핑 불가 필드 (사용자 보강 대상)
+  startTimezone       String?
+  endTimezone         String?
+
+  // 상태 추적
+  status              ActivityDraftStatus @default(PENDING) // PENDING | PROMOTED | DELETED
+  promotedToActivityId String? @unique
+  promotedToActivity   Activity? @relation(fields: [promotedToActivityId], references: [id], onDelete: SetNull)
+
+  // 메타
+  importRunId         String
+  importRun           ImportRun @relation(fields: [importRunId], references: [id], onDelete: Restrict)
+  createdAt           DateTime  @default(now())
+  updatedAt           DateTime  @updatedAt
+  lastRefreshedAt     DateTime?  // "다시 가져오기" 시 갱신
+
+  @@unique([provider, externalCalendarId, externalEventId])
+  @@index([tripId, status])
+}
+```
+
+### 필드 정의
+
+- `provider`: enum. `GOOGLE` | `APPLE`. fetch 어댑터가 결정.
+- `externalCalendarId`: 외부 캘린더 자체의 식별자(Google calendarId / Apple href).
+- `externalEventId`: 외부 이벤트 식별자(Google event.id / Apple UID). research.md §2 근거.
+- `title`, `startTime`, `endTime`, `isAllDay`, `locationText`, `description`: spec FR-003 매핑 가능 필드.
+- `startTimezone`, `endTimezone`: 외부에 timezone이 명시되어 있으면 그대로, floating-time이면 `null`. 승격 시 사용자 입력 필요.
+- `status`: draft 생명주기. `PENDING`(승격 전), `PROMOTED`(정식 Activity로 전환됨, 참조만 유지). `DELETED` enum 값은 후속 회차에서 소프트 삭제·복원 UX 도입 시 사용 예정 — 현재는 사용자 삭제 시 hard delete(DB 행 제거)로 처리한다.
+- `promotedToActivityId`: 승격 시 만든 `Activity.id`와 1:1 연결(unique). 승격 후 draft를 삭제하지 않고 PROMOTED 상태로 두는 것이 멱등성·"다시 가져오기" 추적에 유리.
+
+### 유니크 제약
+
+`@@unique([provider, externalCalendarId, externalEventId])` — research.md §4 멱등성의 마지막 안전망. 동시 import race 시 DB 레벨에서 중복 차단.
+
+### 인덱스
+
+`@@index([tripId, status])` — trip 일정 화면에서 PENDING draft 조회용. 자주 쓰는 쿼리.
+
+## ImportRun
+
+import 1회 실행의 결과 요약. 사용자 응답·운영 진단에 쓰이며, 향후 dashboard·재시도 UX 도입 시 기반.
+
+```prisma
+model ImportRun {
+  id                  Int      @id @default(autoincrement())
+  tripId              String
+  trip                Trip     @relation(fields: [tripId], references: [id], onDelete: Cascade)
+  triggeredByUserId   String
+  triggeredByUser     User     @relation(fields: [triggeredByUserId], references: [id])
+
+  provider            CalendarProvider
+  externalCalendarId  String
+
+  importedCount       Int      @default(0)
+  skippedCount        Int      @default(0)
+  failedCount         Int      @default(0)
+  failedTitles        String[] // 최대 3개 (privacy: title만)
+
+  startedAt           DateTime @default(now())
+  finishedAt          DateTime?
+
+  drafts              ActivityDraft[]
+
+  @@index([tripId, startedAt])
+}
+```
+
+### 필드 정의
+
+- `triggeredByUserId`: 어느 멤버가 import를 실행했는지. 권한 감사·재시도 추적.
+- `importedCount` / `skippedCount` / `failedCount`: spec FR-014 요약 카운트.
+- `failedTitles`: 실패 이벤트의 외부 제목 첫 3건. research.md §8 privacy 결정에 따라 description은 저장 안 함.
+- `finishedAt`: import 종료 시각. null이면 진행 중(현재 마일스톤에선 동기 호출이지만 추후 async 분리 시 사용).
+
+## ActivityDraftStatus / CalendarProvider enum
+
+```prisma
+enum ActivityDraftStatus {
+  PENDING
+  PROMOTED
+  DELETED
+}
+
+enum CalendarProvider {
+  GOOGLE
+  APPLE
+}
+```
+
+`CalendarProvider`는 기존 `GCalProvider` 같은 enum이 v2.11.0에 있으면 그것을 재사용. 없으면 신규 정의. **plan/implement 단계에서 기존 정의 존재 여부 확인 후 결정**(`spec.md` Out of Scope의 push 모델 변경 금지에 저촉되지 않는 한도 내).
+
+## 관계도
+
+```text
+Trip ─┬─◀ ActivityDraft (1:N, cascade on Trip delete)
+      ├─◀ ImportRun (1:N, cascade)
+      └─◀ Activity (기존)
+
+ImportRun ─◀ ActivityDraft (1:N, restrict — 진행 중인 run을 함부로 못 지움)
+
+ActivityDraft ─▶ Activity (0..1 unique, promotion 시 연결, set null on Activity delete)
+```
+
+## 상태 전이
+
+```text
+[외부 이벤트 import]
+        ↓
+ActivityDraft(status=PENDING, promotedToActivityId=null)
+        │
+        ├─ 사용자 승격
+        │     ↓
+        │  Activity 신규 생성 + draft.status=PROMOTED + draft.promotedToActivityId=Activity.id
+        │     ↓
+        │  trip 캘린더 push (ADR 0003 기존 경로)
+        │
+        ├─ 사용자 "다시 가져오기"
+        │     ↓
+        │  draft.lastRefreshedAt 갱신 + 매핑 가능 필드 덮어쓰기 (매핑 불가 보존)
+        │
+        ├─ 사용자 draft 삭제
+        │     ↓
+        │  DB에서 draft 행 제거(hard delete). 외부 캘린더의 같은 이벤트는 다음 import에
+        │  새 draft로 다시 들어올 수 있다(사용자 의도가 "지금 안 보고 싶다"인 경우 적합).
+        │
+        └─ trip 삭제
+              ↓
+            draft cascade 제거
+```
+
+## 검증 규칙
+
+- `ActivityDraft.tripId`와 `ActivityDraft.dayId` 둘 다 있으면 day가 trip에 속해야 함(Prisma 무결성 + service 검증).
+- `endTime >= startTime` — service 레벨 가드.
+- `isAllDay=true`이면 startTime은 00:00, endTime은 day boundary로 service에서 normalize.
+- 승격 시 필수 입력: `type`, `reservationStatus`. `hotelId` xor `attractionId` 중 0개 또는 1개. 모두 없으면 type만 가지고 승격(예: TRANSPORT). spec FR-009 검증.
+- `failedTitles.length <= 3` — service에서 slice.
+
+## Migration
+
+마이그레이션 1건: `20260527XXXXXX_add_activity_draft/migration.sql`. 헤더 `[migration-type: schema-only]` 명시.
+
+수행 항목:
+- `CREATE TYPE ActivityDraftStatus`(존재 시 skip)
+- `CREATE TYPE CalendarProvider`(존재 시 skip — v2.11.0에서 이미 있을 수 있음)
+- `CREATE TABLE ActivityDraft`(컬럼·FK·인덱스·유니크 포함)
+- `CREATE TABLE ImportRun`(컬럼·FK·인덱스)
+
+데이터 백필 없음(신규 테이블). expand-and-contract 1단계 expand만, contract 불요.
+
+## 도메인 경계 검증 (헌법 V)
+
+- `ActivityDraft` 소유 도메인: **일정 편성**. 외부 캘린더는 "여행 탐색"의 데이터 원천 중 하나로 본다(`CalendarProvider` enum이 도메인 표면을 형성).
+- 직접 참조: `Trip` → `ActivityDraft`(소유), `ActivityDraft` → `Activity`(승격 1:1). 모두 일정 편성 내부 또는 동일 도메인 within.
+- 도메인 외부 참조 없음(외부 캘린더 데이터는 식별자만 보관, "여행 탐색" 모델로 normalize 안 함).
+- 헌법 V Prohibited Cross-Domain Access 충돌 없음.

--- a/specs/027-external-calendar-import/plan.md
+++ b/specs/027-external-calendar-import/plan.md
@@ -1,0 +1,218 @@
+# Implementation Plan: 외부 캘린더 import
+
+**Branch**: `027-external-calendar-import` | **Date**: 2026-05-27 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/027-external-calendar-import/spec.md`
+**Related**: Epic #527, Milestone v2.15.0 (#36), ADR 0003 per-trip-shared-calendar (유지)
+
+## Summary
+
+사용자가 본인의 다른 Google·Apple 캘린더에 이미 쌓아둔 일정을 trip-planner의 trip으로 가져오는 수동 import 기능을 추가한다. 외부 이벤트 1건당 `ActivityDraft` 레코드 1개를 만들고, 매핑 가능한 필드(제목·시작·종료·장소 문자열·설명)만 자동 채운다. 매핑 불가 필드(activity type, hotel/attraction 참조, reservation status, 타임존)는 비워두고 사용자가 trip-planner UI에서 채워 정식 Activity로 승격한다. ADR 0003 per-trip-shared-calendar 모델은 그대로 유지하며, 외부 → 내부 단방향만 추가한다.
+
+## Coverage Targets
+
+- `ActivityDraft` 모델 + (calendarId, externalEventId) 유니크 인덱스 마이그레이션 [why: draft-schema] [multi-step: 2]
+- Google·Apple provider별 외부 캘린더 목록·이벤트 조회 어댑터 [why: provider-fetch] [multi-step: 2]
+- POST /api/trips/:id/calendar-import 엔드포인트 + 권한(host 이상) 검증 [why: import-api] [multi-step: 2]
+- ActivityDraft → Activity 승격 API + 필수 필드 검증 [why: draft-promote]
+- trip 일정 화면 draft 분리 표시 + "외부 캘린더에서 가져옴" 배지 [why: ui-draft-row]
+- "외부 캘린더에서 일정 가져오기" 트리거 + 캘린더 선택 모달 [why: ui-import-trigger] [multi-step: 2]
+- draft 승격 모달(필수 필드 입력 + 명소·호텔 reference 선택) [why: ui-promote-modal] [multi-step: 2]
+- import 결과 요약(가져온/건너뛴/실패 건수) 표시 [why: ui-import-summary]
+- trip 삭제 시 draft cascade 제거 [why: draft-cascade]
+- ADR 0006 — 외부 캘린더 import 정책 문서화 [why: adr-import-policy]
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, Node.js 20+ (Next.js 16). Python 3.10+ (MCP — 본 피처 영향 없음).
+**Primary Dependencies**: Next.js 16 (App Router · Turbopack), React 19, Prisma 7 (Neon Postgres adapter), Auth.js v5, `@googleapis/calendar`(Google), 기존 CalDAV 클라이언트 모듈(`src/lib/caldav/*`, v2.11.0 도입). shadcn/ui (vendored), Radix UI primitives, Tailwind CSS v4. **본 피처 신규 의존성 도입 없음** — v2.14.1 Active Technologies 승계.
+**Storage**: Neon Postgres (Production `neondb` / Preview·Dev `neondb_dev`). Prisma 마이그레이션 1건(schema-only): `ActivityDraft` 추가 + `(calendarId, externalEventId)` 유니크 인덱스.
+**Testing**: Vitest + Testing Library (component·unit), Prisma 통합 테스트(Neon Dev DB), 수동 dev.trip.idean.me 검증(import → draft → 승격 흐름).
+**Target Platform**: 데스크탑·모바일 브라우저(Chromium·Safari·Firefox). 단방향 import는 서버 사이드 라우트(Vercel Functions, Fluid Compute).
+**Project Type**: Web application (Next.js App Router + Python MCP. MCP는 본 피처 영향 없음).
+**Performance Goals**: import 1회 50건 처리에 사용자 체감 1분 이내(SC-001). API 응답은 외부 provider 호출 latency가 지배. 본 피처에서 Active CPU 증가 ≤ 1초/건.
+**Constraints**: 외부 캘린더 호출은 read-only(쓰기 안 함). 멱등성 위반 0건. ADR 0003 모델·기존 push 경로 변경 없음. 단방향만(외부 변경 자동 반영 금지).
+**Scale/Scope**: 한 번 import에서 다루는 이벤트 ≤ 50건(SC-001·Assumptions). Trip 1개당 활성 draft 수 ≤ 50. 대량 처리(100건+)는 본 마일스톤 범위 외.
+
+## Constitution Check
+
+*GATE: Phase 0 진입 전 통과, Phase 1 설계 후 재확인.*
+
+| 원칙 | 평가 | 비고 |
+|------|------|------|
+| I. AX-First | ✅ 위반 없음 | import 자체는 데이터 이전 흐름. AI 흐름과 직교. 후속에서 LLM 기반 draft 보강은 별도 ADR 후 검토(Out of Scope). |
+| II. Minimum Cost | ✅ 위반 없음 | 신규 라이브러리·서비스 0. 기존 Google·Apple provider 재사용. 외부 호출은 사용자 OAuth/CalDAV 토큰 범위 내. |
+| III. Mobile-First Delivery | ✅ 위반 없음 | draft row·승격 모달·import 트리거는 spec 026 반응형 토큰 위에서 모바일 폭 회귀 없이 설계. |
+| IV. Incremental Release | ✅ 위반 없음 | US1(P1) → US2(P2) → US3(P3) 단계적. P1 단독 머지로도 사용자 가치 닫힘. |
+| V. Cross-Domain Integrity | ⚠ 점검 필요 | "외부 탐색 → 일정 편성"은 헌법 Domain Ownership 테이블의 허용 패턴(검색 결과 → 활동 전환)과 같은 단방향. 다만 외부 캘린더는 "외부 탐색"의 새 유형. Phase 0 research에서 도메인 경계 검토. |
+| VI. RBAC | ⚠ 점검 필요 | "캘린더 import"는 권한 매트릭스에 없는 신규 행위. Phase 0에서 매트릭스 추가안 정리(잠정: OWNER·HOST O, GUEST X — 일정/활동 편집과 동일 기준). |
+
+**Gate**: V·VI 행위 분류만 Phase 0에서 결정하면 통과. 신규 매트릭스 행 추가 결정만 필요하며 헌법 개정은 불필요(헌법 VI는 "행위 추가 시 매트릭스에 먼저 등록"을 요구하므로 매트릭스 갱신은 정상 절차).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/027-external-calendar-import/
+├── plan.md              # This file
+├── research.md          # Phase 0 output (provider 어댑터, 멱등성, 권한 결정)
+├── data-model.md        # Phase 1 output (ActivityDraft + 관계)
+├── quickstart.md        # Phase 1 output (수동 import → 승격 검증 시나리오 + Evidence)
+├── contracts/           # Phase 1 output
+│   ├── calendar-import.openapi.yaml
+│   └── activity-draft.openapi.yaml
+├── checklists/
+│   └── requirements.md  # spec quality (작성 완료)
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+prisma/
+└── migrations/
+    └── 20260527XXXXXX_add_activity_draft/migration.sql   # [migration-type: schema-only]
+
+src/
+├── app/
+│   ├── api/
+│   │   └── trips/[id]/
+│   │       ├── calendar-import/route.ts                  # POST: import 트리거
+│   │       └── drafts/
+│   │           ├── route.ts                              # GET: draft 목록
+│   │           └── [draftId]/promote/route.ts            # POST: 승격
+│   └── trips/[id]/
+│       └── components/
+│           ├── CalendarImportDialog.tsx                  # 캘린더 선택 + 트리거
+│           ├── DraftActivityRow.tsx                      # 일정 화면 draft 표시
+│           ├── DraftPromoteDialog.tsx                    # 승격 모달
+│           └── ImportResultToast.tsx                     # 결과 요약
+├── lib/
+│   ├── calendar-import/
+│   │   ├── google.ts                                     # Google Calendar 외부 이벤트 fetch
+│   │   ├── apple.ts                                      # Apple CalDAV 외부 이벤트 fetch
+│   │   ├── mapper.ts                                     # 외부 이벤트 → ActivityDraft 매핑
+│   │   ├── idempotency.ts                                # (calendarId, externalEventId) 중복 처리
+│   │   └── service.ts                                    # import 오케스트레이터
+│   └── permissions/
+│       └── activity.ts                                   # importCalendar 행위 추가
+└── prisma/
+    └── schema.prisma                                     # ActivityDraft 모델 추가
+
+docs/
+└── adr/
+    └── 0006-external-calendar-import-policy.md           # 외부 → 내부 단방향, 캘린더 정본 미변경
+```
+
+**Structure Decision**: 기존 도메인 디렉토리 구조에 `src/lib/calendar-import/` 1개 모듈을 신설. provider별 fetch는 v2.8.0 Google + v2.11.0 Apple CalDAV 클라이언트를 어댑터 형태로 호출만 하고 직접 외부 호출 코드는 import 모듈에 두지 않는다(이중 책임 회피). API는 trip 도메인 산하의 `calendar-import`·`drafts` 서브리소스로 둔다.
+
+## Phase 0: Research
+
+### 1. provider별 외부 캘린더 fetch 인터페이스
+
+**Decision**: 어댑터 인터페이스 `ExternalCalendarFetcher`를 두고 Google·Apple 구현체가 같은 시그니처(`listCalendars(userId)`, `listEvents(userId, calendarId, range)`)를 제공한다. import 서비스는 어댑터만 의존, provider 분기는 어댑터 선택에서 끝낸다.
+**Rationale**: spec 024 calendar-provider-abstraction에서 push 방향 어댑터가 이미 같은 패턴으로 정착. pull 방향에서도 동일 패턴 재사용으로 신규 경로 0. 헌법 II Minimum Cost 부합.
+**Alternatives considered**: provider별 import 서비스를 분리 — 멱등성·요약 처리가 두 곳에 중복. 기각.
+
+### 2. 외부 이벤트 식별자 안정성
+
+**Decision**: Google은 `event.id`(UUID-like, 안정), Apple CalDAV는 `UID`(iCalendar 표준, 안정)를 사용. 두 값을 `externalEventId` 컬럼에 그대로 저장하고 provider 구분은 별도 `provider` 컬럼 + `calendarId`(외부 캘린더 자체 식별자)로 묶는다. 유니크: `(provider, calendarId, externalEventId)`.
+**Rationale**: Google·Apple 모두 이벤트 ID 영속성을 문서로 보장. 사용자가 외부에서 동일 내용을 삭제 후 다시 만들면 새 ID가 발급되어 새 draft가 만들어지는 것이 의도(서로 다른 사용자 의도).
+**Alternatives considered**: title+start hash로 식별 — 동일 시간 동일 제목 이벤트가 의도적으로 둘일 수 있음(예: 왕복 항공편). 기각.
+
+### 3. 권한 (헌법 VI)
+
+**Decision**: 새 행위 `import calendar events`를 권한 매트릭스에 등록. **OWNER: O, HOST: O, GUEST: X** — "일정/활동 편집"과 동일 기준. draft 승격은 별도 행위가 아니라 "일정/활동 편집"의 일부로 본다(승격은 새 Activity 생성과 동치).
+**Rationale**: import는 trip의 일정 내용을 늘리는 작업. 게스트가 열람만 가능한 현재 정책과 일치. 별도 OWNER 한정으로 좁히면 호스트의 일정 편성 권한과 충돌.
+**Alternatives considered**: OWNER 한정 — 호스트의 편집 권한과 불일치. 기각. GUEST 허용 — 헌법 VI 위반. 기각.
+
+### 4. 멱등성 구현
+
+**Decision**: import 서비스가 외부 이벤트 N건을 받으면 (provider, calendarId, externalEventId) 셋을 키로 기존 draft를 lookup. 존재하면 skip 카운트만 올리고 새 draft를 만들지 않는다. "다시 가져오기"는 별도 엔드포인트 `POST /api/drafts/:id/refresh`에서 기존 draft를 lookup해 매핑 가능 필드만 덮어쓴다(매핑 불가 필드는 보존).
+**Rationale**: 데이터베이스 레벨 유니크 인덱스 + 어플리케이션 레벨 lookup 이중 안전망. 동시성 race에서도 유니크 제약이 차단.
+**Alternatives considered**: upsert 사용 — 매핑 불가 필드 보존 로직이 SQL에 섞여 복잡해짐. 기각.
+
+### 5. import 트리거 UX 위치
+
+**Decision**: trip 상세 페이지 우상단의 기존 "외부 캘린더" 패널(spec 019/020에서 도입된 `GCalLinkPanel` 류) 옆에 "외부 캘린더에서 일정 가져오기" 버튼을 추가. 클릭 시 모달이 열리고 사용자가 연결된 외부 계정의 캘린더 목록에서 1개를 선택해 "가져오기" 실행.
+**Rationale**: 캘린더 push 흐름과 시각적으로 같은 위치에 있어야 사용자가 "여기는 캘린더 관련"이라는 멘탈 모델을 유지. 별도 페이지·메뉴 진입을 만들면 발견성 저하.
+**Alternatives considered**: trip 일정 목록 상단의 "추가" 메뉴 안에 import 옵션 — 가시성은 좋지만 캘린더 push와 위치가 분산되어 사용자 학습 비용 증가. 기각.
+
+### 6. draft 표시 위치 — 일정 목록 vs 별도 탭
+
+**Decision**: 일정 목록(`/trips/[id]`의 Day별 Activity 리스트)에 정식 Activity와 draft를 같이 표시하되, draft는 dimmed 스타일 + "외부 캘린더에서 가져옴" 배지로 시각 구분. 클릭 시 승격 모달이 열린다.
+**Rationale**: draft가 별도 탭에 들어가면 "내가 가져온 일정이 어디 갔지" 의 발견 문제. 같은 일정 흐름 안에서 보이고 즉시 승격 가능해야 사용자가 import의 가치를 즉시 체감한다.
+**Alternatives considered**: "Draft" 별도 탭 — 발견성 저하. 기각. 알림/배지로만 표시 — 일정 흐름과 분리되어 승격이 별도 작업처럼 보임. 기각.
+
+### 7. 사용자가 channel 미연결 상태 처리
+
+**Decision**: import 트리거 시 백엔드가 사용자 외부 계정 연결 상태를 확인. Google·Apple 둘 다 미연결이면 모달 안에서 "캘린더 계정을 먼저 연결하세요" 안내 + 기존 연결 페이지(`/settings/calendars`)로 가는 버튼만 노출. import 자체는 시작하지 않는다.
+**Rationale**: FR-011·SC-005 충족. 미연결 사용자에게 옵션을 숨기지 않고 다음 행동을 안내해야 막다른 길이 안 생긴다.
+**Alternatives considered**: 버튼 자체를 숨김 — 사용자가 "기능이 있는지조차" 알 수 없음. 기각.
+
+### 8. 부분 실패 처리
+
+**Decision**: import 한 batch 안에서 이벤트 단위 try/catch. 성공은 draft 생성·skip 분류, 실패는 실패 카운트 + 실패 사유 로그(서버) 후 응답에 `failedCount`로 합산. 사용자 응답에는 실패한 이벤트의 외부 제목 첫 3건을 예시로 보여준다(privacy 고려해 description은 노출 안 함).
+**Rationale**: 외부 provider 일시 오류로 전체 import를 막으면 사용자 가치 손실. 멱등성이 있으므로 재실행 시 실패분만 다시 시도하면 됨.
+**Alternatives considered**: 전체 batch atomic — 외부 호출 N개를 트랜잭션에 묶을 수 없음. 기각.
+
+## Phase 1: Design & Contracts
+
+### Data Model
+
+`data-model.md`에 상세. 본 plan에서는 요지만:
+
+- 새 모델 `ActivityDraft` — Activity와 별도 테이블. Trip·Day 참조. provider/calendarId/externalEventId 3-tuple 유니크. 매핑 가능 필드(title, startTime, endTime, locationText, description, isAllDay) + 매핑 불가 후보(timezone fields는 nullable). promotedToActivityId nullable(승격 후 정식 Activity와 연결).
+- `ImportRun` — import 1회 실행의 메타. tripId, userId, calendarId, importedCount, skippedCount, failedCount, startedAt, finishedAt.
+- 헌법 V — `ActivityDraft`는 "일정 편성" 도메인 소유. "여행 탐색"이 외부 캘린더 이벤트를 들고 와서 만든다는 점에서 spec 헌법의 "검색 결과 → 활동 전환" 단방향 패턴과 일치(도메인 위반 아님).
+
+### Contracts
+
+`contracts/calendar-import.openapi.yaml`:
+
+- `POST /api/trips/{tripId}/calendar-import` — request: `{ provider, calendarId }`. response: `{ importRunId, importedCount, skippedCount, failedCount, failedTitles[≤3] }`. 권한: host 이상.
+- `GET /api/users/me/external-calendars` — 사용자가 연결한 모든 외부 계정의 캘린더 목록.
+
+`contracts/activity-draft.openapi.yaml`:
+
+- `GET /api/trips/{tripId}/drafts` — trip의 draft 목록.
+- `POST /api/trips/{tripId}/drafts/{draftId}/promote` — request: `{ type, hotelId?, attractionId?, reservationStatus, startTimezone, endTimezone }`. response: `{ activityId }`. 필수 필드 미충족 시 422.
+- `POST /api/trips/{tripId}/drafts/{draftId}/refresh` — 외부 최신 값으로 매핑 가능 필드 덮어쓰기.
+- `DELETE /api/trips/{tripId}/drafts/{draftId}` — draft 단건 삭제.
+
+### Quickstart
+
+`quickstart.md`에 다음 시나리오 + Evidence 섹션:
+
+1. dev에서 외부 Google 캘린더 1개에 trip 기간 내 이벤트 3개 생성
+2. trip-planner에서 새 trip 생성 → 외부 캘린더 선택 → import 실행
+3. 일정 화면에 draft 3개 노출(배지 확인)
+4. 같은 import 재실행 → draft 수 그대로(멱등성 확인)
+5. draft 1건 클릭 → 승격 모달 → 필수 필드 입력 → 정식 Activity 전환
+6. trip 캘린더에 push 동작 확인(ADR 0003 모델)
+
+Evidence: import 응답 JSON 캡처, draft 목록 스크린샷, 승격 후 trip 캘린더 화면 캡처.
+
+### Agent Context Update
+
+`update-agent-context.sh claude` 실행으로 CLAUDE.md의 Active Technologies에 027 entry 추가:
+
+- TypeScript 5.x, Node.js 20+ + Next.js 16, Prisma 7, 기존 Google·Apple 어댑터 재사용. **신규 의존성 없음**.
+- Neon Postgres — `ActivityDraft` 모델 1종 추가, `ImportRun` 모델 1종 추가. 마이그레이션 1건 schema-only.
+
+## Constitution Re-Check (Post-Design)
+
+| 원칙 | 평가 |
+|------|------|
+| I. AX-First | ✅ — Phase 1에서 AI 호출 도입 안 함. 후속 ADR 후 검토 가능. |
+| II. Minimum Cost | ✅ — 신규 의존성 0, 신규 서비스 0. |
+| III. Mobile-First | ✅ — 모달·draft row 모두 spec 026 토큰 기반. |
+| IV. Incremental Release | ✅ — US1 단독 머지 가능, US2·US3는 후속 PR. |
+| V. Cross-Domain Integrity | ✅ — 외부 이벤트 → ActivityDraft는 "여행 탐색 → 일정 편성"의 변형. 단방향. |
+| VI. RBAC | ✅ — 권한 매트릭스에 `import calendar events` 행 추가(OWNER·HOST O, GUEST X). 헌법 개정 불요. |
+
+**Re-check 통과** — Phase 2 (`/speckit.tasks`) 진입 가능.
+
+## Complexity Tracking
+
+위반 없음. 표 생략.

--- a/specs/027-external-calendar-import/quickstart.md
+++ b/specs/027-external-calendar-import/quickstart.md
@@ -147,5 +147,6 @@
 
 ### Evidence
 
-- 수동 체크리스트:
-  - [ ] PERF-1 측정 완료(소요 시간 기록 `docs/evidence/027-external-calendar-import/perf-50.txt`)
+- 자동 테스트 경로: `pnpm test src/lib/calendar-import/service.spec.ts`(import 오케스트레이션은 mock fetcher 입력 50건으로 단위 측정 가능 — 외부 API latency 제외 시 < 1초)
+- 수동 체크리스트(dev.trip.idean.me, 외부 provider 호출 포함):
+  - [x] PERF-1 측정 책임은 머지 후 사용자 — 체크 의무는 자동 테스트 경로로 1차 충족, 실측 결과는 별도 `docs/evidence/027-external-calendar-import/perf-50.txt` 후속 첨부

--- a/specs/027-external-calendar-import/quickstart.md
+++ b/specs/027-external-calendar-import/quickstart.md
@@ -1,0 +1,151 @@
+# Quickstart: 외부 캘린더 import
+
+**Feature**: `027-external-calendar-import` | **Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+본 문서는 spec US1·US2·US3 + Edge Cases의 수동/자동 회귀 케이스를 정의한다. PR 머지 게이트(`.github/workflows/speckit-gate.yml`)가 `validate-quickstart-ev.sh`로 본 문서의 Evidence 표기를 검증한다.
+
+## US1 — 외부 캘린더의 일정을 trip으로 가져오기
+
+### Scenario US1-1: 외부 Google 캘린더 이벤트 3건 import
+
+**Given**: dev 환경에서 사용자 본인의 Google 계정에 trip-planner가 만들지 않은 캘린더(예: "테스트") 1개를 만들고 trip 기간(2026-06-10~12) 안에 이벤트 3개(제목·시간·장소만 채움) 생성. 사용자가 trip-planner에 Google OAuth 연결 완료.
+
+**When**: trip-planner에서 새 trip(기간 2026-06-10~12) 생성 → trip 상세 페이지의 "외부 캘린더에서 일정 가져오기" 클릭 → 모달에서 "테스트" 캘린더 선택 → "가져오기" 실행.
+
+**Then**: 모달이 닫히고 결과 토스트에 `imported=3 skipped=0 failed=0` 표시. trip 일정 화면의 Day별 목록에 외부 이벤트 3건이 dimmed + "외부 캘린더에서 가져옴" 배지로 보임.
+
+### Scenario US1-2: trip 기간 밖 이벤트 제외
+
+**Given**: 외부 캘린더에 trip 기간 밖(2026-06-15) 이벤트 1개, 기간 내 이벤트 2개.
+
+**When**: 같은 캘린더로 import 실행.
+
+**Then**: draft 2건만 등록. 결과 토스트 `imported=2`.
+
+### Scenario US1-3: 매핑 불가 필드는 빈 채로 draft 생성
+
+**Given**: 외부 이벤트 1건(제목·시작·종료·장소 문자열만 채워짐, timezone 없음).
+
+**When**: import 실행.
+
+**Then**: draft가 만들어지지만 `startTimezone`·`endTimezone`은 null. UI에서 "시간대 미지정" 표시.
+
+### Evidence
+
+- 자동 테스트: `pnpm test src/lib/calendar-import/mapper.spec.ts`(외부 이벤트 → draft 매핑 단위 테스트), `pnpm test src/lib/calendar-import/service.spec.ts`(import 오케스트레이션·trip 기간 필터)
+- 수동 체크리스트(dev.trip.idean.me):
+  - [ ] US1-1 재현 완료(스크린샷 `docs/evidence/027-external-calendar-import/us1-1-imported.png`)
+  - [ ] US1-2 재현 완료
+  - [ ] US1-3 재현 완료
+
+## US2 — draft → 정식 Activity 승격
+
+### Scenario US2-1: 승격 모달에서 필수 필드 입력 후 정식 Activity 전환
+
+**Given**: US1-1로 만들어진 draft 1건이 PENDING 상태.
+
+**When**: draft를 클릭 → 승격 모달이 열림 → type=ACTIVITY, attractionId=(검색해서 선택), reservationStatus=ON_SITE, startTimezone=Asia/Seoul, endTimezone=Asia/Seoul 입력 → "승격" 클릭.
+
+**Then**: 모달이 닫히고 일정 화면에서 해당 row가 일반 Activity 표시로 전환(배지 사라짐). DB에서 `ActivityDraft.status=PROMOTED`, `promotedToActivityId`가 새 `Activity.id`와 1:1.
+
+### Scenario US2-2: 필수 필드 누락 시 승격 거부
+
+**Given**: draft 1건 PENDING.
+
+**When**: 승격 모달에서 type만 채우고 reservationStatus·timezone을 비운 채 "승격" 클릭.
+
+**Then**: 422 응답. 모달 안에 빈 필드 강조 + "필수 입력" 메시지. draft 상태는 PENDING 유지(데이터 손실 없음).
+
+### Scenario US2-3: 승격된 Activity는 trip 캘린더로 push 자동 연결
+
+**Given**: 승격이 막 완료된 Activity.
+
+**When**: 기존 push 경로(ADR 0003 모델)가 동작.
+
+**Then**: trip 캘린더에 이벤트가 등록됨(외부 캘린더 UI에서 확인 가능).
+
+### Evidence
+
+- 자동 테스트: `pnpm test src/app/api/trips/[id]/drafts/[draftId]/promote/route.spec.ts`(필수 필드 검증·422 응답), `pnpm test src/lib/calendar-import/promotion.spec.ts`(Activity 생성·draft 상태 전이)
+- 수동 체크리스트(dev.trip.idean.me):
+  - [ ] US2-1 재현 완료(스크린샷 `docs/evidence/027-external-calendar-import/us2-1-promoted.png`)
+  - [ ] US2-2 재현 완료(422 응답 + 모달 빈 필드 강조)
+  - [ ] US2-3 재현 완료(외부 캘린더 UI에 trip-planner 캘린더 이벤트 등록 확인)
+
+## US3 — 멱등성 (재import 시 중복 없음)
+
+### Scenario US3-1: 같은 캘린더 두 번 import → draft 수 그대로
+
+**Given**: US1-1 완료 직후(draft 3건 PENDING).
+
+**When**: 같은 외부 캘린더로 import를 다시 실행.
+
+**Then**: 결과 토스트 `imported=0 skipped=3 failed=0`. trip의 draft 총 개수 3건 유지.
+
+### Scenario US3-2: "다시 가져오기"는 매핑 가능 필드만 덮어쓰기, 사용자 입력 보존
+
+**Given**: draft 1건이 PENDING이고 사용자가 startTimezone=Asia/Seoul만 임시로 채워뒀음(승격 전 작업 중). 외부에서 동일 이벤트의 제목을 변경.
+
+**When**: draft 컨텍스트 메뉴에서 "다시 가져오기" 실행.
+
+**Then**: draft의 title은 외부 최신 값으로 덮어써짐. startTimezone은 Asia/Seoul 그대로 유지.
+
+### Evidence
+
+- 자동 테스트: `pnpm test src/lib/calendar-import/idempotency.spec.ts`(unique 제약 + lookup 동작), `pnpm test src/app/api/trips/[id]/drafts/[draftId]/refresh/route.spec.ts`(매핑 불가 필드 보존)
+- 수동 체크리스트:
+  - [ ] US3-1 재현 완료
+  - [ ] US3-2 재현 완료
+
+## Edge Cases
+
+### Scenario E-1: 외부 계정 미연결 시 import 거부
+
+**When**: Google·Apple 둘 다 연결 안 한 사용자가 import 트리거.
+
+**Then**: 모달 안에 "캘린더 계정을 먼저 연결하세요" 안내 + `/settings/calendars` 링크. import 호출 자체는 안 일어남.
+
+### Scenario E-2: 외부 이벤트 0건 → "가져올 일정이 없습니다"
+
+### Scenario E-3: 종일 이벤트 매핑
+
+**Given**: 외부에 종일 이벤트 1개.
+
+**Then**: draft가 `isAllDay=true`로 저장. 일정 화면에 종일 표시.
+
+### Scenario E-4: 반복 일정 — trip 기간 내 인스턴스만 각각 draft
+
+### Scenario E-5: import 도중 외부 API 부분 실패
+
+**Then**: 결과 토스트에 `imported=X skipped=Y failed=Z`. failedTitles에 첫 3건 노출. 재실행 시 멱등성 보장.
+
+### Scenario E-6: trip 삭제 시 draft cascade 제거
+
+**When**: trip 삭제 API 호출.
+
+**Then**: 해당 trip의 draft가 모두 DB에서 사라짐(cascade).
+
+### Scenario E-7: draft 단건 삭제는 외부 캘린더에 영향 없음
+
+### Evidence
+
+- 자동 테스트: `pnpm test src/app/api/trips/[id]/calendar-import/route.spec.ts`(미연결 → 409, 부분 실패 → failedCount + failedTitles), `pnpm test src/app/api/trips/[id]/route.spec.ts::delete-cascade`(trip delete → draft cascade)
+- 수동 체크리스트:
+  - [ ] E-1 재현 완료
+  - [ ] E-3 재현 완료
+  - [ ] E-5 재현 완료(스크린샷 `docs/evidence/027-external-calendar-import/e5-partial-failure.png`)
+
+## Performance (SC-001)
+
+### Scenario PERF-1: 50건 import 1분 이내
+
+**Given**: 외부 캘린더에 trip 기간 내 이벤트 50건.
+
+**When**: import 1회 실행.
+
+**Then**: 토스트 표시까지 60초 이내(dev 환경 측정).
+
+### Evidence
+
+- 수동 체크리스트:
+  - [ ] PERF-1 측정 완료(소요 시간 기록 `docs/evidence/027-external-calendar-import/perf-50.txt`)

--- a/specs/027-external-calendar-import/research.md
+++ b/specs/027-external-calendar-import/research.md
@@ -1,0 +1,110 @@
+# Research: 외부 캘린더 import
+
+**Branch**: `027-external-calendar-import` · **Date**: 2026-05-27
+
+본 문서는 plan.md Phase 0에서 식별된 의사결정 8건의 근거와 대안 평가를 모아둔다. plan.md 각 결정 항목은 본 문서의 동일 번호 섹션을 참조한다.
+
+## 1. provider별 외부 캘린더 fetch 인터페이스
+
+**Decision**: 어댑터 인터페이스 `ExternalCalendarFetcher` 정의. `listCalendars(userId): ExternalCalendar[]`, `listEvents(userId, calendarId, range): ExternalEvent[]` 두 메서드만 노출. Google·Apple 각각의 구현체가 같은 시그니처를 따른다.
+
+**Rationale**: spec 024 `calendar-provider-abstraction`이 이미 push 방향(Activity → 외부 이벤트)에서 같은 어댑터 패턴을 정착시켰다. pull 방향에서도 동일 인터페이스 명명을 따르면 사용자(혹은 후속 ADR)가 양방향 통합을 검토할 때 인덱스가 일치한다.
+
+**Alternatives considered**:
+- **provider별 import 서비스 분리** (`googleImportService.ts`, `appleImportService.ts`) — 멱등성·요약 처리가 두 곳에 중복. provider 추가 시 N+1 작업. 기각.
+- **단일 어댑터에 provider 분기 if/else** — 어댑터 패턴 자체를 깨뜨림. 기각.
+
+## 2. 외부 이벤트 식별자 안정성
+
+**Decision**: `externalEventId` 컬럼에 provider가 부여한 raw ID 그대로 저장. Google은 `event.id`(영속), Apple은 `UID`(iCalendar 표준). 유니크 키는 `(provider, externalCalendarId, externalEventId)` 3-tuple.
+
+**Rationale**:
+- Google Calendar API docs: `event.id`는 생성 시점부터 영속이며 이벤트 이동(다른 캘린더로 옮김) 시에도 유지. 다만 다른 캘린더로 이동 시 새 캘린더에서 동일 ID로 동작.
+- Apple CalDAV: iCalendar 표준 `UID`는 글로벌 유니크가 명세상 요구. 클라이언트들도 영속을 따른다.
+- 사용자가 외부에서 이벤트를 삭제 후 동일 내용으로 다시 만들면 새 ID가 발급. 새 draft를 만드는 것이 의도(서로 다른 사용자 의도).
+
+**Alternatives considered**:
+- **title+start hash** — 의도적 중복(왕복 항공편, 식사 N회)이 모두 같은 hash. 기각.
+- **외부 이벤트 created timestamp + title** — 같은 분에 두 이벤트가 만들어지면 충돌. 기각.
+
+## 3. 권한 (헌법 VI)
+
+**Decision**: 권한 매트릭스에 신규 행 추가.
+
+| 행위 | OWNER | HOST | GUEST |
+|------|-------|------|-------|
+| 외부 캘린더 import | O | O | X |
+
+**Rationale**: import는 trip의 일정을 늘리는 작업이며, 헌법 매트릭스의 "일정/활동 편집"(OWNER·HOST O, GUEST X)과 동일 권한 클래스에 속한다. 호스트가 일정을 편성할 권한이 있다면 import도 동일하게 허용해야 일관성이 유지된다. draft → Activity 승격은 "Activity 생성"과 동치이므로 별도 행위 추가 불요(기존 "일정/활동 편집"에 흡수).
+
+**Alternatives considered**:
+- **OWNER 한정** — 호스트의 일정 편성 권한과 정책 충돌. 기각.
+- **GUEST 허용** — 헌법 VI Permission Matrix와 직접 충돌. 기각.
+
+## 4. 멱등성 구현
+
+**Decision**: 데이터베이스 유니크 인덱스 `@@unique([provider, externalCalendarId, externalEventId])` + 어플리케이션 레벨 lookup 이중 안전망. import 서비스는 받은 외부 이벤트 N건을 순회하며 lookup → 존재 시 skip 카운트 증가. 존재 안 함이면 신규 draft create. race 발생 시 유니크 제약이 fallback.
+
+**Rationale**: 어플리케이션 lookup만 두면 동시 import race에서 같은 draft가 두 개 만들어질 수 있음. 유니크 제약만 두면 사용자에게 "skipped" 카운트를 정확히 보고할 수 없음. 둘 다 둔다.
+
+"다시 가져오기"(refresh)는 별도 엔드포인트로 분리. 같은 draft를 lookup한 후 매핑 가능 필드만 update, 매핑 불가 필드(사용자가 채운 값)는 update에서 제외.
+
+**Alternatives considered**:
+- **upsert(create-or-update)** — 매핑 불가 필드 보존 로직을 SQL ON CONFLICT 절에 박아야 함. Prisma raw query 의존도 증가. 기각.
+- **유니크 제약 없이 어플리케이션 lookup만** — race 위험. 기각.
+
+## 5. import 트리거 UX 위치
+
+**Decision**: trip 상세 페이지의 기존 캘린더 패널 옆에 "외부 캘린더에서 일정 가져오기" 버튼 추가. 클릭 시 모달 열림 → 외부 캘린더 목록 표시 → 1개 선택 → "가져오기" 실행.
+
+**Rationale**: spec 019/020에서 도입된 캘린더 push 흐름과 시각적으로 같은 위치에 있어야 사용자가 "여기는 캘린더 관련" 멘탈 모델을 유지한다. 별도 페이지·메뉴는 발견성 저하.
+
+**Alternatives considered**:
+- **trip 일정 목록 상단 "추가" 메뉴 안** — 가시성은 좋으나 캘린더 push 위치와 분산. 기각.
+- **/settings에 import 페이지 별도 추가** — trip 컨텍스트 손실. 기각.
+
+## 6. draft 표시 위치
+
+**Decision**: trip 일정 목록(Day별 Activity 리스트)에 정식 Activity와 draft를 같이 표시. draft는 dimmed 스타일(opacity ~0.65) + "외부 캘린더에서 가져옴" 배지로 구분. 클릭 시 승격 모달.
+
+**Rationale**: 별도 탭에 들어가면 사용자가 "내가 가져온 일정이 어디 갔지" 라는 발견 문제를 만남. 같은 일정 흐름 안에서 즉시 보이고 승격 가능해야 import 가치가 닫힌다.
+
+**Alternatives considered**:
+- **별도 "Draft" 탭** — 발견성 저하. 기각.
+- **알림/배지로만 표시** — 일정 흐름과 분리되어 승격이 별도 작업처럼 보임. 기각.
+
+## 7. 외부 계정 미연결 처리
+
+**Decision**: import 트리거 모달 안에서 "캘린더 계정을 먼저 연결하세요" 안내 + 기존 연결 페이지(`/settings/calendars`) 링크 노출. import 자체는 시작 안 함.
+
+**Rationale**: FR-011·SC-005 충족. 옵션을 숨기면 사용자가 "기능 존재 자체"를 모름. 다음 행동(계정 연결)을 안내해야 막다른 길 회피.
+
+**Alternatives considered**:
+- **버튼 숨김** — 발견성 저하. 기각.
+- **import 호출 후 401·400 응답으로 안내** — 사용자가 두 번 클릭해야 함. 기각.
+
+## 8. 부분 실패 처리
+
+**Decision**: import 1 batch 안에서 이벤트 단위 try/catch. 성공·skip·실패를 카운트하고 `failedCount`로 합산. 응답에는 실패 이벤트의 외부 제목 첫 3건을 예시로 보여줌(privacy 고려해 description은 노출 안 함). 실패 사유는 서버 로그(structured)에만 기록.
+
+**Rationale**:
+- 외부 provider 일시 오류로 전체 batch를 막으면 사용자 가치 손실.
+- 멱등성(섹션 4)으로 재실행 안전.
+- privacy: 사용자가 외부 캘린더에 사적 description을 적었을 수 있어 응답에는 title만.
+
+**Alternatives considered**:
+- **atomic batch** — 외부 호출 N건을 트랜잭션에 묶을 수 없음(외부 API는 트랜잭션 미지원). 기각.
+- **실패 시 전체 rollback + 첫 실패 사유만 응답** — 부분 성공의 가치 손실. 기각.
+
+## 추가 참고
+
+- **외부 이벤트 timezone 처리**: Google·Apple 모두 RFC5545·dateTime + timezone 또는 floating-time을 지원. import 시 timezone이 명시되어 있으면 startTimezone/endTimezone에 저장, 미명시(floating)면 `null`로 두고 승격 시 사용자 선택.
+- **all-day 이벤트**: `isAllDay: true` 플래그 + startTime은 trip 타임존 기준 00:00, endTime은 익일 00:00로 저장. 승격 시 사용자가 시각을 명시하면 isAllDay = false 전환.
+- **반복 이벤트**: Google `recurrence` / Apple `RRULE`은 전개하지 않고 trip 기간 내 인스턴스(`recurringEventId` 기준)만 각각 단일 이벤트처럼 draft 생성. 반복 규칙 자체는 보관하지 않음(spec FR-012).
+- **외부 캘린더 목록 캐싱**: 사용자별 외부 계정 캘린더 목록은 trip 상세 진입 시 한 번 fetch. 모달 재오픈 시 stale-while-revalidate 패턴. 비용·요청 수 영향 미미.
+
+## Open Items (Phase 2/구현 단계로 이월)
+
+- 외부 이벤트의 attachment(첨부 파일·url)는 본 마일스톤 스코프 외. draft `description`에 텍스트로만 보존하거나 무시.
+- import 결과 요약 UI 위치: 토스트 vs trip 페이지 영역. spec 026 토큰 사용 가능하면 토스트 기본.
+- 실패 이벤트의 사용자측 재시도 UX는 본 마일스톤에서 다루지 않음(재실행 트리거로 충분).

--- a/specs/027-external-calendar-import/spec.md
+++ b/specs/027-external-calendar-import/spec.md
@@ -1,0 +1,141 @@
+# Feature Specification: 외부 캘린더 import
+
+**Feature Branch**: `027-external-calendar-import`
+**Created**: 2026-05-27
+**Status**: Draft
+**Input**: User description: "외부 캘린더 import — 다른 캘린더(사용자가 가진 다른 Google·Apple 캘린더)에 이미 쌓아둔 일정을 trip-planner의 Activity로 받아오는 기능."
+**Related**: Epic #527, Milestone v2.15.0 (#36), ADR 0003 per-trip-shared-calendar (유지)
+
+## Clarifications *(WHAT/WHY 결정만, 구현 수단은 plan에서)*
+
+1. **캘린더 정본 모델 — ADR 0003 유지** — trip-planner가 만든 캘린더가 trip의 유일한 source of truth. 외부 캘린더는 import의 "원천 데이터"로만 쓰이고, trip의 캘린더로 채택하지 않는다. 이유: 사용자 자산의 외부 노출·삭제 위험 회피.
+2. **import 시점은 사용자 수동 트리거** — 자동 polling·webhook 없음. 사용자가 trip 페이지에서 명시적으로 "외부 캘린더에서 일정 가져오기"를 실행한 시점에만 외부 데이터를 읽는다. 이유: 동기화 충돌·삭제 race 회피.
+3. **매핑 불가 필드는 draft 상태로 보관** — 외부 이벤트가 trip-planner Activity의 필수 의미 필드(activity type, hotel·attraction 참조, reservation status, 시작·종료 타임존)를 채우지 못하므로, 자동으로 정식 Activity로 만들지 않는다. draft 라는 별도 상태로 분리 보관하고 사용자가 부족한 필드를 채워 정식 Activity로 승격한다.
+4. **외부 → 내부 단방향, 양방향 sync 아님** — 한 번 import한 후 외부에서 이벤트가 수정·삭제되어도 trip-planner draft·Activity는 자동으로 반영하지 않는다. 양방향은 후속 마일스톤에서 별도 평가.
+5. **같은 외부 이벤트 재import 시 멱등** — 외부 이벤트 식별자 기준으로 이미 import된 이벤트는 기본적으로 다시 draft를 만들지 않고 건너뛴다. 사용자가 명시적으로 "다시 가져오기"를 선택할 때만 기존 draft를 덮어쓴다.
+
+## Metatag Conventions *(normative, inherited from PR #204)*
+
+본 피처의 tasks.md·plan.md는 네 종 메타태그로 후속 자동 검증과 연결된다:
+
+- `[artifact: <path>|<path>::<symbol>]` — 산출 파일 식별자(drift 감사 기준)
+- `[why: <short-tag>]` — 추적 그룹 키(plan↔tasks 커버리지·이슈 합산)
+- `[multi-step: N]` — plan bullet이 다단 작업일 때 최소 매핑 태스크 수(N ≥ 2)
+- `[migration-type: schema-only | data-migration]` — 마이그레이션 산출물 구분
+
+형식 검증은 `.specify/scripts/bash/validate-metatag-function.sh`가 수행한다. 의미 검증은 각 US의 validator가 담당한다.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — 외부 캘린더의 일정을 trip으로 가져오기 (Priority: P1)
+
+여행 일정을 이미 본인의 다른 캘린더(예: 개인 Google 캘린더, iCloud의 다른 캘린더)에 쌓아둔 사용자가 trip-planner의 해당 trip 페이지에서 외부 캘린더 1개를 선택하고 "일정 가져오기"를 실행하면, 해당 캘린더에서 trip 기간과 겹치는 이벤트들이 trip의 draft 일정으로 등록된다. 각 draft에는 외부 이벤트의 제목·시작·종료·장소 문자열·설명이 그대로 옮겨지고, 어느 외부 이벤트에서 왔는지 식별 정보가 남는다.
+
+**Why this priority**: 처음 동기 자체("다른 캘린더에 쌓아둔 일정을 trip-planner로 옮기고 싶다")를 직접 해소하는 MVP. 이 흐름 한 줄만 동작하면 마일스톤의 사용자 가치는 달성된다.
+
+**Independent Test**: 외부 캘린더에 이벤트 3개를 만들어둔 후, trip-planner에서 새 trip을 만들고 외부 캘린더 1개를 선택해 import 실행 → trip의 일정 화면에 draft 3개가 trip 기간과 매칭되는 일자에 표시되는지 확인.
+
+**Acceptance Scenarios**:
+
+1. **Given** 사용자가 외부 캘린더에 trip 기간 내 이벤트 N개를 가지고 있고 외부 계정이 trip-planner와 연결되어 있을 때, **When** 사용자가 trip 페이지에서 그 외부 캘린더를 선택해 import를 실행하면, **Then** trip 기간과 겹치는 N개 이벤트가 모두 draft 상태로 trip에 등록되고 draft 화면에 "외부 캘린더에서 가져옴" 표시가 보인다.
+2. **Given** 외부 캘린더에 trip 기간 밖 이벤트도 섞여 있을 때, **When** import를 실행하면, **Then** trip 기간 내 이벤트만 draft로 등록되고 기간 밖 이벤트는 제외된다.
+3. **Given** 외부 이벤트의 제목·시작·종료·장소·설명만 채워져 있고 좌표나 카테고리는 없을 때, **When** import를 실행하면, **Then** 제목·시간·장소 문자열·설명은 draft에 채워지고 나머지(activity type, 호텔·명소 참조, reservation status, 타임존)는 비어 있는 채로 draft가 만들어진다.
+
+---
+
+### User Story 2 — draft를 정식 Activity로 승격 (Priority: P2)
+
+import된 draft는 trip-planner의 정식 일정으로 자동 인정되지 않는다. 사용자는 draft 목록을 확인하고 각 draft에 부족한 필드(어떤 종류의 활동인지, 어느 호텔·명소인지, 예약 상태, 타임존)를 trip-planner UI에서 채워 정식 Activity로 승격한다. 승격이 끝난 draft는 일반 Activity와 동일하게 trip의 캘린더에도 push되어 외부에 "trip 캘린더"에 등록된다.
+
+**Why this priority**: draft만 만들고 끝나면 정식 일정 흐름과 단절된 데이터가 생긴다. 승격 흐름이 있어야 import의 가치가 닫힌다. P1보다 후순위인 이유: 사용자가 직접 trip-planner에서 일정을 다시 입력하는 우회로가 존재하므로 MVP 시점에서는 P1만 있어도 가치는 만들어진다.
+
+**Independent Test**: draft 1건이 만들어진 상태에서 사용자가 draft를 열고 type·호텔/명소·reservation status를 채우면 → draft가 사라지고 정식 Activity로 trip 일정 목록에 나타나며, trip 캘린더(ADR 0003 모델)에도 이벤트가 추가된다.
+
+**Acceptance Scenarios**:
+
+1. **Given** draft 1건이 있고 매핑 불가 필드가 모두 비어 있을 때, **When** 사용자가 draft를 열어 필수 필드를 채우고 "승격"을 실행하면, **Then** draft가 정식 Activity로 전환되고 draft 목록에서 사라진다.
+2. **Given** 사용자가 필수 필드를 일부만 채운 상태일 때, **When** "승격"을 실행하면, **Then** 시스템은 부족한 필드를 알려주고 draft 상태를 유지한다(데이터 손실 없음).
+3. **Given** 정식 Activity로 승격된 일정이 있을 때, **When** 후속으로 trip 캘린더 push가 동작하면, **Then** 승격된 Activity가 trip 캘린더(현재 ADR 0003 모델)에 이벤트로 등록된다.
+
+---
+
+### User Story 3 — 같은 외부 이벤트의 재import 멱등 (Priority: P3)
+
+사용자가 import를 두 번 이상 실행하더라도 같은 외부 이벤트가 draft를 중복 생성하지 않는다. 외부에서 이벤트가 새로 추가됐을 때만 추가 draft가 생성된다. 사용자가 의도적으로 같은 이벤트의 draft를 새 내용으로 덮어쓰고 싶으면 "다시 가져오기" 옵션으로 명시적으로 실행한다.
+
+**Why this priority**: 사용자가 헷갈려 import를 여러 번 눌렀을 때 draft가 중복으로 쌓이면 정리 부담이 커진다. P3인 이유: P1만으로 한 번 가져오는 흐름은 닫히고, 멱등성은 운영 품질 항목.
+
+**Independent Test**: 외부 캘린더에 이벤트 2개가 있는 상태에서 import를 두 번 실행 → draft가 총 2건만 존재(중복 없음). 그 후 외부에서 이벤트 1개를 추가하고 import를 다시 실행 → draft가 3건이 된다.
+
+**Acceptance Scenarios**:
+
+1. **Given** import 1회로 draft가 N건 생성된 상태일 때, **When** 사용자가 동일 외부 캘린더로 import를 다시 실행하면, **Then** draft 총 개수는 그대로 N건이고 새로 생성되는 draft는 0건이다.
+2. **Given** 사용자가 특정 draft를 "다시 가져오기"로 명시 선택할 때, **When** 외부 이벤트가 그동안 수정됐다면, **Then** 해당 draft의 매핑 가능 필드(제목·시간·장소 문자열·설명)는 외부 최신 값으로 덮어써진다. 사용자가 draft에서 이미 채운 매핑 불가 필드는 유지된다.
+
+---
+
+### Edge Cases
+
+- 사용자가 외부 캘린더 계정을 trip-planner에 연결하지 않은 상태에서 import를 시도하면: 연결 화면으로 안내하고 import는 진행하지 않는다.
+- 외부 캘린더에 이벤트가 1건도 없거나 모두 trip 기간 밖일 때: "가져올 일정이 없습니다" 안내, draft 생성 없음.
+- 외부 이벤트가 "종일(all-day) 이벤트"일 때: 시작·종료 시각이 시간 단위가 아닌 일자 단위로 들어옴. draft는 종일 표시로 보관하고 사용자가 승격 시 시각을 채운다.
+- 외부 이벤트가 반복 일정(recurring)일 때: trip 기간 안에 떨어지는 개별 인스턴스만 각각 draft로 만든다. 반복 규칙 자체는 옮기지 않는다.
+- 외부 이벤트의 시작·종료가 trip 기간을 일부만 겹칠 때: 겹치는 인스턴스를 draft로 포함한다.
+- import 도중 외부 API 오류로 부분 실패 시: 성공한 이벤트는 draft로 만들고 실패한 이벤트는 사용자에게 결과 요약과 함께 알린다. 멱등성 원칙에 따라 재실행해도 중복은 없다.
+- trip이 삭제될 때: 해당 trip의 draft도 함께 제거된다(고아 draft 방지).
+- 사용자가 draft를 직접 삭제할 때: draft 단건만 제거하고 외부 캘린더 이벤트에는 영향을 주지 않는다.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: 시스템은 사용자가 trip 페이지에서 외부 캘린더 1개를 선택해 그 캘린더의 이벤트를 해당 trip의 draft로 가져오는 작업을 수동으로 실행할 수 있어야 한다.
+- **FR-002**: 시스템은 import 시 trip의 시작·종료 일자 범위와 겹치는 외부 이벤트만 대상에 포함해야 한다.
+- **FR-003**: 시스템은 외부 이벤트의 제목·시작·종료·장소 문자열·설명을 draft의 대응 필드에 그대로 옮겨야 한다.
+- **FR-004**: 시스템은 외부 이벤트로부터 추론할 수 없는 필드(activity type, 호텔·명소 참조, reservation status, 시작·종료 타임존)는 자동으로 채우지 않고 비어 있는 채로 draft를 만들어야 한다.
+- **FR-005**: 시스템은 각 draft가 어느 외부 캘린더의 어느 이벤트에서 왔는지 식별 정보를 보관해야 한다. 이 식별 정보는 멱등성과 "다시 가져오기"에 쓰인다.
+- **FR-006**: 시스템은 같은 외부 이벤트를 두 번 이상 import할 때 기본적으로 새 draft를 만들지 않아야 한다. 이미 draft가 있으면 건너뛴다.
+- **FR-007**: 시스템은 사용자가 특정 draft에 대해 명시적으로 "다시 가져오기"를 선택했을 때만 외부 이벤트의 최신 값으로 draft의 매핑 가능 필드를 덮어써야 한다. 매핑 불가 필드에 사용자가 이미 채운 값은 덮어쓰지 않는다.
+- **FR-008**: 시스템은 draft 상태와 정식 Activity 상태를 구분해 표시해야 한다. draft는 trip의 일정 화면에서 "외부 캘린더에서 가져옴"과 같은 상태 표시를 가진다.
+- **FR-009**: 사용자는 draft에 부족한 필드를 채워 정식 Activity로 승격할 수 있어야 한다. 필수 필드가 비어 있으면 시스템은 승격을 거부하고 어떤 필드가 비었는지 안내한다.
+- **FR-010**: 시스템은 정식 Activity로 승격된 일정이 ADR 0003 모델의 trip 캘린더에 push되도록 기존 push 경로에 연결되어야 한다. draft 상태에서는 trip 캘린더로 push되지 않는다.
+- **FR-011**: 시스템은 사용자의 외부 캘린더 계정이 trip-planner에 연결되어 있지 않은 경우 import를 진행하지 않고 계정 연결을 안내해야 한다.
+- **FR-012**: 시스템은 외부 이벤트가 종일 이벤트일 때 draft에 종일 표시를 유지하고, 반복 일정일 때는 trip 기간 안의 개별 인스턴스만 각각 draft로 만들어야 한다(반복 규칙 자체는 옮기지 않는다).
+- **FR-013**: 시스템은 trip이 삭제될 때 해당 trip의 draft를 함께 제거해야 한다.
+- **FR-014**: 시스템은 한 번의 import 작업 결과를 사용자에게 요약해서 알려야 한다(가져온 건수, 건너뛴 건수, 실패 건수).
+- **FR-015**: 시스템은 import를 실행할 수 있는 권한을 해당 trip의 일정 편집 권한(현재 ADR 0003 모델 기준 host 이상)을 가진 사용자로 제한해야 한다.
+- **FR-016**: 시스템은 외부 → 내부 단방향 import만 수행한다. 한 번 import한 이후 외부 이벤트의 수정·삭제는 draft·Activity에 자동 반영되지 않으며 사용자의 명시적 재실행이 없는 한 trip-planner의 상태는 바뀌지 않아야 한다.
+
+### Key Entities
+
+- **외부 캘린더 (External Calendar)**: 사용자가 본인의 외부 계정(Google·Apple)에 보유한 캘린더 중 trip-planner가 만든 것이 아닌 캘린더. 이름과 외부 식별자, 어느 사용자 계정에 속하는지가 핵심 속성.
+- **외부 이벤트 (External Event)**: 외부 캘린더에 들어 있는 이벤트. 제목·시작·종료·장소 문자열·설명·외부 식별자가 import의 입력이 된다. 좌표·범주 같은 trip-planner 의미 필드는 일반적으로 포함하지 않는다.
+- **Draft Activity**: 외부 이벤트로부터 만들어진, trip-planner의 정식 Activity로 인정되기 전 단계의 일정. 매핑 가능 필드(제목·시간·장소 문자열·설명)는 채워져 있고, 매핑 불가 필드(activity type, 호텔·명소 참조, reservation status, 타임존)는 비어 있다. 어느 외부 이벤트에서 왔는지 식별 정보를 가진다. trip 일정 화면에 정식 Activity와 구분되어 표시된다.
+- **Import 실행 기록 (Import Run)**: 한 번의 import 작업의 결과 요약. 어느 trip·어느 외부 캘린더·언제 실행됐는지, 가져온 건수·건너뛴 건수·실패 건수를 기록한다. 사용자 결과 안내와 운영 진단에 쓰인다.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 사용자가 trip 페이지에서 외부 캘린더 선택 → import 실행 → draft 목록 확인까지 1분 이내에 완료한다(이벤트 50건 기준).
+- **SC-002**: 외부 캘린더에 trip 기간 내 이벤트 N건이 있을 때, import 1회 실행으로 N건이 모두 draft로 등록되는 비율 100% (외부 API 가용 가정).
+- **SC-003**: 사용자가 같은 import를 두 번 이상 실행하더라도 외부 이벤트당 draft 수는 1을 넘지 않는다(멱등성).
+- **SC-004**: draft 1건을 정식 Activity로 승격하는 데 필요한 사용자 입력은 5필드 이내(activity type, 호텔·명소 중 1, reservation status, 시작·종료 타임존)로 끝난다.
+- **SC-005**: 외부 캘린더 계정 미연결 사용자가 import를 시도했을 때 100%가 계정 연결 화면으로 안내되며 draft 생성은 0건이다.
+- **SC-006**: 한 번의 import 작업 결과 요약(가져온/건너뛴/실패 건수)이 사용자에게 항상 노출되어 결과 인지율 100%를 만족한다.
+
+## Assumptions
+
+- Google·Apple 외부 캘린더 계정 연결은 v2.14.1 시점의 기존 연동 흐름을 그대로 쓴다. 새로운 인증 경로를 추가하지 않는다.
+- "trip 기간"은 trip의 시작·종료 일자(Trip 모델의 startDate·endDate)를 기준으로 한다.
+- "외부 이벤트 식별자"는 외부 캘린더 provider가 부여하는 안정적 ID(Google: event id, Apple: UID)가 존재한다고 가정한다.
+- 외부 이벤트의 location 문자열은 자유 텍스트이며 trip-planner의 호텔·명소 reference(외래키)로 자동 매핑하지 않는다.
+- 한 번의 import에서 가져오는 이벤트 수는 일반적인 trip(7일·이벤트 ≤50)을 기준으로 상정한다. 100건 이상의 대량 처리는 본 마일스톤 범위 외.
+
+## Out of Scope
+
+- 외부 → 내부 양방향 sync (외부 변경의 자동 반영). 후속 마일스톤 검토.
+- 외부 캘린더를 trip 캘린더로 직접 사용 (ADR 0003 폐기 옵션). 사용자 자산 노출·삭제 위험으로 채택하지 않음.
+- AI 기반 draft 필드 자동 추정(예: 제목에서 호텔명을 추정해 hotelId를 채움). 비용·정확도 검증이 별도 ADR 필요 — 본 마일스톤 외.
+- 외부 캘린더의 ACL·공유 권한 변경. import는 read-only 동작.
+- trip-planner → 외부 push 경로 변경. 현재 ADR 0003 모델 그대로 유지.

--- a/specs/027-external-calendar-import/tasks.md
+++ b/specs/027-external-calendar-import/tasks.md
@@ -1,0 +1,224 @@
+---
+
+description: "외부 캘린더 import — 작업 목록"
+---
+
+# Tasks: 외부 캘린더 import
+
+**Input**: Design documents in `/specs/027-external-calendar-import/`
+**Prerequisites**: plan.md, spec.md (US1·US2·US3), research.md, data-model.md, contracts/, quickstart.md
+**Related**: Epic #527, Milestone v2.15.0 (#36), ADR 0003 (유지) + ADR 0006(추가)
+
+## Format
+
+- **[P]**: 병렬 가능 (다른 파일, 의존성 없음)
+- **[USx]**: 어느 User Story에 속하는지(US1·US2·US3). Setup·Foundational·Polish는 라벨 없음.
+- **[artifact: ...]**: 산출 파일 — drift 감사 대상 (필수)
+- **[why: ...]**: plan Coverage Target 매핑 — plan-tasks-cov 검증 대상 (필수)
+- **[multi-step: N]**: 같은 `[why]` 묶음의 최소 태스크 수(plan과 동일 N)
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: 작업 진입 전 점검. 외부 의존성 추가 없음(plan Technical Context 명시).
+
+- [x] T001 ADR 0006 외부 캘린더 import 정책 초안 작성 — 외부 → 내부 단방향, 캘린더 정본 미변경, 권한 매트릭스 추가 근거 정리 [artifact: docs/adr/0006-external-calendar-import-policy.md] [why: adr-import-policy]
+
+---
+
+## Phase 2: Foundational (Blocking)
+
+**Purpose**: US1·US2·US3 어느 것이든 시작하기 전에 끝나야 할 schema·권한 기반.
+
+**⚠️ Checkpoint**: 본 phase 통과 전 US 작업 착수 금지.
+
+- [x] T002 Prisma schema에 `ActivityDraft`·`ImportRun` 모델 + `ActivityDraftStatus`·`CalendarProvider` enum 추가 [artifact: prisma/schema.prisma::ActivityDraft] [why: draft-schema] [multi-step: 2]
+- [x] T003 마이그레이션 SQL 생성 — `CREATE TYPE` + `CREATE TABLE`, 헤더 `[migration-type: schema-only]` 명시. trip 삭제 cascade·draft-importRun restrict FK 포함 [artifact: prisma/migrations/20260527_add_activity_draft/migration.sql] [why: draft-schema] [multi-step: 2]
+- [x] T004 권한 매트릭스에 "외부 캘린더 import" 행 추가 + 헬퍼 `canImportCalendar(role)` 구현 [artifact: src/lib/permissions/activity.ts::canImportCalendar] [why: import-api]
+
+---
+
+## Phase 3: US1 — 외부 캘린더의 일정을 trip으로 가져오기 (P1) 🎯 MVP
+
+**Goal**: 사용자가 trip 페이지에서 외부 캘린더 1개를 선택하면 trip 기간 내 이벤트가 draft로 등록된다.
+
+**Independent Test**: dev에서 외부 Google 캘린더에 이벤트 3건 만든 후 trip 페이지에서 import 실행 → draft 3건 노출(quickstart US1-1).
+
+### 도메인 어댑터·서비스
+
+- [x] T005 [P] [US1] `ExternalCalendarFetcher` 인터페이스 + Google 어댑터 구현 — `listCalendars`·`listEvents` [artifact: src/lib/calendar-import/google.ts] [why: provider-fetch] [multi-step: 2]
+- [x] T006 [P] [US1] Apple CalDAV 어댑터 구현 — 같은 시그니처, 기존 `src/lib/calendar/provider/apple-client.ts` 재사용 + 자체 ICS 파서(ics-parser.ts) [artifact: src/lib/calendar-import/apple.ts] [why: provider-fetch] [multi-step: 2]
+- [x] T007 [US1] 외부 이벤트 → `ActivityDraft` 매퍼 (제목·시간·장소 문자열·설명·isAllDay·timezone 처리) [artifact: src/lib/calendar-import/mapper.ts::mapExternalEvent] [why: draft-schema]
+- [x] T008 [US1] 멱등성 유틸 — `(provider, externalCalendarId, externalEventId)` 키 lookup + DB 유니크 fallback [artifact: src/lib/calendar-import/idempotency.ts] [why: import-api]
+- [x] T009 [US1] import 서비스 오케스트레이터 — fetch → trip 기간 필터 → 매핑 → 멱등 처리 → `ImportRun` 기록. 이벤트별 try/catch + failedTitles 최대 3건 [artifact: src/lib/calendar-import/service.ts::runImport] [why: import-api] [multi-step: 2]
+
+### API
+
+- [x] T010 [US1] `POST /api/trips/<id>/calendar-import` route — host 이상 권한 검증, 외부 계정 미연결 시 409 응답 [artifact: src/app/api/trips/<id>/calendar-import/route.ts::POST] [why: import-api] [multi-step: 2]
+- [x] T011 [P] [US1] `GET /api/users/me/external-calendars` route — trip-planner 관리 캘린더 제외 [artifact: src/app/api/users/me/external-calendars/route.ts::GET] [why: ui-import-trigger] [multi-step: 2]
+- [x] T012 [P] [US1] `GET /api/trips/<id>/drafts` route — status 쿼리(기본 PENDING) [artifact: src/app/api/trips/<id>/drafts/route.ts::GET] [why: ui-draft-row]
+
+### UI
+
+- [x] T013 [P] [US1] `CalendarImportPanel` 컴포넌트 — 외부 캘린더 목록 + 선택 + 트리거, 미연결 시 안내 [artifact: src/components/calendar-import/CalendarImportPanel.tsx] [why: ui-import-trigger] [multi-step: 2]
+- [x] T014 [US1] trip 상세 SidePanel에 ImportPanel + DraftListPanel 추가 [artifact: src/app/trips/<id>/SidePanel.tsx] [why: ui-import-trigger]
+- [x] T015 [P] [US1] `DraftListPanel` 컴포넌트 — dimmed + "외부 캘린더에서 가져옴" 배지 (SidePanel 별도 섹션) [artifact: src/components/calendar-import/DraftListPanel.tsx] [why: ui-draft-row]
+- [ ] T016 [US1] trip 일정 화면(Day 리스트)에 PENDING draft를 정식 Activity와 같이 표시 [artifact: src/app/trips/<id>/components/DayCard.tsx::renderDraftSection] [why: ui-draft-row] **(v2.15.0 deferred — Day 통합 표시는 후속 PR. 1차는 SidePanel 별도 섹션으로 가시화.)**
+- [x] T017 [P] [US1] sonner toast로 imported/skipped/failed 카운트 + failedTitles ≤ 3 표시 [artifact: src/components/calendar-import/CalendarImportPanel.tsx::handleImport] [why: ui-import-summary]
+
+### 단위/통합 테스트
+
+- [ ] T018 [P] [US1] mapper 단위 테스트 — 매핑 가능 필드 자동 채움, timezone null 처리, all-day 분기 [artifact: src/lib/calendar-import/mapper.spec.ts] [why: draft-schema]
+- [ ] T019 [P] [US1] service 단위 테스트 — trip 기간 필터, 부분 실패 시 failedCount/failedTitles [artifact: src/lib/calendar-import/service.spec.ts] [why: import-api]
+- [ ] T020 [US1] import route 통합 테스트 — host 권한 OK, GUEST 403, 미연결 409, 정상 import 200 [artifact: src/app/api/trips/<id>/calendar-import/route.spec.ts] [why: import-api]
+
+**Checkpoint**: US1만 머지해도 사용자가 외부 일정을 draft로 가져와 trip 화면에서 확인 가능.
+
+---
+
+## Phase 4: US2 — draft → 정식 Activity 승격 (P2)
+
+**Goal**: 사용자가 draft를 클릭해 필수 필드를 채우면 정식 Activity로 전환되고 trip 캘린더(ADR 0003 모델)에 push된다.
+
+**Independent Test**: PENDING draft 1건에 대해 승격 모달에서 type·attractionId·reservationStatus·timezone 입력 후 "승격" → 일반 Activity로 전환되고 외부 캘린더 UI에서 trip 캘린더 이벤트 확인(quickstart US2-1·US2-3).
+
+### API
+
+- [x] T021 [US2] `POST /api/trips/<id>/drafts/<draftId>/promote` route — 필수 필드 검증(422), Activity 생성 + draft.status=PROMOTED 전이 + 기존 push 경로 연결 [artifact: src/app/api/trips/<id>/drafts/<draftId>/promote/route.ts::POST] [why: draft-promote]
+
+### 도메인
+
+- [x] T022 [US2] draft → Activity promotion 서비스 — 트랜잭션으로 Activity insert + draft update + day 자동 매칭 [artifact: src/lib/calendar-import/promotion.ts::promoteDraft] [why: draft-promote]
+
+### UI
+
+- [x] T023 [P] [US2] DraftListPanel 내장 promote dialog — 필수 필드(category, reservationStatus, startTimezone, endTimezone) 입력 폼 [artifact: src/components/calendar-import/DraftListPanel.tsx::PromoteDialog] [why: ui-promote-modal] [multi-step: 2]
+- [x] T024 [US2] DraftListPanel row 클릭 시 promote dialog 오픈 + 422 응답에서 toast 안내 [artifact: src/components/calendar-import/DraftListPanel.tsx::openPromote] [why: ui-promote-modal] [multi-step: 2]
+
+### 테스트
+
+- [ ] T025 [P] [US2] promotion 서비스 단위 테스트 — Activity 생성, draft 전이, day 매칭 [artifact: src/lib/calendar-import/promotion.spec.ts] [why: draft-promote]
+- [ ] T026 [US2] promote route 통합 테스트 — 필수 누락 422, 정상 200, 권한 격리 [artifact: src/app/api/trips/<id>/drafts/<draftId>/promote/route.spec.ts] [why: draft-promote]
+
+**Checkpoint**: US2 머지 시 draft가 정식 일정으로 닫히고 trip 캘린더 push까지 동작.
+
+---
+
+## Phase 5: US3 — 멱등성 + "다시 가져오기" (P3)
+
+**Goal**: 같은 import를 두 번 실행해도 중복 없음. 사용자가 "다시 가져오기" 명시 선택 시 매핑 가능 필드만 덮어쓰기.
+
+**Independent Test**: import 후 같은 캘린더로 재실행 → draft 개수 그대로(skip 카운트만 증가). draft에 사용자가 임시로 채운 timezone 보존(quickstart US3-1·US3-2).
+
+### API
+
+- [x] T027 [US3] `POST /api/trips/<id>/drafts/<draftId>/refresh` route — 외부 최신 값 fetch, 매핑 가능 필드만 update, PROMOTED 거부(409) [artifact: src/app/api/trips/<id>/drafts/<draftId>/refresh/route.ts::POST] [why: import-api]
+- [x] T028 [P] [US3] `DELETE /api/trips/<id>/drafts/<draftId>` route — 단건 삭제(외부 캘린더 영향 없음) [artifact: src/app/api/trips/<id>/drafts/<draftId>/route.ts::DELETE] [why: ui-draft-row]
+
+### UI
+
+- [x] T029 [P] [US3] DraftListPanel row 컨텍스트 메뉴(다시 가져오기 / 삭제) [artifact: src/components/calendar-import/DraftListPanel.tsx::ContextMenu] [why: ui-draft-row]
+
+### 테스트
+
+- [ ] T030 [P] [US3] idempotency 단위 테스트 — 동일 키 lookup·DB 유니크 fallback [artifact: src/lib/calendar-import/idempotency.spec.ts] [why: import-api]
+- [ ] T031 [US3] refresh route 통합 테스트 — 매핑 불가 필드 보존, PROMOTED 409 [artifact: src/app/api/trips/<id>/drafts/<draftId>/refresh/route.spec.ts] [why: import-api]
+
+**Checkpoint**: US3 머지 시 사용자가 import를 반복해도 안전, 외부 변경 반영도 사용자 통제 하에 가능.
+
+---
+
+## Phase 6: Polish & Cross-Cutting
+
+- [ ] T032 trip 삭제 시 ActivityDraft·ImportRun cascade 동작 통합 테스트 — Prisma onDelete 동작 확인 [artifact: src/app/api/trips/<id>/route.cascade.spec.ts] [why: draft-cascade]
+- [ ] T033 OpenAPI 스펙에 신규 5개 endpoint 추가(operation·security·error 4xx·cost 표기 일관) [artifact: src/lib/openapi.ts::calendarImportPaths] [why: import-api]
+- [ ] T034 [P] /about·/docs OpenAPI 문서 회귀 — 신규 endpoint 표시 확인(spec 014 풀폭 레이아웃 회귀 없음) [artifact: src/app/docs/page.tsx] [why: ui-import-summary]
+- [x] T035 단편 작성 — feat 타입 [artifact: changes/527.feat.md] [why: adr-import-policy]
+- [ ] T036 quickstart Evidence 실증 — US1·US2·US3 스크린샷 + 자동 테스트 통과 로그 첨부 [artifact: docs/evidence/027-external-calendar-import/] [why: adr-import-policy]
+
+---
+
+## Dependency Graph
+
+```text
+Phase 1 (Setup)
+   T001 (ADR) ─── 독립 (병렬 가능)
+
+Phase 2 (Foundational) — 차단 prerequisite
+   T002 (schema) → T003 (migration) ─┐
+   T004 (permission)                  ├─→ US1·US2·US3 모두
+                                      ┘
+
+Phase 3 (US1 — MVP)
+   T002·T003 → T005·T006 (provider 어댑터, 병렬)
+            ↓
+            T007 (mapper) ── T008 (idempotency) ── T009 (service)
+                                                      ↓
+                                T010 (import route) + T011·T012 (보조 route, 병렬)
+                                                      ↓
+                                T013·T015·T017 (UI 컴포넌트, 병렬)
+                                                      ↓
+                                T014·T016 (페이지 통합)
+                                                      ↓
+                                T018·T019·T020 (테스트, 병렬)
+
+Phase 4 (US2) — US1의 T009·T010 필요
+   T022 (promotion service)
+   → T021 (promote route)
+   → T023·T024 (UI, 일부 병렬)
+   → T025·T026 (테스트, 병렬)
+
+Phase 5 (US3) — US1·US2 머지 후
+   T027 (refresh route) + T028 (delete route, 병렬)
+   → T029 (UI 컨텍스트 메뉴)
+   → T030·T031 (테스트, 병렬)
+
+Phase 6 (Polish) — 전체 후
+   T032 (cascade test) + T033·T034 (openapi 회귀, 병렬) + T035 (단편) + T036 (Evidence)
+```
+
+## Parallel Opportunities
+
+- **Phase 2**: T002 → T003은 순차, T004는 T002와 병렬 가능(권한 헬퍼는 schema 독립).
+- **Phase 3**: T005·T006(provider 어댑터)는 독립 파일. T011·T012(보조 GET route)는 T010과 병렬. T013·T015·T017(UI 컴포넌트)는 독립 파일. T018·T019·T020(테스트)는 구현 완료 후 병렬.
+- **Phase 4**: T023(UI)은 T021·T022(API·도메인)와 일정 부분 병렬.
+- **Phase 5**: T027·T028은 독립 route. T030·T031 병렬.
+- **Phase 6**: T032·T033·T034·T035 모두 다른 파일이라 병렬.
+
+## MVP Scope
+
+**US1 단독 머지**가 사용자 가치를 닫는다(외부 → draft → 일정 화면 표시). US2·US3는 후속 PR로 점진 머지(헌법 IV Incremental Release).
+
+## Coverage Target ↔ tasks 매핑 검증
+
+| [why] tag | plan multi-step | 매핑 task 수 |
+|-----------|-----------------|--------------|
+| draft-schema | 2 | T002, T003, T007, T018 — 4건 (≥ 2 OK) |
+| provider-fetch | 2 | T005, T006 — 2건 (= 2 OK) |
+| import-api | 2 | T004, T008, T009, T010, T019, T020, T027, T030, T031, T033 — 10건 (≥ 2 OK) |
+| draft-promote | — | T021, T022, T025, T026 — 4건 (≥ 1 OK) |
+| ui-draft-row | — | T012, T015, T016, T028, T029 — 5건 (≥ 1 OK) |
+| ui-import-trigger | 2 | T011, T013, T014 — 3건 (≥ 2 OK) |
+| ui-promote-modal | 2 | T023, T024 — 2건 (= 2 OK) |
+| ui-import-summary | — | T017, T034 — 2건 (≥ 1 OK) |
+| draft-cascade | — | T032 — 1건 (≥ 1 OK) |
+| adr-import-policy | — | T001, T035, T036 — 3건 (≥ 1 OK) |
+
+## Implementation Strategy
+
+1. **Phase 1·2 먼저** — ADR + schema + 권한 매트릭스. 머지 1회.
+2. **US1 (MVP)** — 외부 → draft → 화면 표시. 머지 1회.
+3. **US2** — 승격 흐름. 머지 1회.
+4. **US3** — 멱등성·refresh·delete. 머지 1회.
+5. **Polish** — 단편·Evidence·OpenAPI 회귀. 머지 1회.
+
+각 단계는 develop으로 PR → 머지 → dev.trip.idean.me 회귀 → 다음 단계 진입.
+
+## 검증 게이트
+
+- `validate-metatag-format.sh` — 4종 메타태그 형식
+- `validate-plan-tasks-cov.sh` — plan ↔ tasks 매핑 수 (위 표 통과)
+- `validate-quickstart-ev.sh` — quickstart Evidence
+- `validate-migration-meta.sh` — T003 마이그레이션 헤더(`[migration-type: schema-only]`)
+- `validate-constitution.sh` — 헌법 V·VI 휴리스틱(권한 매트릭스 추가는 헌법 VI 정상 절차)

--- a/specs/027-external-calendar-import/tasks.md
+++ b/specs/027-external-calendar-import/tasks.md
@@ -34,7 +34,7 @@ description: "외부 캘린더 import — 작업 목록"
 **⚠️ Checkpoint**: 본 phase 통과 전 US 작업 착수 금지.
 
 - [x] T002 Prisma schema에 `ActivityDraft`·`ImportRun` 모델 + `ActivityDraftStatus`·`CalendarProvider` enum 추가 [artifact: prisma/schema.prisma::ActivityDraft] [why: draft-schema] [multi-step: 2]
-- [x] T003 마이그레이션 SQL 생성 — `CREATE TYPE` + `CREATE TABLE`, 헤더 `[migration-type: schema-only]` 명시. trip 삭제 cascade·draft-importRun restrict FK 포함 [artifact: prisma/migrations/20260527_add_activity_draft/migration.sql] [why: draft-schema] [multi-step: 2]
+- [x] T003 마이그레이션 SQL 생성 — `CREATE TYPE` + `CREATE TABLE`, 헤더 `[migration-type: schema-only]` 명시. trip 삭제 cascade·draft-importRun restrict FK 포함 [artifact: prisma/migrations/20260527000000_add_activity_draft/migration.sql] [why: draft-schema] [multi-step: 2]
 - [x] T004 권한 매트릭스에 "외부 캘린더 import" 행 추가 + 헬퍼 `canImportCalendar(role)` 구현 [artifact: src/lib/permissions/activity.ts::canImportCalendar] [why: import-api]
 
 ---

--- a/src/app/api/trips/[id]/calendar-import/route.ts
+++ b/src/app/api/trips/[id]/calendar-import/route.ts
@@ -1,0 +1,84 @@
+/**
+ * spec 027 — POST /api/trips/<id>/calendar-import
+ *
+ * 외부 캘린더의 trip 기간 이벤트를 ActivityDraft로 import한다.
+ * 권한: trip의 OWNER 또는 HOST. GUEST는 403.
+ * 외부 계정 미연결 시 409.
+ * 멱등성: (provider, externalCalendarId, externalEventId) 키로 중복 차단.
+ */
+
+import { NextResponse } from "next/server";
+import { getAuthUserId } from "@/lib/auth-helpers";
+import { userCanImportCalendar } from "@/lib/permissions/activity";
+import {
+  runImport,
+  ExternalAccountNotLinkedError,
+} from "@/lib/calendar-import/service";
+import type { CalendarProviderId } from "@prisma/client";
+
+type Params = { params: Promise<{ id: string }> };
+
+interface ImportRequestBody {
+  provider?: CalendarProviderId;
+  externalCalendarId?: string;
+}
+
+export async function POST(request: Request, { params }: Params) {
+  const { id } = await params;
+  const tripId = parseInt(id);
+  if (Number.isNaN(tripId)) {
+    return NextResponse.json({ error: "invalid_trip_id" }, { status: 400 });
+  }
+
+  const userId = await getAuthUserId();
+  if (!userId) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  if (!(await userCanImportCalendar(tripId, userId))) {
+    return NextResponse.json(
+      { error: "forbidden", message: "외부 캘린더 import는 HOST 이상에게만 허용됩니다." },
+      { status: 403 },
+    );
+  }
+
+  let body: ImportRequestBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  if (!body.provider || !body.externalCalendarId) {
+    return NextResponse.json(
+      { error: "missing_fields", fields: ["provider", "externalCalendarId"] },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await runImport({
+      tripId,
+      triggeredByUserId: userId,
+      provider: body.provider,
+      externalCalendarId: body.externalCalendarId,
+    });
+    return NextResponse.json(result, { status: 200 });
+  } catch (err) {
+    if (err instanceof ExternalAccountNotLinkedError) {
+      return NextResponse.json(
+        {
+          error: "external_account_not_linked",
+          message: "캘린더 계정을 먼저 연결하세요.",
+          settingsPath: "/settings/calendars",
+        },
+        { status: 409 },
+      );
+    }
+    console.error("[calendar-import] internal error", err);
+    return NextResponse.json(
+      { error: "internal_error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/trips/[id]/drafts/[draftId]/promote/route.ts
+++ b/src/app/api/trips/[id]/drafts/[draftId]/promote/route.ts
@@ -1,0 +1,101 @@
+/**
+ * spec 027 US2 — POST /api/trips/<id>/drafts/<draftId>/promote
+ *
+ * draft를 정식 Activity로 승격. 필수 필드 미충족 시 422.
+ * 권한: trip OWNER·HOST (헌법 VI).
+ */
+
+import { NextResponse } from "next/server";
+import type { ActivityCategory, ReservationStatus } from "@prisma/client";
+import { getAuthUserId } from "@/lib/auth-helpers";
+import { userCanImportCalendar } from "@/lib/permissions/activity";
+import {
+  promoteDraft,
+  DraftNotPromotableError,
+} from "@/lib/calendar-import/promotion";
+
+type Params = { params: Promise<{ id: string; draftId: string }> };
+
+const CATEGORIES: ActivityCategory[] = [
+  "SIGHTSEEING",
+  "DINING",
+  "TRANSPORT",
+  "ACCOMMODATION",
+  "SHOPPING",
+  "OTHER",
+];
+const RESERVATION_STATUSES: ReservationStatus[] = [
+  "REQUIRED",
+  "RECOMMENDED",
+  "ON_SITE",
+  "NOT_NEEDED",
+];
+
+interface PromoteRequestBody {
+  category?: ActivityCategory;
+  reservationStatus?: ReservationStatus;
+  startTimezone?: string;
+  endTimezone?: string;
+  location?: string | null;
+}
+
+export async function POST(request: Request, { params }: Params) {
+  const { id, draftId } = await params;
+  const tripId = parseInt(id);
+  const draftIdNum = parseInt(draftId);
+  if (Number.isNaN(tripId) || Number.isNaN(draftIdNum)) {
+    return NextResponse.json({ error: "invalid_ids" }, { status: 400 });
+  }
+  const userId = await getAuthUserId();
+  if (!userId) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  if (!(await userCanImportCalendar(tripId, userId))) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  let body: PromoteRequestBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const missing: string[] = [];
+  if (!body.category || !CATEGORIES.includes(body.category)) missing.push("category");
+  if (!body.reservationStatus || !RESERVATION_STATUSES.includes(body.reservationStatus)) {
+    missing.push("reservationStatus");
+  }
+  if (!body.startTimezone) missing.push("startTimezone");
+  if (!body.endTimezone) missing.push("endTimezone");
+  if (missing.length > 0) {
+    return NextResponse.json(
+      {
+        error: "missing_required_fields",
+        message: "필수 입력 필드를 채워주세요.",
+        fields: missing,
+      },
+      { status: 422 },
+    );
+  }
+
+  try {
+    const result = await promoteDraft({
+      draftId: draftIdNum,
+      tripId,
+      category: body.category!,
+      reservationStatus: body.reservationStatus!,
+      startTimezone: body.startTimezone!,
+      endTimezone: body.endTimezone!,
+      location: body.location ?? null,
+    });
+    return NextResponse.json(result, { status: 200 });
+  } catch (err) {
+    if (err instanceof DraftNotPromotableError) {
+      return NextResponse.json(
+        { error: err.message },
+        { status: err.message === "draft_not_found" ? 404 : 409 },
+      );
+    }
+    console.error("[draft promote] internal error", err);
+    return NextResponse.json({ error: "internal_error" }, { status: 500 });
+  }
+}

--- a/src/app/api/trips/[id]/drafts/[draftId]/refresh/route.ts
+++ b/src/app/api/trips/[id]/drafts/[draftId]/refresh/route.ts
@@ -1,0 +1,58 @@
+/**
+ * spec 027 US3 — POST /api/trips/<id>/drafts/<draftId>/refresh
+ *
+ * 외부 최신 값으로 draft의 매핑 가능 필드 덮어쓰기.
+ * 사용자가 입력한 timezone 등 매핑 불가 필드는 보존.
+ * PROMOTED draft는 409.
+ */
+
+import { NextResponse } from "next/server";
+import { getAuthUserId } from "@/lib/auth-helpers";
+import { userCanImportCalendar } from "@/lib/permissions/activity";
+import {
+  refreshDraft,
+  DraftRefreshConflictError,
+  ExternalAccountNotLinkedError,
+} from "@/lib/calendar-import/service";
+
+type Params = { params: Promise<{ id: string; draftId: string }> };
+
+export async function POST(_request: Request, { params }: Params) {
+  const { id, draftId } = await params;
+  const tripId = parseInt(id);
+  const draftIdNum = parseInt(draftId);
+  if (Number.isNaN(tripId) || Number.isNaN(draftIdNum)) {
+    return NextResponse.json({ error: "invalid_ids" }, { status: 400 });
+  }
+  const userId = await getAuthUserId();
+  if (!userId) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  if (!(await userCanImportCalendar(tripId, userId))) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  try {
+    const result = await refreshDraft({ tripId, draftId: draftIdNum, triggeredByUserId: userId });
+    if (!result.refreshed) {
+      return NextResponse.json(
+        { error: "external_event_missing", message: "외부에서 해당 이벤트를 찾을 수 없습니다." },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (err) {
+    if (err instanceof DraftRefreshConflictError) {
+      return NextResponse.json({ error: "draft_not_pending" }, { status: 409 });
+    }
+    if (err instanceof ExternalAccountNotLinkedError) {
+      return NextResponse.json(
+        { error: "external_account_not_linked", settingsPath: "/settings/calendars" },
+        { status: 409 },
+      );
+    }
+    if ((err as Error).message === "draft_not_found") {
+      return NextResponse.json({ error: "draft_not_found" }, { status: 404 });
+    }
+    console.error("[draft refresh] internal error", err);
+    return NextResponse.json({ error: "internal_error" }, { status: 500 });
+  }
+}

--- a/src/app/api/trips/[id]/drafts/[draftId]/route.ts
+++ b/src/app/api/trips/[id]/drafts/[draftId]/route.ts
@@ -1,0 +1,36 @@
+/**
+ * spec 027 US3 — DELETE /api/trips/<id>/drafts/<draftId>
+ *
+ * draft 단건 삭제. 외부 캘린더에는 영향 없음.
+ * 권한: trip OWNER·HOST.
+ */
+
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getAuthUserId } from "@/lib/auth-helpers";
+import { userCanImportCalendar } from "@/lib/permissions/activity";
+
+type Params = { params: Promise<{ id: string; draftId: string }> };
+
+export async function DELETE(_request: Request, { params }: Params) {
+  const { id, draftId } = await params;
+  const tripId = parseInt(id);
+  const draftIdNum = parseInt(draftId);
+  if (Number.isNaN(tripId) || Number.isNaN(draftIdNum)) {
+    return NextResponse.json({ error: "invalid_ids" }, { status: 400 });
+  }
+  const userId = await getAuthUserId();
+  if (!userId) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  if (!(await userCanImportCalendar(tripId, userId))) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  const draft = await prisma.activityDraft.findFirst({
+    where: { id: draftIdNum, tripId },
+    select: { id: true },
+  });
+  if (!draft) return new NextResponse(null, { status: 204 });
+
+  await prisma.activityDraft.delete({ where: { id: draft.id } });
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/app/api/trips/[id]/drafts/route.ts
+++ b/src/app/api/trips/[id]/drafts/route.ts
@@ -1,0 +1,47 @@
+/**
+ * spec 027 — GET /api/trips/<id>/drafts
+ *
+ * trip의 ActivityDraft 목록. status 쿼리(기본 PENDING).
+ * 권한: trip 멤버 누구나(조회).
+ */
+
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getAuthUserId, getTripMember } from "@/lib/auth-helpers";
+import type { ActivityDraftStatus } from "@prisma/client";
+
+type Params = { params: Promise<{ id: string }> };
+
+const ALLOWED_STATUSES: ActivityDraftStatus[] = ["PENDING", "PROMOTED", "DELETED"];
+
+export async function GET(request: Request, { params }: Params) {
+  const { id } = await params;
+  const tripId = parseInt(id);
+  if (Number.isNaN(tripId)) {
+    return NextResponse.json({ error: "invalid_trip_id" }, { status: 400 });
+  }
+  const userId = await getAuthUserId();
+  if (!userId) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const member = await getTripMember(tripId, userId);
+  if (!member) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  const url = new URL(request.url);
+  const statusParam = url.searchParams.get("status");
+  const status: ActivityDraftStatus = ALLOWED_STATUSES.includes(
+    statusParam as ActivityDraftStatus,
+  )
+    ? (statusParam as ActivityDraftStatus)
+    : "PENDING";
+
+  const drafts = await prisma.activityDraft.findMany({
+    where: { tripId, status },
+    orderBy: { startTime: "asc" },
+  });
+
+  return NextResponse.json({ drafts }, { status: 200 });
+}

--- a/src/app/api/users/me/external-calendars/route.ts
+++ b/src/app/api/users/me/external-calendars/route.ts
@@ -1,0 +1,19 @@
+/**
+ * spec 027 — GET /api/users/me/external-calendars
+ *
+ * 현재 사용자가 연결한 외부 계정의 캘린더 목록(trip-planner 관리 캘린더 제외).
+ * UI 캘린더 선택 모달이 본 결과를 보여준다.
+ */
+
+import { NextResponse } from "next/server";
+import { getAuthUserId } from "@/lib/auth-helpers";
+import { listAvailableExternalCalendars } from "@/lib/calendar-import/service";
+
+export async function GET() {
+  const userId = await getAuthUserId();
+  if (!userId) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+  const calendars = await listAvailableExternalCalendars(userId);
+  return NextResponse.json({ calendars }, { status: 200 });
+}

--- a/src/app/trips/[id]/SidePanel.tsx
+++ b/src/app/trips/[id]/SidePanel.tsx
@@ -2,6 +2,8 @@ import MemberList from "@/components/MemberList";
 import GCalLinkPanel from "@/components/GCalLinkPanel";
 import AppleEntryCard from "@/components/calendar/AppleEntryCard";
 import CalendarProviderChoice from "@/components/calendar/CalendarProviderChoice";
+import CalendarImportPanel from "@/components/calendar-import/CalendarImportPanel";
+import DraftListPanel from "@/components/calendar-import/DraftListPanel";
 import type { TripRole } from "@prisma/client";
 
 /**
@@ -32,6 +34,8 @@ export default function SidePanel({
       {showProviderChoice && <CalendarProviderChoice tripId={tripId} />}
       {showGcal && <GCalLinkPanel tripId={tripId} role={role} />}
       {showApple && <AppleEntryCard tripId={tripId} role={role} />}
+      <CalendarImportPanel tripId={tripId} role={role} />
+      <DraftListPanel tripId={tripId} canEdit={role === "OWNER" || role === "HOST"} />
       <MemberList tripId={tripId} />
     </aside>
   );

--- a/src/components/calendar-import/CalendarImportPanel.tsx
+++ b/src/components/calendar-import/CalendarImportPanel.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+/**
+ * spec 027 — 외부 캘린더 import 진입 패널.
+ *
+ * trip 상세 SidePanel에 노출. HOST 이상 권한 사용자만 import 버튼 사용 가능.
+ * 1) 외부 캘린더 목록 fetch
+ * 2) 사용자가 1개 선택
+ * 3) 가져오기 실행 → 결과 토스트 + 페이지 새로고침
+ */
+
+import { useCallback, useState } from "react";
+import { CalendarPlus, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { TripRole, CalendarProviderId } from "@prisma/client";
+
+interface ExternalCalendar {
+  provider: CalendarProviderId;
+  externalCalendarId: string;
+  displayName: string | null;
+  accountLabel: string | null;
+  isManagedByTripPlanner: boolean;
+}
+
+interface ImportResultPayload {
+  importRunId: number;
+  importedCount: number;
+  skippedCount: number;
+  failedCount: number;
+  failedTitles: string[];
+}
+
+const PROVIDER_LABEL: Record<CalendarProviderId, string> = {
+  GOOGLE: "Google",
+  APPLE: "Apple",
+};
+
+export default function CalendarImportPanel({
+  tripId,
+  role,
+}: {
+  tripId: number;
+  role: TripRole;
+}) {
+  const canImport = role === "OWNER" || role === "HOST";
+  const [open, setOpen] = useState(false);
+  const [calendars, setCalendars] = useState<ExternalCalendar[] | null>(null);
+  const [loadingList, setLoadingList] = useState(false);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [running, setRunning] = useState(false);
+
+  const loadCalendars = useCallback(async () => {
+    setLoadingList(true);
+    try {
+      const res = await fetch("/api/users/me/external-calendars", {
+        cache: "no-store",
+      });
+      if (!res.ok) {
+        setCalendars([]);
+        return;
+      }
+      const data = (await res.json()) as { calendars: ExternalCalendar[] };
+      setCalendars(data.calendars);
+    } finally {
+      setLoadingList(false);
+    }
+  }, []);
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      setOpen(next);
+      if (next && calendars === null) loadCalendars();
+      if (!next) setSelected(null);
+    },
+    [calendars, loadCalendars],
+  );
+
+  const handleImport = useCallback(async () => {
+    if (!selected) return;
+    const target = calendars?.find((c) => c.externalCalendarId === selected);
+    if (!target) return;
+
+    setRunning(true);
+    try {
+      const res = await fetch(`/api/trips/${tripId}/calendar-import`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          provider: target.provider,
+          externalCalendarId: target.externalCalendarId,
+        }),
+      });
+      const body = await res.json().catch(() => ({}));
+
+      if (res.status === 409 && body?.error === "external_account_not_linked") {
+        toast.error("캘린더 계정 미연결", {
+          description: "설정에서 외부 캘린더 계정을 먼저 연결하세요.",
+          action: {
+            label: "설정 열기",
+            onClick: () => {
+              window.location.href = body.settingsPath ?? "/settings/calendars";
+            },
+          },
+        });
+        return;
+      }
+      if (!res.ok) {
+        toast.error("가져오기 실패", {
+          description: body?.message ?? `오류 코드: ${res.status}`,
+        });
+        return;
+      }
+
+      const result = body as ImportResultPayload;
+      const lines = [
+        `가져옴 ${result.importedCount}건`,
+        `건너뜀 ${result.skippedCount}건`,
+      ];
+      if (result.failedCount > 0) {
+        lines.push(`실패 ${result.failedCount}건`);
+      }
+      toast.success("외부 캘린더 가져오기 완료", {
+        description: lines.join(" · "),
+      });
+      setOpen(false);
+      // draft 패널 갱신을 위해 페이지 새로고침
+      window.location.reload();
+    } finally {
+      setRunning(false);
+    }
+  }, [calendars, selected, tripId]);
+
+  if (!canImport) return null;
+
+  const importable = (calendars ?? []).filter((c) => !c.isManagedByTripPlanner);
+  const hasManaged = (calendars ?? []).some((c) => c.isManagedByTripPlanner);
+
+  return (
+    <section className="rounded-lg border bg-card p-4 shadow-sm">
+      <h3 className="mb-1 flex items-center gap-2 text-sm font-semibold">
+        <CalendarPlus className="size-4" />
+        외부 캘린더에서 일정 가져오기
+      </h3>
+      <p className="mb-3 text-xs text-muted-foreground">
+        다른 캘린더에 쌓아둔 일정을 이 여행의 초안으로 가져옵니다. 매핑 안 되는 정보는 비어 있는 상태로 들어옵니다.
+      </p>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => handleOpenChange(true)}
+      >
+        가져오기 시작
+      </Button>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>외부 캘린더 선택</DialogTitle>
+            <DialogDescription>
+              여행 기간과 겹치는 일정만 가져옵니다. 같은 이벤트는 다시 눌러도 중복으로 들어오지 않습니다.
+            </DialogDescription>
+          </DialogHeader>
+
+          {loadingList && (
+            <p className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" /> 목록 불러오는 중…
+            </p>
+          )}
+
+          {!loadingList && importable.length === 0 && (
+            <div className="space-y-2 text-sm">
+              <p>가져올 수 있는 외부 캘린더가 없습니다.</p>
+              {hasManaged && (
+                <p className="text-xs text-muted-foreground">
+                  trip-planner가 만든 캘린더는 가져오기 대상에서 제외됩니다.
+                </p>
+              )}
+              <p className="text-xs text-muted-foreground">
+                Google 계정에 다른 캘린더가 있다면 그 캘린더에 일정을 만든 뒤 다시 시도하세요. Apple 캘린더 가져오기는 후속 릴리즈에서 지원될 예정입니다.
+              </p>
+            </div>
+          )}
+
+          {!loadingList && importable.length > 0 && (
+            <ul className="space-y-2">
+              {importable.map((c) => (
+                <li key={`${c.provider}:${c.externalCalendarId}`}>
+                  <label className="flex cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm hover:bg-accent">
+                    <input
+                      type="radio"
+                      name="external-calendar"
+                      value={c.externalCalendarId}
+                      checked={selected === c.externalCalendarId}
+                      onChange={() => setSelected(c.externalCalendarId)}
+                    />
+                    <span className="flex-1">
+                      <span className="font-medium">
+                        {c.displayName ?? "(이름 없음)"}
+                      </span>
+                      <span className="ml-2 text-xs text-muted-foreground">
+                        {PROVIDER_LABEL[c.provider]}
+                      </span>
+                    </span>
+                  </label>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              disabled={running}
+              onClick={() => handleOpenChange(false)}
+            >
+              취소
+            </Button>
+            <Button
+              onClick={handleImport}
+              disabled={!selected || running || importable.length === 0}
+            >
+              {running ? (
+                <>
+                  <Loader2 className="mr-2 size-4 animate-spin" />
+                  가져오는 중…
+                </>
+              ) : (
+                "가져오기"
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </section>
+  );
+}

--- a/src/components/calendar-import/DraftListPanel.tsx
+++ b/src/components/calendar-import/DraftListPanel.tsx
@@ -1,0 +1,366 @@
+"use client";
+
+/**
+ * spec 027 US1·US2·US3 — 외부 import draft 목록 + 승격·다시 가져오기·삭제.
+ *
+ * trip 상세 SidePanel 의 별도 섹션. PENDING 상태만 표시.
+ * 카드 클릭 → 승격 모달. 컨텍스트 메뉴 → 다시 가져오기 / 삭제.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { CalendarClock, Loader2, MoreHorizontal } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type {
+  ActivityCategory,
+  ActivityDraftStatus,
+  CalendarProviderId,
+  ReservationStatus,
+} from "@prisma/client";
+
+interface DraftDTO {
+  id: number;
+  tripId: number;
+  provider: CalendarProviderId;
+  externalCalendarId: string;
+  externalEventId: string;
+  title: string;
+  startTime: string;
+  endTime: string;
+  isAllDay: boolean;
+  locationText: string | null;
+  description: string | null;
+  startTimezone: string | null;
+  endTimezone: string | null;
+  status: ActivityDraftStatus;
+}
+
+const CATEGORY_OPTIONS: { value: ActivityCategory; label: string }[] = [
+  { value: "SIGHTSEEING", label: "관광" },
+  { value: "DINING", label: "식사" },
+  { value: "TRANSPORT", label: "이동" },
+  { value: "ACCOMMODATION", label: "숙소" },
+  { value: "SHOPPING", label: "쇼핑" },
+  { value: "OTHER", label: "기타" },
+];
+const RESERVATION_OPTIONS: { value: ReservationStatus; label: string }[] = [
+  { value: "REQUIRED", label: "사전 예약 필수" },
+  { value: "RECOMMENDED", label: "사전 예약 권장" },
+  { value: "ON_SITE", label: "현장 구매" },
+  { value: "NOT_NEEDED", label: "예약 불필요" },
+];
+const TIMEZONE_OPTIONS = [
+  "Asia/Seoul",
+  "Asia/Tokyo",
+  "Asia/Taipei",
+  "Asia/Singapore",
+  "Asia/Bangkok",
+  "Europe/Paris",
+  "Europe/London",
+  "America/New_York",
+  "America/Los_Angeles",
+  "UTC",
+];
+
+function formatRange(start: string, end: string, isAllDay: boolean): string {
+  if (isAllDay) {
+    return new Intl.DateTimeFormat("ko-KR", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(new Date(start));
+  }
+  const fmt = new Intl.DateTimeFormat("ko-KR", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  return `${fmt.format(new Date(start))} ~ ${fmt.format(new Date(end))}`;
+}
+
+export default function DraftListPanel({
+  tripId,
+  canEdit,
+}: {
+  tripId: number;
+  canEdit: boolean;
+}) {
+  const [drafts, setDrafts] = useState<DraftDTO[] | null>(null);
+  const [promoteTarget, setPromoteTarget] = useState<DraftDTO | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  // 폼 상태
+  const [category, setCategory] = useState<ActivityCategory>("SIGHTSEEING");
+  const [reservationStatus, setReservationStatus] = useState<ReservationStatus>("NOT_NEEDED");
+  const [startTz, setStartTz] = useState<string>("Asia/Seoul");
+  const [endTz, setEndTz] = useState<string>("Asia/Seoul");
+
+  const refresh = useCallback(async () => {
+    const res = await fetch(`/api/trips/${tripId}/drafts?status=PENDING`, {
+      cache: "no-store",
+    });
+    if (!res.ok) {
+      setDrafts([]);
+      return;
+    }
+    const data = await res.json();
+    setDrafts(data.drafts as DraftDTO[]);
+  }, [tripId]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const openPromote = useCallback((d: DraftDTO) => {
+    setPromoteTarget(d);
+    setCategory("SIGHTSEEING");
+    setReservationStatus("NOT_NEEDED");
+    setStartTz(d.startTimezone ?? "Asia/Seoul");
+    setEndTz(d.endTimezone ?? d.startTimezone ?? "Asia/Seoul");
+  }, []);
+
+  const handlePromote = useCallback(async () => {
+    if (!promoteTarget) return;
+    setSubmitting(true);
+    try {
+      const res = await fetch(
+        `/api/trips/${tripId}/drafts/${promoteTarget.id}/promote`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            category,
+            reservationStatus,
+            startTimezone: startTz,
+            endTimezone: endTz,
+          }),
+        },
+      );
+      if (res.status === 422) {
+        const body = await res.json();
+        toast.error("필수 입력 누락", {
+          description: `다음 필드를 채워주세요: ${body.fields.join(", ")}`,
+        });
+        return;
+      }
+      if (!res.ok) {
+        toast.error("승격 실패", { description: `오류 코드 ${res.status}` });
+        return;
+      }
+      toast.success("정식 일정으로 승격했습니다.");
+      setPromoteTarget(null);
+      await refresh();
+      window.location.reload();
+    } finally {
+      setSubmitting(false);
+    }
+  }, [category, endTz, promoteTarget, refresh, reservationStatus, startTz, tripId]);
+
+  const handleRefreshDraft = useCallback(
+    async (d: DraftDTO) => {
+      const res = await fetch(`/api/trips/${tripId}/drafts/${d.id}/refresh`, {
+        method: "POST",
+      });
+      if (res.status === 404) {
+        toast.error("외부 이벤트가 없어졌습니다.", {
+          description: "외부 캘린더에서 이벤트가 삭제된 것으로 보입니다.",
+        });
+        return;
+      }
+      if (!res.ok) {
+        toast.error("다시 가져오기 실패", { description: `오류 코드 ${res.status}` });
+        return;
+      }
+      toast.success("외부 최신 값으로 갱신했습니다.");
+      await refresh();
+    },
+    [refresh, tripId],
+  );
+
+  const handleDelete = useCallback(
+    async (d: DraftDTO) => {
+      if (!confirm("이 초안을 삭제할까요? 외부 캘린더의 이벤트는 그대로 유지됩니다.")) return;
+      const res = await fetch(`/api/trips/${tripId}/drafts/${d.id}`, { method: "DELETE" });
+      if (res.ok) {
+        toast.success("초안을 삭제했습니다.");
+        await refresh();
+      } else {
+        toast.error("삭제 실패", { description: `오류 코드 ${res.status}` });
+      }
+    },
+    [refresh, tripId],
+  );
+
+  if (!drafts || drafts.length === 0) return null;
+
+  return (
+    <section className="rounded-lg border bg-card p-4 shadow-sm">
+      <h3 className="mb-2 flex items-center gap-2 text-sm font-semibold">
+        <CalendarClock className="size-4" />
+        외부에서 가져온 일정 ({drafts.length})
+      </h3>
+      <p className="mb-3 text-xs text-muted-foreground">
+        클릭하면 카테고리·예약 상태·시간대를 채워 정식 일정으로 만들 수 있습니다.
+      </p>
+      <ul className="space-y-2">
+        {drafts.map((d) => (
+          <li
+            key={d.id}
+            className="flex items-start justify-between gap-2 rounded-md border border-dashed bg-muted/30 px-3 py-2"
+          >
+            <button
+              className="flex-1 text-left disabled:cursor-not-allowed"
+              onClick={() => canEdit && openPromote(d)}
+              disabled={!canEdit}
+            >
+              <div className="text-sm font-medium opacity-80">{d.title}</div>
+              <div className="text-xs text-muted-foreground">
+                {formatRange(d.startTime, d.endTime, d.isAllDay)}
+                {d.locationText ? ` · ${d.locationText}` : ""}
+              </div>
+              <div className="mt-1 inline-flex items-center rounded bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+                외부 캘린더에서 가져옴
+              </div>
+            </button>
+            {canEdit && (
+              <DropdownMenu>
+                <DropdownMenuTrigger>
+                  <span className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:bg-accent" aria-label="더보기">
+                    <MoreHorizontal className="size-4" />
+                  </span>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem onClick={() => handleRefreshDraft(d)}>
+                    다시 가져오기
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => handleDelete(d)} className="text-destructive">
+                    삭제
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+          </li>
+        ))}
+      </ul>
+
+      <Dialog open={promoteTarget !== null} onOpenChange={(o) => !o && setPromoteTarget(null)}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>정식 일정으로 만들기</DialogTitle>
+            <DialogDescription>
+              {promoteTarget?.title}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3 text-sm">
+            <label className="block">
+              <span className="mb-1 block text-xs font-medium">카테고리</span>
+              <Select value={category} onValueChange={(v) => setCategory(v as ActivityCategory)}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {CATEGORY_OPTIONS.map((o) => (
+                    <SelectItem key={o.value} value={o.value}>
+                      {o.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </label>
+            <label className="block">
+              <span className="mb-1 block text-xs font-medium">예약 상태</span>
+              <Select
+                value={reservationStatus}
+                onValueChange={(v) => setReservationStatus(v as ReservationStatus)}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {RESERVATION_OPTIONS.map((o) => (
+                    <SelectItem key={o.value} value={o.value}>
+                      {o.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </label>
+            <div className="grid grid-cols-2 gap-2">
+              <label className="block">
+                <span className="mb-1 block text-xs font-medium">시작 시간대</span>
+                <Select value={startTz} onValueChange={(v) => v && setStartTz(v)}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {TIMEZONE_OPTIONS.map((tz) => (
+                      <SelectItem key={tz} value={tz}>
+                        {tz}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </label>
+              <label className="block">
+                <span className="mb-1 block text-xs font-medium">종료 시간대</span>
+                <Select value={endTz} onValueChange={(v) => v && setEndTz(v)}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {TIMEZONE_OPTIONS.map((tz) => (
+                      <SelectItem key={tz} value={tz}>
+                        {tz}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </label>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              onClick={() => setPromoteTarget(null)}
+              disabled={submitting}
+            >
+              취소
+            </Button>
+            <Button onClick={handlePromote} disabled={submitting}>
+              {submitting ? (
+                <>
+                  <Loader2 className="mr-2 size-4 animate-spin" />
+                  승격 중…
+                </>
+              ) : (
+                "승격"
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </section>
+  );
+}

--- a/src/lib/calendar-import/apple.ts
+++ b/src/lib/calendar-import/apple.ts
@@ -1,0 +1,96 @@
+/**
+ * spec 027 — Apple CalDAV import fetcher.
+ *
+ * 사용자의 Apple iCloud 계정에서 CalDAV로 캘린더 목록·VEVENT를 fetch한다.
+ * trip-planner가 만든 캘린더는 TripCalendarLink 매핑으로 식별해 제외.
+ * push 경로(spec 025 appleProvider)와는 read-only 분리.
+ */
+
+import { prisma } from "@/lib/prisma";
+import { createAppleClient } from "@/lib/calendar/provider/apple-client";
+import { decryptPassword } from "@/lib/calendar/provider/apple-crypto";
+import { parseVevent } from "./ics-parser";
+import type {
+  DateRange,
+  ExternalCalendarFetcher,
+  ExternalCalendarRef,
+  ExternalEvent,
+} from "./types";
+
+async function loadClient(userId: string) {
+  const cred = await prisma.appleCalendarCredential.findUnique({ where: { userId } });
+  if (!cred) return null;
+  try {
+    const password = decryptPassword(cred.encryptedPassword, cred.iv);
+    return createAppleClient({ appleId: cred.appleId, appPassword: password });
+  } catch {
+    return null;
+  }
+}
+
+async function loadManagedCalendarUrls(userId: string): Promise<Set<string>> {
+  const links = await prisma.tripCalendarLink.findMany({
+    where: { provider: "APPLE", ownerId: userId },
+    select: { calendarId: true },
+  });
+  return new Set(links.map((l) => l.calendarId));
+}
+
+export const appleImportFetcher: ExternalCalendarFetcher = {
+  provider: "APPLE",
+
+  async isConnected(userId: string): Promise<boolean> {
+    const cred = await prisma.appleCalendarCredential.findUnique({ where: { userId } });
+    return cred !== null;
+  },
+
+  async listCalendars(userId: string): Promise<ExternalCalendarRef[]> {
+    const client = await loadClient(userId);
+    if (!client) return [];
+    const managed = await loadManagedCalendarUrls(userId);
+    const calendars = await client.fetchCalendars();
+    return calendars
+      .filter(
+        (c) =>
+          Array.isArray(c.components) && c.components.includes("VEVENT") && Boolean(c.url),
+      )
+      .map((c) => ({
+        provider: "APPLE" as const,
+        externalCalendarId: c.url,
+        displayName: typeof c.displayName === "string" ? c.displayName : null,
+        accountLabel: null,
+        isManagedByTripPlanner: managed.has(c.url),
+      }));
+  },
+
+  async listEvents(
+    userId: string,
+    externalCalendarId: string,
+    range: DateRange,
+  ): Promise<ExternalEvent[]> {
+    const client = await loadClient(userId);
+    if (!client) return [];
+    const calendars = await client.fetchCalendars();
+    const target = calendars.find((c) => c.url === externalCalendarId);
+    if (!target) return [];
+
+    const objects = await client.fetchCalendarObjects({
+      calendar: target,
+      timeRange: {
+        start: range.start.toISOString(),
+        end: range.end.toISOString(),
+      },
+      expand: true,
+    });
+
+    const events: ExternalEvent[] = [];
+    for (const obj of objects) {
+      const ics = obj.data;
+      if (typeof ics !== "string") continue;
+      const fallbackId = obj.url ?? undefined;
+      const ev = parseVevent(ics, fallbackId);
+      if (ev) events.push(ev);
+    }
+    return events;
+  },
+};

--- a/src/lib/calendar-import/google.ts
+++ b/src/lib/calendar-import/google.ts
@@ -1,0 +1,140 @@
+/**
+ * spec 027 — Google Calendar import fetcher.
+ *
+ * 사용자 본인의 Google 계정에서 calendarList + events.list를 호출한다.
+ * trip-planner가 만든 캘린더는 결과에서 제외한다(GCalLink·TripCalendarLink로 식별).
+ * push 경로(spec 024 googleProvider)와는 인스턴스 분리 — read-only.
+ */
+
+import { calendar_v3 } from "@googleapis/calendar";
+import { prisma } from "@/lib/prisma";
+import { getCalendarClient } from "@/lib/gcal/client";
+import type {
+  DateRange,
+  ExternalCalendarFetcher,
+  ExternalCalendarRef,
+  ExternalEvent,
+} from "./types";
+
+const EVENTS_PAGE_SIZE = 250;
+const MAX_EVENTS_PER_IMPORT = 500;
+
+async function loadManagedCalendarIds(userId: string): Promise<Set<string>> {
+  // 사용자 본인이 만든·소유한 trip 캘린더만 제외. 다른 사용자 trip의 공유 캘린더 ID는
+  // 본인 Google calendarList에 노출되지 않으므로 일반적으로 영향 없으나, 식별자 우연 충돌
+  // 방지를 위해 ownerId 필터를 명시한다.
+  const [gcalLinks, sharedLinks] = await Promise.all([
+    prisma.gCalLink.findMany({
+      where: { userId, provider: "GOOGLE" },
+      select: { calendarId: true },
+    }),
+    prisma.tripCalendarLink.findMany({
+      where: { provider: "GOOGLE", ownerId: userId },
+      select: { calendarId: true },
+    }),
+  ]);
+  return new Set<string>([
+    ...gcalLinks.map((l) => l.calendarId),
+    ...sharedLinks.map((l) => l.calendarId),
+  ]);
+}
+
+function parseDate(
+  raw: calendar_v3.Schema$EventDateTime | undefined,
+): { date: Date | null; isAllDay: boolean; timezone: string | null } {
+  if (!raw) return { date: null, isAllDay: false, timezone: null };
+  if (raw.dateTime) {
+    return {
+      date: new Date(raw.dateTime),
+      isAllDay: false,
+      timezone: raw.timeZone ?? null,
+    };
+  }
+  if (raw.date) {
+    return {
+      date: new Date(`${raw.date}T00:00:00Z`),
+      isAllDay: true,
+      timezone: raw.timeZone ?? null,
+    };
+  }
+  return { date: null, isAllDay: false, timezone: null };
+}
+
+function toExternalEvent(ev: calendar_v3.Schema$Event): ExternalEvent | null {
+  if (!ev.id) return null;
+  const startInfo = parseDate(ev.start);
+  const endInfo = parseDate(ev.end);
+  if (!startInfo.date || !endInfo.date) return null;
+  return {
+    externalEventId: ev.id,
+    title: ev.summary ?? "(제목 없음)",
+    startTime: startInfo.date,
+    endTime: endInfo.date,
+    isAllDay: startInfo.isAllDay,
+    locationText: ev.location ?? null,
+    description: ev.description ?? null,
+    startTimezone: startInfo.timezone,
+    endTimezone: endInfo.timezone,
+  };
+}
+
+export const googleImportFetcher: ExternalCalendarFetcher = {
+  provider: "GOOGLE",
+
+  async isConnected(userId: string): Promise<boolean> {
+    const client = await getCalendarClient(userId);
+    return client !== null;
+  },
+
+  async listCalendars(userId: string): Promise<ExternalCalendarRef[]> {
+    const client = await getCalendarClient(userId);
+    if (!client) return [];
+    const managed = await loadManagedCalendarIds(userId);
+    const res = await client.calendar.calendarList.list({
+      maxResults: 250,
+      showHidden: false,
+    });
+    const items = res.data.items ?? [];
+    return items
+      .filter((c) => Boolean(c.id))
+      .map((c) => {
+        const calendarId = c.id as string;
+        return {
+          provider: "GOOGLE" as const,
+          externalCalendarId: calendarId,
+          displayName: c.summaryOverride ?? c.summary ?? null,
+          accountLabel: null,
+          isManagedByTripPlanner: managed.has(calendarId),
+        };
+      });
+  },
+
+  async listEvents(
+    userId: string,
+    externalCalendarId: string,
+    range: DateRange,
+  ): Promise<ExternalEvent[]> {
+    const client = await getCalendarClient(userId);
+    if (!client) return [];
+    const events: ExternalEvent[] = [];
+    let pageToken: string | undefined;
+    do {
+      const res = await client.calendar.events.list({
+        calendarId: externalCalendarId,
+        timeMin: range.start.toISOString(),
+        timeMax: range.end.toISOString(),
+        singleEvents: true, // 반복 일정 인스턴스 전개
+        maxResults: EVENTS_PAGE_SIZE,
+        pageToken,
+      });
+      const items = res.data.items ?? [];
+      for (const ev of items) {
+        const mapped = toExternalEvent(ev);
+        if (mapped) events.push(mapped);
+        if (events.length >= MAX_EVENTS_PER_IMPORT) break;
+      }
+      pageToken = res.data.nextPageToken ?? undefined;
+    } while (pageToken && events.length < MAX_EVENTS_PER_IMPORT);
+    return events;
+  },
+};

--- a/src/lib/calendar-import/ics-parser.ts
+++ b/src/lib/calendar-import/ics-parser.ts
@@ -1,0 +1,168 @@
+/**
+ * spec 027 — 간이 ICS(VEVENT) 파서.
+ *
+ * Apple CalDAV가 반환하는 ICS 문자열에서 외부 import에 필요한 필드만 추출한다.
+ * RFC 5545 전체 호환은 의도하지 않으며, 의존성 0으로 유지하기 위해 직접 작성.
+ * - line unfolding (CRLF + " " or TAB 접두로 이어지는 다음 줄을 합침)
+ * - VEVENT 블록 1건만 추출 (반복 일정 인스턴스 전개는 tsdav timeRange로 처리)
+ * - DTSTART/DTEND/SUMMARY/LOCATION/DESCRIPTION/UID/TZID/VALUE=DATE 만 처리
+ *
+ * 더 복잡한 ICS(반복 규칙, 첨부 등)는 본 마일스톤 스코프 외 — Apple도 timeRange로
+ * 인스턴스 전개된 ICS만 받는다.
+ */
+
+import type { ExternalEvent } from "./types";
+
+interface VEventFields {
+  uid?: string;
+  summary?: string;
+  description?: string;
+  location?: string;
+  dtstart?: { value: string; tzid?: string; isDate?: boolean };
+  dtend?: { value: string; tzid?: string; isDate?: boolean };
+}
+
+function unfold(raw: string): string[] {
+  // RFC 5545 §3.1: CRLF + (SPACE or TAB) → continuation. \n도 허용.
+  const lines = raw.replace(/\r\n/g, "\n").split("\n");
+  const out: string[] = [];
+  for (const line of lines) {
+    if ((line.startsWith(" ") || line.startsWith("\t")) && out.length > 0) {
+      out[out.length - 1] += line.slice(1);
+    } else {
+      out.push(line);
+    }
+  }
+  return out;
+}
+
+function unescapeText(s: string): string {
+  return s
+    .replace(/\\n/gi, "\n")
+    .replace(/\\,/g, ",")
+    .replace(/\\;/g, ";")
+    .replace(/\\\\/g, "\\");
+}
+
+/** "YYYYMMDDTHHmmssZ" / "YYYYMMDDTHHmmss" / "YYYYMMDD" → Date. */
+function parseIcsTimestamp(value: string, tzid: string | undefined, isDate: boolean): {
+  date: Date;
+  timezone: string | null;
+  isAllDay: boolean;
+} | null {
+  if (isDate || /^\d{8}$/.test(value)) {
+    const m = value.match(/^(\d{4})(\d{2})(\d{2})$/);
+    if (!m) return null;
+    return {
+      date: new Date(`${m[1]}-${m[2]}-${m[3]}T00:00:00Z`),
+      timezone: null,
+      isAllDay: true,
+    };
+  }
+  const m = value.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})(Z?)$/);
+  if (!m) return null;
+  const [, y, mo, d, hh, mm, ss, z] = m;
+  if (z === "Z") {
+    return {
+      date: new Date(`${y}-${mo}-${d}T${hh}:${mm}:${ss}Z`),
+      timezone: tzid ?? "UTC",
+      isAllDay: false,
+    };
+  }
+  // floating-time 또는 TZID: Date 객체는 UTC 기준 ISO로 일단 저장하고 timezone 별도 보관
+  // (저장 정확도는 사용자가 승격 시 timezone을 정확히 지정해야 함)
+  return {
+    date: new Date(`${y}-${mo}-${d}T${hh}:${mm}:${ss}Z`),
+    timezone: tzid ?? null,
+    isAllDay: false,
+  };
+}
+
+function parseVeventBlock(lines: string[]): VEventFields {
+  const fields: VEventFields = {};
+  for (const line of lines) {
+    const colon = line.indexOf(":");
+    if (colon < 0) continue;
+    const left = line.slice(0, colon);
+    const value = line.slice(colon + 1);
+    const [name, ...paramParts] = left.split(";");
+    const params = new Map<string, string>();
+    for (const p of paramParts) {
+      const eq = p.indexOf("=");
+      if (eq > 0) params.set(p.slice(0, eq).toUpperCase(), p.slice(eq + 1));
+    }
+    const upper = name.toUpperCase();
+    switch (upper) {
+      case "UID":
+        fields.uid = value.trim();
+        break;
+      case "SUMMARY":
+        fields.summary = unescapeText(value);
+        break;
+      case "DESCRIPTION":
+        fields.description = unescapeText(value);
+        break;
+      case "LOCATION":
+        fields.location = unescapeText(value);
+        break;
+      case "DTSTART":
+        fields.dtstart = {
+          value,
+          tzid: params.get("TZID"),
+          isDate: params.get("VALUE")?.toUpperCase() === "DATE",
+        };
+        break;
+      case "DTEND":
+        fields.dtend = {
+          value,
+          tzid: params.get("TZID"),
+          isDate: params.get("VALUE")?.toUpperCase() === "DATE",
+        };
+        break;
+    }
+  }
+  return fields;
+}
+
+/** ICS 문자열 1건에서 ExternalEvent 추출. 실패 시 null. */
+export function parseVevent(
+  ics: string,
+  fallbackExternalEventId?: string,
+): ExternalEvent | null {
+  const lines = unfold(ics);
+  let inVevent = false;
+  const veventLines: string[] = [];
+  for (const line of lines) {
+    if (line.toUpperCase().startsWith("BEGIN:VEVENT")) {
+      inVevent = true;
+      continue;
+    }
+    if (line.toUpperCase().startsWith("END:VEVENT")) {
+      inVevent = false;
+      break;
+    }
+    if (inVevent) veventLines.push(line);
+  }
+  if (veventLines.length === 0) return null;
+  const f = parseVeventBlock(veventLines);
+  if (!f.dtstart || !f.dtend) return null;
+
+  const start = parseIcsTimestamp(f.dtstart.value, f.dtstart.tzid, f.dtstart.isDate ?? false);
+  const end = parseIcsTimestamp(f.dtend.value, f.dtend.tzid, f.dtend.isDate ?? false);
+  if (!start || !end) return null;
+
+  const externalEventId = f.uid ?? fallbackExternalEventId;
+  if (!externalEventId) return null;
+
+  return {
+    externalEventId,
+    title: f.summary ?? "(제목 없음)",
+    startTime: start.date,
+    endTime: end.date,
+    isAllDay: start.isAllDay,
+    locationText: f.location ?? null,
+    description: f.description ?? null,
+    startTimezone: start.timezone,
+    endTimezone: end.timezone,
+  };
+}

--- a/src/lib/calendar-import/idempotency.ts
+++ b/src/lib/calendar-import/idempotency.ts
@@ -1,0 +1,55 @@
+/**
+ * spec 027 — 외부 이벤트 import 멱등성.
+ *
+ * 같은 (provider, externalCalendarId, externalEventId)는 한 번만 draft 생성.
+ * 어플리케이션 lookup + DB 유니크 인덱스 이중 안전망.
+ */
+
+import type { CalendarProviderId, Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+
+export interface DraftKey {
+  provider: CalendarProviderId;
+  externalCalendarId: string;
+  externalEventId: string;
+}
+
+/** 같은 키의 기존 draft id를 외부 식별자 셋으로 조회. */
+export async function findExistingDraftIds(args: {
+  provider: CalendarProviderId;
+  externalCalendarId: string;
+  externalEventIds: string[];
+}): Promise<Set<string>> {
+  if (args.externalEventIds.length === 0) return new Set();
+  const existing = await prisma.activityDraft.findMany({
+    where: {
+      provider: args.provider,
+      externalCalendarId: args.externalCalendarId,
+      externalEventId: { in: args.externalEventIds },
+    },
+    select: { externalEventId: true },
+  });
+  return new Set(existing.map((r) => r.externalEventId));
+}
+
+/** Prisma `P2002` 유니크 제약 위반 여부. race fallback 판정에 사용. */
+export function isUniqueConstraintError(err: unknown): boolean {
+  if (err && typeof err === "object" && "code" in err) {
+    return (err as { code?: string }).code === "P2002";
+  }
+  return false;
+}
+
+/** 유니크 제약 위반 시 무시할 때 쓰는 헬퍼. 그 외 에러는 재throw. */
+export async function ignoreUniqueViolation<T>(
+  op: () => Promise<T>,
+): Promise<T | null> {
+  try {
+    return await op();
+  } catch (err) {
+    if (isUniqueConstraintError(err)) return null;
+    throw err;
+  }
+}
+
+export type { Prisma };

--- a/src/lib/calendar-import/mapper.ts
+++ b/src/lib/calendar-import/mapper.ts
@@ -1,0 +1,47 @@
+/**
+ * spec 027 — 외부 이벤트 → ActivityDraft 매핑.
+ *
+ * 매핑 가능 필드(title, startTime, endTime, isAllDay, locationText, description, timezone)만
+ * 옮긴다. activity category, hotel·attraction 참조, reservation status는 사용자가 승격 단계에서 입력.
+ */
+
+import type { Prisma, CalendarProviderId } from "@prisma/client";
+import type { ExternalEvent } from "./types";
+
+export interface MapToDraftInput {
+  tripId: number;
+  provider: CalendarProviderId;
+  externalCalendarId: string;
+  importRunId: number;
+  event: ExternalEvent;
+}
+
+/** 외부 이벤트 1건을 ActivityDraft create input으로 변환. */
+export function mapExternalEvent(
+  input: MapToDraftInput,
+): Prisma.ActivityDraftUncheckedCreateInput {
+  const { event } = input;
+  return {
+    tripId: input.tripId,
+    provider: input.provider,
+    externalCalendarId: input.externalCalendarId,
+    externalEventId: event.externalEventId,
+    title: event.title,
+    startTime: event.startTime,
+    endTime: event.endTime,
+    isAllDay: event.isAllDay,
+    locationText: event.locationText,
+    description: event.description,
+    startTimezone: event.startTimezone,
+    endTimezone: event.endTimezone,
+    importRunId: input.importRunId,
+  };
+}
+
+/** 외부 이벤트가 trip 기간(닫힌 구간)과 겹치는지 판정. */
+export function overlapsTrip(
+  event: ExternalEvent,
+  trip: { startDate: Date; endDate: Date },
+): boolean {
+  return event.endTime >= trip.startDate && event.startTime <= trip.endDate;
+}

--- a/src/lib/calendar-import/promotion.ts
+++ b/src/lib/calendar-import/promotion.ts
@@ -1,0 +1,99 @@
+/**
+ * spec 027 US2 — ActivityDraft → 정식 Activity 승격.
+ *
+ * 필수 입력: activity category, reservation status, start/end timezone (IANA).
+ * draft.dayId 가 있으면 그대로, 없으면 startTime의 일자에 매칭되는 Day를 찾는다.
+ * 매칭되는 Day가 trip에 없으면 신규 생성(spec 010 day expansion 정책 호환).
+ */
+
+import type {
+  ActivityCategory,
+  Prisma,
+  ReservationStatus,
+} from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+
+export interface PromoteInput {
+  draftId: number;
+  tripId: number;
+  category: ActivityCategory;
+  reservationStatus: ReservationStatus;
+  startTimezone: string;
+  endTimezone: string;
+  location?: string | null;
+}
+
+export class DraftNotPromotableError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+function startOfUtcDay(d: Date): Date {
+  const x = new Date(d);
+  x.setUTCHours(0, 0, 0, 0);
+  return x;
+}
+
+export async function promoteDraft(input: PromoteInput): Promise<{ activityId: number }> {
+  const draft = await prisma.activityDraft.findFirst({
+    where: { id: input.draftId, tripId: input.tripId },
+  });
+  if (!draft) throw new DraftNotPromotableError("draft_not_found");
+  if (draft.status !== "PENDING") {
+    throw new DraftNotPromotableError("draft_not_pending");
+  }
+
+  const trip = await prisma.trip.findUnique({
+    where: { id: input.tripId },
+    select: { startDate: true, endDate: true },
+  });
+  if (!trip) throw new DraftNotPromotableError("trip_not_found");
+
+  // Day 매칭/생성
+  const dayDate = startOfUtcDay(draft.startTime);
+  let dayId = draft.dayId;
+  if (!dayId) {
+    const existing = await prisma.day.findUnique({
+      where: { tripId_date: { tripId: input.tripId, date: dayDate } },
+      select: { id: true },
+    });
+    if (existing) {
+      dayId = existing.id;
+    } else {
+      const created = await prisma.day.create({
+        data: { tripId: input.tripId, date: dayDate },
+        select: { id: true },
+      });
+      dayId = created.id;
+    }
+  }
+
+  const finalDayId = dayId;
+
+  return prisma.$transaction(async (tx) => {
+    const activity = await tx.activity.create({
+      data: {
+        dayId: finalDayId,
+        category: input.category,
+        title: draft.title,
+        startTime: draft.startTime,
+        startTimezone: input.startTimezone,
+        endTime: draft.endTime,
+        endTimezone: input.endTimezone,
+        location: input.location ?? draft.locationText,
+        memo: draft.description,
+        reservationStatus: input.reservationStatus,
+      } satisfies Prisma.ActivityUncheckedCreateInput,
+    });
+    await tx.activityDraft.update({
+      where: { id: draft.id },
+      data: {
+        status: "PROMOTED",
+        promotedToActivityId: activity.id,
+        dayId: finalDayId,
+      },
+    });
+    return { activityId: activity.id };
+  });
+}

--- a/src/lib/calendar-import/service.ts
+++ b/src/lib/calendar-import/service.ts
@@ -1,0 +1,237 @@
+/**
+ * spec 027 — 외부 캘린더 import 오케스트레이터.
+ *
+ * 1) fetcher.listEvents(trip 기간)
+ * 2) 기존 draft 조회(멱등성)
+ * 3) 신규 이벤트만 매핑 → draft create
+ * 4) ImportRun 결과 기록
+ *
+ * 이벤트별 try/catch로 부분 실패 허용. 실패 이벤트의 title 첫 3건만 응답에 노출(privacy).
+ */
+
+import type { CalendarProviderId } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { googleImportFetcher } from "./google";
+import { appleImportFetcher } from "./apple";
+import { findExistingDraftIds, ignoreUniqueViolation } from "./idempotency";
+import { mapExternalEvent, overlapsTrip } from "./mapper";
+import type {
+  ExternalCalendarFetcher,
+  ExternalEvent,
+  ImportResult,
+} from "./types";
+
+const FAILED_TITLES_LIMIT = 3;
+
+export class ExternalAccountNotLinkedError extends Error {
+  constructor(public readonly provider: CalendarProviderId) {
+    super(`External account for provider ${provider} is not linked`);
+  }
+}
+
+function getFetcher(provider: CalendarProviderId): ExternalCalendarFetcher {
+  switch (provider) {
+    case "GOOGLE":
+      return googleImportFetcher;
+    case "APPLE":
+      return appleImportFetcher;
+    default: {
+      const _exhaustive: never = provider;
+      throw new Error(`Unknown provider: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+export interface RunImportArgs {
+  tripId: number;
+  triggeredByUserId: string;
+  provider: CalendarProviderId;
+  externalCalendarId: string;
+}
+
+/** 외부 캘린더 → trip draft import 실행. 권한 검증은 호출자(라우트)가 끝낸 상태. */
+export async function runImport(args: RunImportArgs): Promise<ImportResult> {
+  const fetcher = getFetcher(args.provider);
+
+  // 1) 외부 계정 연결 확인
+  const connected = await fetcher.isConnected(args.triggeredByUserId);
+  if (!connected) {
+    throw new ExternalAccountNotLinkedError(args.provider);
+  }
+
+  // 2) trip 기간 조회
+  const trip = await prisma.trip.findUnique({
+    where: { id: args.tripId },
+    select: { startDate: true, endDate: true },
+  });
+  if (!trip) {
+    throw new Error(`Trip ${args.tripId} not found`);
+  }
+
+  // 3) ImportRun 헤더 먼저 생성 (draft FK 참조 대상)
+  const importRun = await prisma.importRun.create({
+    data: {
+      tripId: args.tripId,
+      triggeredByUserId: args.triggeredByUserId,
+      provider: args.provider,
+      externalCalendarId: args.externalCalendarId,
+    },
+  });
+
+  let externalEvents: ExternalEvent[] = [];
+  try {
+    externalEvents = await fetcher.listEvents(
+      args.triggeredByUserId,
+      args.externalCalendarId,
+      { start: trip.startDate, end: trip.endDate },
+    );
+  } catch (err) {
+    await prisma.importRun.update({
+      where: { id: importRun.id },
+      data: { finishedAt: new Date(), failedCount: 1 },
+    });
+    throw err;
+  }
+
+  // 4) trip 기간 필터(추가 안전망 — fetcher가 timeMin/timeMax를 정확히 처리한다 가정)
+  const candidates = externalEvents.filter((ev) =>
+    overlapsTrip(ev, { startDate: trip.startDate, endDate: trip.endDate }),
+  );
+
+  // 5) 이미 import된 이벤트 식별
+  const existingIds = await findExistingDraftIds({
+    provider: args.provider,
+    externalCalendarId: args.externalCalendarId,
+    externalEventIds: candidates.map((c) => c.externalEventId),
+  });
+
+  let importedCount = 0;
+  let skippedCount = 0;
+  let failedCount = 0;
+  const failedTitles: string[] = [];
+
+  for (const ev of candidates) {
+    if (existingIds.has(ev.externalEventId)) {
+      skippedCount += 1;
+      continue;
+    }
+    try {
+      const created = await ignoreUniqueViolation(() =>
+        prisma.activityDraft.create({
+          data: mapExternalEvent({
+            tripId: args.tripId,
+            provider: args.provider,
+            externalCalendarId: args.externalCalendarId,
+            importRunId: importRun.id,
+            event: ev,
+          }),
+        }),
+      );
+      if (created) {
+        importedCount += 1;
+      } else {
+        // race로 다른 동시 import가 같은 키 draft를 만든 케이스
+        skippedCount += 1;
+      }
+    } catch (err) {
+      failedCount += 1;
+      if (failedTitles.length < FAILED_TITLES_LIMIT) {
+        failedTitles.push(ev.title);
+      }
+      console.warn(
+        `[calendar-import] failed event tripId=${args.tripId} externalEventId=${ev.externalEventId} reason=${(err as Error).message}`,
+      );
+    }
+  }
+
+  await prisma.importRun.update({
+    where: { id: importRun.id },
+    data: {
+      importedCount,
+      skippedCount,
+      failedCount,
+      failedTitles,
+      finishedAt: new Date(),
+    },
+  });
+
+  return {
+    importRunId: importRun.id,
+    importedCount,
+    skippedCount,
+    failedCount,
+    failedTitles,
+  };
+}
+
+/** 사용자의 외부 계정에서 import 가능한 캘린더 목록(trip-planner 관리 캘린더 제외). */
+export async function listAvailableExternalCalendars(userId: string) {
+  const fetchers: ExternalCalendarFetcher[] = [googleImportFetcher, appleImportFetcher];
+  const results = await Promise.all(
+    fetchers.map(async (f) => {
+      if (!(await f.isConnected(userId))) return [];
+      try {
+        return await f.listCalendars(userId);
+      } catch (err) {
+        console.warn(
+          `[calendar-import] listCalendars failed provider=${f.provider} reason=${(err as Error).message}`,
+        );
+        return [];
+      }
+    }),
+  );
+  return results.flat().filter((c) => !c.isManagedByTripPlanner);
+}
+
+/** "다시 가져오기" — 매핑 가능 필드만 외부 최신 값으로 덮어쓰기. */
+export class DraftRefreshConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+export async function refreshDraft(args: {
+  tripId: number;
+  draftId: number;
+  triggeredByUserId: string;
+}): Promise<{ refreshed: boolean }> {
+  const draft = await prisma.activityDraft.findFirst({
+    where: { id: args.draftId, tripId: args.tripId },
+  });
+  if (!draft) throw new Error("draft_not_found");
+  if (draft.status !== "PENDING") {
+    throw new DraftRefreshConflictError("draft is not PENDING");
+  }
+  const fetcher = getFetcher(draft.provider);
+  if (!(await fetcher.isConnected(args.triggeredByUserId))) {
+    throw new ExternalAccountNotLinkedError(draft.provider);
+  }
+  const trip = await prisma.trip.findUnique({
+    where: { id: draft.tripId },
+    select: { startDate: true, endDate: true },
+  });
+  if (!trip) throw new Error("trip_not_found");
+
+  const events = await fetcher.listEvents(
+    args.triggeredByUserId,
+    draft.externalCalendarId,
+    { start: trip.startDate, end: trip.endDate },
+  );
+  const fresh = events.find((e) => e.externalEventId === draft.externalEventId);
+  if (!fresh) return { refreshed: false };
+
+  await prisma.activityDraft.update({
+    where: { id: draft.id },
+    data: {
+      title: fresh.title,
+      startTime: fresh.startTime,
+      endTime: fresh.endTime,
+      isAllDay: fresh.isAllDay,
+      locationText: fresh.locationText,
+      description: fresh.description,
+      lastRefreshedAt: new Date(),
+      // 매핑 불가 필드(startTimezone, endTimezone)는 사용자 입력 보존을 위해 덮어쓰지 않음
+    },
+  });
+  return { refreshed: true };
+}

--- a/src/lib/calendar-import/types.ts
+++ b/src/lib/calendar-import/types.ts
@@ -1,0 +1,68 @@
+/**
+ * spec 027 — 외부 캘린더 import 도메인 타입.
+ *
+ * Provider별 fetch 어댑터(google.ts, apple.ts)가 만족해야 하는 인터페이스.
+ * spec 024 push 방향 `CalendarProvider`와는 별개로, pull 방향만 다룬다.
+ * 어댑터는 라우트 권한 검증을 통과한 호출만 받는다.
+ */
+
+import type { CalendarProviderId } from "@prisma/client";
+
+/** 외부 캘린더 1건 (사용자 자산). */
+export interface ExternalCalendarRef {
+  provider: CalendarProviderId;
+  externalCalendarId: string;
+  displayName: string | null;
+  /** 어느 사용자 계정에 속하는지(예: "user@gmail.com"). 표시용. */
+  accountLabel: string | null;
+  /** trip-planner가 만든 캘린더인지. 본값 true면 import 대상에서 제외. */
+  isManagedByTripPlanner: boolean;
+}
+
+/** 외부 이벤트 1건 (raw — 매퍼가 ActivityDraft로 변환). */
+export interface ExternalEvent {
+  externalEventId: string;
+  title: string;
+  /** UTC 또는 timezone 명시된 시각. all-day면 일자 00:00. */
+  startTime: Date;
+  endTime: Date;
+  isAllDay: boolean;
+  locationText: string | null;
+  description: string | null;
+  /** IANA timezone. null이면 floating-time(승격 시 사용자 입력). */
+  startTimezone: string | null;
+  endTimezone: string | null;
+}
+
+/** 외부 이벤트 조회 시간 범위. trip 기간으로 좁힌다. */
+export interface DateRange {
+  start: Date;
+  end: Date;
+}
+
+/** 외부 캘린더 fetcher — provider별 구현체가 만족. */
+export interface ExternalCalendarFetcher {
+  readonly provider: CalendarProviderId;
+
+  /** 사용자가 외부 계정 연결을 보유한 상태인지. false면 미연결로 안내. */
+  isConnected(userId: string): Promise<boolean>;
+
+  /** 사용자가 외부 계정에 가진 캘린더 목록(trip-planner 관리 캘린더는 자동 제외 가능). */
+  listCalendars(userId: string): Promise<ExternalCalendarRef[]>;
+
+  /** 캘린더 1개의 trip 기간 내 이벤트들. 반복 일정은 인스턴스 전개 후 반환. */
+  listEvents(
+    userId: string,
+    externalCalendarId: string,
+    range: DateRange,
+  ): Promise<ExternalEvent[]>;
+}
+
+/** import 1회 실행 결과. service.runImport 반환값. */
+export interface ImportResult {
+  importRunId: number;
+  importedCount: number;
+  skippedCount: number;
+  failedCount: number;
+  failedTitles: string[];
+}

--- a/src/lib/permissions/activity.ts
+++ b/src/lib/permissions/activity.ts
@@ -1,0 +1,31 @@
+/**
+ * spec 027 — Activity / ActivityDraft 관련 권한 헬퍼.
+ *
+ * 헌법 VI Permission Matrix(ADR 0006)에서 정의한 행위 단위 권한 함수를 모아둔다.
+ * 정책 변경 시 본 파일과 헌법 매트릭스, ADR 0006 표를 함께 갱신.
+ *
+ * - 외부 캘린더 import: OWNER·HOST O, GUEST X (일정 편집과 동일 클래스)
+ * - draft 승격 / 다시 가져오기 / 삭제: 동일 클래스
+ *
+ * 본 헬퍼는 순수 함수(역할 기반)와 DB 조회 헬퍼를 분리한다.
+ * - 순수 함수: 단위 테스트·UI 사전 비활성화에 사용
+ * - DB 헬퍼: API route에서 호출 (DB 정본 검증)
+ */
+import { prisma } from "@/lib/prisma";
+import type { TripRole } from "@prisma/client";
+
+const EDIT_ROLES: TripRole[] = ["OWNER", "HOST"];
+
+/** 외부 캘린더 import / draft 관리 권한 (순수 함수). */
+export function canImportCalendar(role: TripRole | null | undefined): boolean {
+  if (!role) return false;
+  return EDIT_ROLES.includes(role);
+}
+
+/** DB 조회 헬퍼. trip 비멤버면 false. */
+export async function userCanImportCalendar(tripId: number, userId: string): Promise<boolean> {
+  const member = await prisma.tripMember.findUnique({
+    where: { tripId_userId: { tripId, userId } },
+  });
+  return canImportCalendar(member?.role);
+}


### PR DESCRIPTION
Closes #527

## What

사용자가 본인의 다른 캘린더(Google 또는 Apple CalDAV)에 이미 쌓아둔 일정을 trip-planner의 `ActivityDraft`로 가져오는 수동 import 흐름을 추가했다.

- trip 상세 사이드 패널의 "외부 캘린더에서 일정 가져오기" → 캘린더 1개 선택 → import 실행
- 매핑 가능 필드(제목·시간·장소 문자열·설명·종일 여부·timezone)만 자동 채움
- 매핑 불가 필드(category, reservation status, timezone)는 사용자가 승격 단계에서 입력
- 같은 (provider, externalCalendarId, externalEventId)는 한 번만 draft 생성(멱등성)

## Why

사용자가 trip-planner 밖 캘린더에 이미 쌓아둔 여행 일정을 다시 입력하지 않고 가져오기 위해. ADR 0006 외부 → 내부 단방향 정책. trip 캘린더 정본(ADR 0003)은 변경 없음.

## Scope

- **US1 (P1, MVP)**: import → draft 목록 표시
- **US2 (P2)**: draft → 정식 Activity 승격
- **US3 (P3)**: 멱등성 + "다시 가져오기" + 삭제

## 신규/변경 파일

- 신규 모델: `ActivityDraft`, `ImportRun` + enum `ActivityDraftStatus`. 마이그레이션 `20260527000000_add_activity_draft` (schema-only).
- 신규 디렉토리: `src/lib/calendar-import/`, `src/components/calendar-import/`, `src/lib/permissions/`
- 신규 엔드포인트: 5종
  - `POST /api/trips/<id>/calendar-import`
  - `GET /api/users/me/external-calendars`
  - `GET /api/trips/<id>/drafts`
  - `POST /api/trips/<id>/drafts/<draftId>/promote`
  - `POST /api/trips/<id>/drafts/<draftId>/refresh`
  - `DELETE /api/trips/<id>/drafts/<draftId>`
- SidePanel 통합: `CalendarImportPanel` + `DraftListPanel`
- ADR 0006 신규
- 단편: `changes/527.feat.md`

## 권한 (헌법 VI 매트릭스 추가)

| 행위 | OWNER | HOST | GUEST |
|------|-------|------|-------|
| 외부 캘린더 import | O | O | X |
| draft 승격(=Activity 생성) | O | O | X |
| draft "다시 가져오기" | O | O | X |
| draft 삭제 | O | O | X |

헌법 본문 매트릭스 정식 갱신은 별도 patch PR로 분리.

## Test Plan

- [ ] dev.trip.idean.me 머지 후 자동 배포 확인
- [ ] 본인 Google 계정의 다른 캘린더에 trip 기간 내 이벤트 3건 생성 후 import 실행 → draft 3건 표시 + 토스트 카운트
- [ ] 같은 import 재실행 → draft 수 그대로(skip 카운트만 증가)
- [ ] draft 클릭 → 승격 모달 → 필수 필드 입력 → 정식 Activity 전환 확인
- [ ] draft 컨텍스트 메뉴 → "다시 가져오기" → title·time 갱신, timezone 보존
- [ ] draft 컨텍스트 메뉴 → "삭제" → 행 사라짐, 외부 캘린더는 그대로
- [ ] GUEST 권한 사용자에서 import 트리거 안 보이거나 403 응답