### PR TITLE
fix: Apple 연결 안내 링크 6곳 dead URL 정정

### DIFF
--- a/changes/555.fix.md
+++ b/changes/555.fix.md
@@ -1,0 +1,1 @@
+**Apple 연결 안내 링크 6곳**을 trip 단위 진입점(`/trips/<id>/calendar/connect-apple`)으로 정정. 왜: 기존 `/settings/calendars` URL은 존재하지 않아 클릭 시 404로 떨어졌고, 사용자가 Apple 등록 경로에 도달하지 못했다.

--- a/src/app/api/trips/[id]/calendar-import/route.ts
+++ b/src/app/api/trips/[id]/calendar-import/route.ts
@@ -70,7 +70,7 @@ export async function POST(request: Request, { params }: Params) {
         {
           error: "external_account_not_linked",
           message: "캘린더 계정을 먼저 연결하세요.",
-          settingsPath: "/settings/calendars",
+          settingsPath: `/trips/${tripId}/calendar/connect-apple`,
         },
         { status: 409 },
       );

--- a/src/app/api/trips/[id]/drafts/[draftId]/refresh/route.ts
+++ b/src/app/api/trips/[id]/drafts/[draftId]/refresh/route.ts
@@ -45,7 +45,7 @@ export async function POST(_request: Request, { params }: Params) {
     }
     if (err instanceof ExternalAccountNotLinkedError) {
       return NextResponse.json(
-        { error: "external_account_not_linked", settingsPath: "/settings/calendars" },
+        { error: "external_account_not_linked", settingsPath: `/trips/${tripId}/calendar/connect-apple` },
         { status: 409 },
       );
     }

--- a/src/components/calendar-import/CalendarImportPanel.tsx
+++ b/src/components/calendar-import/CalendarImportPanel.tsx
@@ -117,11 +117,11 @@ export default function CalendarImportPanel({
 
       if (res.status === 409 && body?.error === "external_account_not_linked") {
         toast.error("캘린더 계정 미연결", {
-          description: "설정에서 외부 캘린더 계정을 먼저 연결하세요.",
+          description: "외부 캘린더 계정을 먼저 연결하세요.",
           action: {
-            label: "설정 열기",
+            label: "연결하기",
             onClick: () => {
-              window.location.href = body.settingsPath ?? "/settings/calendars";
+              window.location.href = body.settingsPath ?? `/trips/${tripId}/calendar/connect-apple`;
             },
           },
         });
@@ -211,10 +211,10 @@ export default function CalendarImportPanel({
                     Google 또는 Apple 캘린더 계정을 trip-planner에 먼저 연결하세요.
                   </p>
                   <a
-                    href="/settings/calendars"
+                    href={`/trips/${tripId}/calendar/connect-apple`}
                     className="inline-flex items-center rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:opacity-90"
                   >
-                    설정 열기
+                    Apple 연결하기
                   </a>
                 </>
               ) : hasManaged ? (

--- a/src/components/calendar-sync/sections/ImportSection.tsx
+++ b/src/components/calendar-sync/sections/ImportSection.tsx
@@ -106,11 +106,11 @@ export default function ImportSection({ tripId, role, onImported }: Props) {
       const body = await res.json().catch(() => ({}));
       if (res.status === 409 && body?.error === "external_account_not_linked") {
         toast.error("캘린더 계정 미연결", {
-          description: "설정에서 외부 캘린더 계정을 먼저 연결하세요.",
+          description: "외부 캘린더 계정을 먼저 연결하세요.",
           action: {
-            label: "설정 열기",
+            label: "연결하기",
             onClick: () => {
-              window.location.href = body.settingsPath ?? "/settings/calendars";
+              window.location.href = body.settingsPath ?? `/trips/${tripId}/calendar/connect-apple`;
             },
           },
         });
@@ -185,13 +185,13 @@ export default function ImportSection({ tripId, role, onImported }: Props) {
             <div className="space-y-2 rounded-md border p-3 text-sm">
               <p className="font-medium">Apple 캘린더 미연결</p>
               <p className="text-xs text-muted-foreground">
-                Apple은 OAuth를 지원하지 않습니다. 설정에서 Apple ID와 앱 비밀번호를 등록하세요.
+                Apple은 OAuth를 지원하지 않습니다. Apple ID와 앱 비밀번호를 직접 등록하세요.
               </p>
               <a
-                href="/settings/calendars"
+                href={`/trips/${tripId}/calendar/connect-apple`}
                 className="inline-flex items-center rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:opacity-90"
               >
-                Apple 연결 설정
+                Apple 연결하기
               </a>
             </div>
           )}


### PR DESCRIPTION
## 작업 내용

`/settings/calendars` URL은 라우트가 존재하지 않아(404) Apple 등록 진입점으로 안내된 링크 6곳이 모두 죽어 있었다. 실제 Apple 등록 페이지는 trip 단위인 `/trips/[id]/calendar/connect-apple`(`AppleConnectWizard`)이다. 6곳 모두 trip URL로 교체.

v2.16.4(#551)에서 추가한 Apple 안내 카드의 dead link도 함께 정정.

## 변경 사항

- `ImportSection`: Apple 카드 `href`, toast action fallback
- `CalendarImportPanel` (v2.16.0 deprecated): notConnected 안내 `href`, toast action fallback
- `POST /api/trips/[id]/calendar-import`: 409 응답 `settingsPath` 필드값
- `POST /api/trips/[id]/drafts/[draftId]/refresh`: 409 응답 `settingsPath` 필드값

응답 필드명 `settingsPath`는 사용자 정의 계약이라 그대로 유지(BC), 값만 trip 경로로 변경.

## 자가 검증

| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ✅ 통과 | `tsc --noEmit` 에러 0 |
| 테스트 | ⬜ 해당없음 | 링크 문자열 교체. 기존 테스트 영향 없음 |
| 문서 동기화 | ✅ 완료 | `changes/555.fix.md` 단편 추가 |

## 후속 (스코프 밖)

- `/settings/calendars` 라우트 신설(trip 무관 Apple 등록 페이지) — 별도 이슈
- `CalendarImportPanel` deprecated 컴포넌트 삭제 — 별도 정리 이슈

Closes #555