### PR TITLE
fix(547): draft 0건 시 DraftSection 숨김

### DIFF
--- a/changes/547.fix.md
+++ b/changes/547.fix.md
@@ -1,0 +1,1 @@
+- **다이얼로그 — draft 0건 빈 상태 섹션 숨김**. 왜: v2.16.2에서 "외부에서 가져온 일정" 섹션이 draft 0건일 때도 "외부 캘린더에서 가져온 초안이 아직 없습니다…" 안내로 노출돼 다이얼로그·trip 페이지에 노이즈가 됐다. `<details>` summary가 이미 가져오기 진입점을 안내하므로 중복. drafts 0건이면 DraftSection 자체 숨김. ([#547](https://github.com/idean3885/trip-planner/issues/547))

--- a/src/components/calendar-sync/sections/DraftSection.tsx
+++ b/src/components/calendar-sync/sections/DraftSection.tsx
@@ -207,16 +207,10 @@ export default function DraftSection({ tripId, canEdit, onMutated }: Props) {
     return null;
   }
 
+  // draft 0건이면 섹션 자체를 숨긴다. 다이얼로그의 <details> summary가 이미
+  // 가져오기 진입점을 안내하므로 빈 상태 안내는 중복 노이즈.
   if (!drafts || drafts.length === 0) {
-    if (!canEdit) return null;
-    return (
-      <section>
-        <h4 className="mb-2 text-sm font-semibold">외부에서 가져온 일정</h4>
-        <p className="text-xs text-muted-foreground">
-          외부 캘린더에서 가져온 초안이 아직 없습니다. 위 가져오기 섹션에서 시작하세요.
-        </p>
-      </section>
-    );
+    return null;
   }
 
   return (


### PR DESCRIPTION
Closes #547

draft 0건일 때 빈 상태 안내가 다이얼로그·trip 페이지에 노이즈로 보이던 결함. `<details>` summary가 이미 가져오기 진입점을 안내하므로 중복. drafts 0건이면 섹션 자체 숨김.