### PR TITLE
docs: spec 030 — MCP 자동 부트스트랩 산출물

### DIFF
--- a/specs/030-mcp-auto-bootstrap/checklists/requirements.md
+++ b/specs/030-mcp-auto-bootstrap/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: MCP 자동 부트스트랩 — 노터치 설치·인증·업데이트
+
+**Purpose**: 명세 완전성·품질 검증. plan 단계 진입 전에 통과해야 합니다.
+**Created**: 2026-05-28
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain — 2026-05-28 clarify session에서 4개 결정 해소 완료
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+* 2026-05-28 clarify session에서 4개 결정 해소: (1) 인증 = 브라우저 OAuth 1회(gh CLI 패턴), (2) 업데이트 트리거 = startup verify + 호출 실패 감지 + 명시 요청 혼합, (3) 폴백 = 1회 재시도 + 진단 메시지 + 동의 시 이슈 등록, (4) client 범위 = Claude Code 우선·그 외 best-effort.
+* 마일스톤 v3.0.0 묶음 — spec 029(여행 모델 + 캘린더 뷰)와 동시 출시. plan 단계에서 두 spec의 의존성을 정리합니다.
+* CI/CD 환경 인증(PAT fallback)은 본 spec 범위 밖. 필요 시 후속 spec에서 다룹니다.

--- a/specs/030-mcp-auto-bootstrap/contracts/install-cli.md
+++ b/specs/030-mcp-auto-bootstrap/contracts/install-cli.md
@@ -1,0 +1,76 @@
+# Contract — install CLI
+
+## 1줄 진입점
+
+```bash
+curl -fsSL https://trip.idean.me/install | sh
+```
+
+또는 (AI client 자연어 요청 시 AI가 자동 실행):
+
+```bash
+curl -fsSL https://trip.idean.me/install | sh -s -- --auto
+```
+
+## 환경 변수
+
+| 변수 | 용도 | 기본 |
+|------|------|------|
+| `TRIP_PLANNER_INSTALL_DIR` | MCP 서버 설치 경로 | `~/.local/share/trip-planner` |
+| `TRIP_PLANNER_NO_REGISTER` | MCP client 등록 스킵 (수동 등록 케이스) | unset |
+| `TRIP_PLANNER_AUTO` | 사용자 입력 없이 자동 진행 (AI client용) | unset |
+| `TRIP_PLANNER_API_HOST` | API 호스트 override (개발용) | `https://trip.idean.me` |
+
+## 표준 종료 코드 (FR-015)
+
+| 코드 | 의미 | AI client 처리 |
+|------|------|------|
+| 0 | 성공 | "설치 완료" 안내 |
+| 1 | 일반 실패 (네트워크·다운로드·파일 시스템 등) | 진단 메시지 + 1회 재시도 |
+| 2 | 인증 필요 (사용자 브라우저 인증 누락·실패) | "브라우저에서 인증 마쳐주세요" |
+| 3 | 의존성 부족 (Python·uv·Node 미설치 등) | "다음 도구를 설치해주세요" |
+| 4 | OS 미지원 (Windows 등) | "지원되지 않는 환경" 안내 |
+| 5 | 권한 부족 (keychain·파일 쓰기) | 권한 문제 안내 |
+
+## stdout / stderr 출력 형식 (FR-014)
+
+* **stdout**: 사용자 친화 메시지 — "다운로드 중...", "인증 대기 중...", "설치 완료". 한국어
+* **stderr**: 진단 로그 — 명령 출력·에러 trace. 사용자가 일반적으로 안 봄
+
+**평문 비노출 룰**:
+
+* PAT·비밀번호는 어느 stream에도 출력 안 함
+* 진단 로그에서도 PAT은 prefix 8자만 + `...` 마스킹
+* 이메일은 도메인 부분만 노출(`xxx@gmail.com` → `***@gmail.com`)
+
+## 흐름
+
+```text
+$ curl ... | sh
+[1/5] 의존성 확인...
+[2/5] trip-planner-mcp 다운로드...
+[3/5] 인증 — 브라우저가 열립니다. 로그인 후 동의해주세요.
+       (로컬에서 https://trip.idean.me/oauth/authorize?... 자동 열림)
+       (사용자 브라우저 1회 동의)
+       (자동 PAT 발급 + 키체인 저장)
+[4/5] Claude Code에 등록 (claude mcp add -s user trip-planner ...)
+[5/5] 동작 검증 — trip-planner MCP가 list_trips 호출에 응답합니다.
+✓ 설치 완료. Claude에 "trip-planner로 여행 목록 보여줘" 같이 요청해보세요.
+```
+
+## 실패 시 흐름
+
+```text
+$ curl ... | sh
+[3/5] 인증 실패 (사용자가 브라우저 닫음)
+  1회 자동 재시도...
+[3/5] 인증 실패 (재시도 후에도 실패)
+  진단:
+    - listener: localhost:54321 (timeout 60초)
+    - 마지막 콜백 응답 없음
+  다음 행동:
+    1. 브라우저에서 https://trip.idean.me 로그인 상태 확인
+    2. 다시 시도: curl -fsSL https://trip.idean.me/install | sh
+    3. 도움 받기: 이슈를 자동 등록할까요? (y/n)
+$
+```

--- a/specs/030-mcp-auto-bootstrap/contracts/mcp-version-handshake.md
+++ b/specs/030-mcp-auto-bootstrap/contracts/mcp-version-handshake.md
@@ -1,0 +1,79 @@
+# Contract — MCP 버전 handshake
+
+## startup verify
+
+MCP 서버(`trip_mcp/bootstrap.py`)가 spawn 직후 1회 실행:
+
+```text
+1. 자기 패키지 버전 확인 (pkg_resources / importlib.metadata)
+2. PyPI JSON API 호출:
+     GET https://pypi.org/pypi/trip-planner-mcp/json
+     timeout 5s
+3. response.info.version 비교
+4. 자기 버전 < latest:
+     stderr에 안내:
+       trip-planner-mcp 새 버전(<latest>)이 있습니다.
+       Claude에 "trip-planner MCP 업데이트해줘" 라고 요청해주세요.
+5. PyPI 호출 실패: 무시 (network·rate limit 등)
+```
+
+## 도구 호출 응답 헤더
+
+trip-planner API의 모든 v2 응답에 헤더 포함:
+
+```http
+HTTP/1.1 200 OK
+X-Trip-Planner-Min-MCP-Version: 3.0.0
+X-Trip-Planner-Server-Version: 3.0.0
+Content-Type: application/json
+```
+
+* `X-Trip-Planner-Min-MCP-Version`: 현재 API와 호환되는 MCP 최소 버전
+* `X-Trip-Planner-Server-Version`: 현재 server 버전 (참조용)
+
+## MCP client(자기) 버전 < Min-MCP-Version 처리
+
+```text
+1. MCP 서버가 도구 호출 후 응답 헤더 확인
+2. Min-MCP-Version > 자기 버전:
+     도구 응답을 그대로 반환하되 응답에 메타 추가:
+       {
+         ...정상 응답...,
+         _meta: {
+           upgrade_required: true,
+           server_version: "3.0.0",
+           min_mcp_version: "3.0.0",
+           current_mcp_version: "2.16.10",
+           upgrade_hint: "trip-planner-mcp 업데이트가 필요합니다."
+         }
+       }
+3. AI client는 _meta.upgrade_required true를 보고 사용자에게 자연어 안내
+```
+
+## MAJOR breaking 응답 (v3.0.0 같은 케이스)
+
+API가 호환 안 되는 호출(예: 폐기된 파라미터)을 받으면:
+
+```http
+HTTP/1.1 400 Bad Request
+X-Trip-Planner-Min-MCP-Version: 3.0.0
+
+{
+  "error": "deprecated_parameter",
+  "message": "create_trip의 startDate/endDate 파라미터는 v3.0.0부터 제거됐습니다. trip-planner MCP를 업데이트해주세요.",
+  "deprecated": ["startDate", "endDate"],
+  "guidance": "create_day 또는 create_activity로 derived 기간이 부여됩니다."
+}
+```
+
+AI client가 응답을 받아 자연어로 사용자에게 안내 + 자동 업데이트 흐름 trigger.
+
+## 종료 코드
+
+* MCP 서버 startup verify는 stderr 안내 외 종료 코드 영향 없음 (0 유지 — 정상 동작)
+* 도구 호출 응답이 4xx여도 MCP 서버 자체는 살아 있음. AI client가 자연어 처리
+
+## 헤더 미존재 케이스
+
+* server가 헤더 안 보내면 (구버전 API) client는 default `MIN-VERSION ≤ 자기` 가정 → 정상 동작
+* PyPI 호출 실패 시 update verify 안 함 → 정상 동작 (degraded)

--- a/specs/030-mcp-auto-bootstrap/contracts/oauth-listener.md
+++ b/specs/030-mcp-auto-bootstrap/contracts/oauth-listener.md
@@ -1,0 +1,69 @@
+# Contract — OAuth 로컬 HTTP listener
+
+## 흐름
+
+```text
+1. install 스크립트가 Node helper 실행:
+     node scripts/bootstrap/oauth-listener.mjs
+
+2. listener가 사용 가능한 랜덤 포트(localhost:0 → kernel 할당)에 바인딩
+     → 예: localhost:54321
+
+3. listener가 다음 URL을 stdout에 출력:
+     CALLBACK_URL=http://localhost:54321/oauth/callback
+
+4. install 스크립트가 사용자 브라우저로 OAuth authorize URL 열기:
+     https://trip.idean.me/oauth/authorize
+       ?provider=google
+       &redirect_uri=http://localhost:54321/oauth/callback
+       &state=<random>
+       &device_name=<hostname>
+
+5. 사용자가 브라우저에서 Google OAuth 동의 → trip-planner가 사용자 인증
+
+6. trip-planner가 callback URL로 redirect (302):
+     http://localhost:54321/oauth/callback?state=<>&token=<one-time code>
+
+7. listener가 GET 요청 수령 → state 검증 → token으로 PAT 발급 API 호출:
+     POST https://trip.idean.me/api/tokens
+       Authorization: Bearer <one-time code>
+       Body: { name: "<hostname> (auto YYYY-MM-DD)" }
+     → 응답: { token: "tp_..." }
+
+8. listener가 PAT을 keychain·파일에 저장 + stdout에 "OAUTH_OK" 출력 후 종료
+
+9. 브라우저 페이지에 "설치가 완료되었습니다. 이 창을 닫아주세요" 표시
+```
+
+## listener 설정
+
+| 항목 | 값 |
+|------|------|
+| 바인딩 주소 | localhost (127.0.0.1) 만 — 외부 노출 금지 |
+| 포트 | 0(kernel 할당) |
+| timeout | 60초 (사용자 인증 마칠 시간) |
+| 콜백 횟수 | 1회 수령 후 즉시 종료 |
+| HTTP method | GET 만 처리 (콜백) |
+| Path | `/oauth/callback` (그 외 404) |
+
+## one-time code · state 검증
+
+* OAuth state는 listener가 randomBytes(16) 생성 + URL에 포함 + 콜백에서 검증. 일치 안 하면 PAT 발급 시도 안 함
+* one-time code(authorization code 자리)는 listener가 PAT 발급 API 1회 호출 후 즉시 소진
+* PAT 발급 API는 trip-planner 서버가 one-time code → 사용자 세션 검증 → Token 생성
+
+## 보안 룰
+
+* PAT은 stdout·stderr·log에 평문 출력 안 함
+* listener 자체는 localhost 바인딩이라 외부 접근 불가
+* state mismatch 시 listener는 PAT 발급 시도 없이 종료 + 진단 메시지
+
+## 종료 코드
+
+| 코드 | 의미 |
+|------|------|
+| 0 | PAT 발급·저장 성공 |
+| 1 | timeout (60초 안에 콜백 없음) |
+| 2 | state mismatch |
+| 3 | PAT 발급 API 실패 |
+| 4 | keychain 저장 실패 |

--- a/specs/030-mcp-auto-bootstrap/data-model.md
+++ b/specs/030-mcp-auto-bootstrap/data-model.md
@@ -1,0 +1,68 @@
+# Data Model — Spec 030 (MCP 자동 부트스트랩)
+
+Phase 1 산출. 본 spec은 신규 DB 모델 도입을 최소화합니다.
+
+## 변경 대상
+
+### `Token` (기존)
+
+변경 없음. OAuth 콜백에서 자동 발급 시 같은 `Token` 모델·같은 `/api/tokens` 엔드포인트 재사용.
+
+```prisma
+model Token {
+  id          Int       @id @default(autoincrement())
+  userId      String
+  name        String
+  tokenHash   String    @unique
+  tokenPrefix String
+  expiresAt   DateTime?
+  lastUsedAt  DateTime?
+  createdAt   DateTime  @default(now())
+  user        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+```
+
+OAuth 자동 발급 시 `name`은 디바이스 hostname + 부트스트랩 세션 마커(예: `"MacBook-Pro (auto 2026-05-28)"`).
+
+### 신규 모델 (선택)
+
+본 spec에서는 신규 DB 모델을 도입하지 않습니다. 부트스트랩 세션 로그·진단 정보는 협력자 로컬 파일(`~/.config/trip-planner/bootstrap.log`)에만 남깁니다. DB 모델은 후속 spec에서 필요 시 검토.
+
+## 외부 응답 추가 헤더
+
+trip-planner API의 모든 v2 응답에 다음 헤더 추가:
+
+| 헤더 | 값 | 용도 |
+|------|------|------|
+| `X-Trip-Planner-Min-MCP-Version` | 예: `3.0.0` | 현재 API와 호환되는 최소 MCP 버전. MCP client가 자기 버전과 비교해 update trigger |
+
+`Min-MCP-Version`보다 낮은 MCP가 호출하면 API는 200 응답 + 헤더로 안내. 또는 MAJOR breaking 시 4xx 응답 + body에 안내. (`contracts/mcp-version-handshake.md` 참조)
+
+## 로컬 파일
+
+```text
+~/.config/trip-planner/
+├── credentials               # PAT 저장 (mode 0600, Linux fallback). macOS는 Keychain
+├── bootstrap.log             # install/update/재인증 세션 로그
+└── consent.json              # 사용자 동의 기록 (이슈 등록·diagnostics 전송 동의)
+```
+
+macOS Keychain entry:
+
+* Service: `trip-planner`
+* Account: 사용자 trip-planner email (or user id)
+* Password: PAT 평문
+
+## 도메인 경계 (Constitution V)
+
+| 데이터 | 원천 도메인 | 본 spec 변경 |
+|--------|-----------|-----------|
+| `Token` | 인증 (사용자 도메인) | 추가 발급 흐름 — 같은 모델 재사용. 도메인 경계 변경 없음 |
+| MCP 버전 정보 | MCP 패키징 | PyPI JSON 응답 조회. 단방향 |
+| GitHub 이슈 | 외부 (GitHub) | 사용자 본인 토큰으로만 등록. trip-planner 본 도메인에서는 작성 시도 안 함 |
+
+## 무결성·검증 규칙
+
+* OAuth 콜백은 1회만 listener가 수령. 재시도 시 새 listener·새 포트.
+* PAT 발급 후 즉시 keychain·파일 저장. 메모리 평문 유지 시간 최소화.
+* `X-Trip-Planner-Min-MCP-Version` 헤더 미존재 시 client는 기본값(현재 release 시점 MCP 버전 = 호환)으로 동작.

--- a/specs/030-mcp-auto-bootstrap/plan.md
+++ b/specs/030-mcp-auto-bootstrap/plan.md
@@ -1,0 +1,185 @@
+# Implementation Plan: MCP 자동 부트스트랩 — 노터치 설치·인증·업데이트
+
+**Branch**: `030-mcp-auto-bootstrap` | **Date**: 2026-05-28 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/030-mcp-auto-bootstrap/spec.md`
+
+## Summary
+
+협력자가 AI client(Claude Code 우선, Claude Desktop·Cursor best-effort)에 자연어로 "trip-planner MCP 설치/업데이트해줘" 요청 시 사용자 노터치(브라우저 1회 인증 제외)로 install·PAT 발급·MCP 등록·동작 검증이 완료되는 자동 부트스트랩 흐름을 도입합니다. install 스크립트가 로컬 HTTP listener를 띄워 OAuth 콜백을 받고(`gh auth login` 패턴), MCP 서버는 startup 시 1회 + 호출 실패 시 + 사용자 명시 요청 시 세 시점에서 자동 update를 trigger합니다. 부트스트랩 실패는 1회 자동 재시도 → 진단 메시지 → 사용자 동의 시 GitHub 이슈 자동 등록 순으로 처리합니다. spec 029(여행 모델 + 캘린더 뷰)와 v3.0.0 마일스톤 묶음으로 동시 출시합니다.
+
+## Coverage Targets
+
+- 1줄 install 진입점 — 협력자가 1줄 curl 또는 `claude mcp add` 한 줄로 시작 가능 [why: install-entry] [multi-step: 2]
+- OAuth 1회 인증 흐름 — 로컬 HTTP listener + 브라우저 콜백 + PAT 자동 발급·저장 [why: oauth-listener] [multi-step: 3]
+- MCP 등록 자동 트리거 — `claude mcp add -s user` 등 client별 등록 명령 자동 호출 [why: mcp-register]
+- 설치 직후 동작 검증 ping — MCP 도구 1건 호출 결과로 install 성공·실패 판정 [why: install-verify]
+- 자동 update 트리거 — startup verify + 호출 실패 감지 + 명시 요청 세 시점 동일 흐름 [why: auto-update-trigger] [multi-step: 3]
+- MAJOR breaking 변경 시 사용자 안내 — v3.0.0 같은 release에서 변경 사항 요약 [why: breaking-notice]
+- PAT 만료·권한 회수 자동 감지 — 401 응답 감지 + 자동 재발급 흐름 진입 [why: pat-recovery] [multi-step: 2]
+- 부트스트랩 실패 폴백 — 1회 자동 재시도 + 진단 메시지 + 동의 시 이슈 자동 등록 [why: bootstrap-fallback] [multi-step: 3]
+- 표준 종료 코드 — 0=성공/1=일반/2=인증 필요/3=의존성 부족 [why: standard-exit-codes]
+- PAT 평문 비노출 — stdout·stderr 어디에도 비밀번호·PAT 평문 출력 안 함 [why: secret-redaction]
+
+## Technical Context
+
+**Language/Version**: Bash (install 스크립트), Node.js 20+ (로컬 HTTP listener 후보), Python 3.10+ (MCP 서버)
+**Primary Dependencies**: trip-planner-mcp (PyPI), FastMCP, httpx, `claude` CLI (Claude Code), curl/openssl (Bash). 로컬 listener는 Node native `http` 모듈 또는 Bash + ncat 후보 — Phase 0 research에서 결정.
+**Storage**: PAT 로컬 저장 위치 — Phase 0 research에서 결정 (macOS Keychain `trip-planner` 우선, fallback `~/.config/trip-planner/credentials`)
+**Testing**: shellcheck (Bash), pytest (MCP), Node test runner(로컬 listener). 통합 검증은 quickstart 시나리오 수동.
+**Target Platform**: macOS 우선, Linux best-effort, Windows ad-hoc. AI client는 Claude Code 우선.
+**Project Type**: shell script + Python MCP server + Node helper
+**Performance Goals**: SC-001 새 협력자 install 평균 3분 이내 (브라우저 인증 포함). SC-002 사용자 추가 키 입력·파일 편집 단계 = 0.
+**Constraints**: 1줄 curl 진입(메모 [feedback_capsule]). PAT·비밀번호 stdout/stderr 평문 비노출(FR-014). 표준 종료 코드(FR-015).
+**Scale/Scope**: 협력자 1~10명. 1인 + 동행자 2~5명 / trip-planner 사용자. install·update는 사용자별 1회/주기.
+
+## Constitution Check
+
+| 원칙 | 평가 | 비고 |
+|------|------|------|
+| I. AX-First | ✅ 통과 | 자연어 요청 1회로 install/update 완결 — AX 핵심 |
+| II. Minimum Cost | ✅ 통과 | 신규 유료 의존성 0. PyPI·GitHub Releases 기존 채널 재사용 |
+| III. Mobile-First Delivery | ✅ 해당 없음 | 부트스트랩은 협력자 CLI 환경. 모바일 직접 사용 시나리오 없음 |
+| IV. Incremental Release | ✅ 통과 | v3.0.0 출시 시 1단계 도입. 후속은 별도 spec(CI/CD PAT fallback 등) |
+| V. Cross-Domain Integrity | ✅ 통과 | PAT는 사용자 인증 도메인. MCP는 일정 편성/탐색 도메인 호출. 단방향 |
+| VI. Role-Based Access Control | ✅ 통과 | PAT는 사용자 본인 권한만 위임. 기존 Token 모델 RBAC 정합 |
+
+**Gate 결과**: 통과.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/030-mcp-auto-bootstrap/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── install-cli.md           # 1줄 install 진입점·종료 코드·환경 변수
+│   ├── oauth-listener.md         # 로컬 HTTP listener 콜백 프로토콜
+│   └── mcp-version-handshake.md  # MCP 서버 startup verify + 호출 실패 감지 응답 코드
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code
+
+```text
+install.sh                       # 1줄 진입점 (curl | bash). 의존성·OS 진단·다운로드·MCP 등록 단계 분기
+scripts/
+├── bootstrap/
+│   ├── oauth-listener.mjs       # Node 로컬 HTTP listener (콜백 수령 + PAT 발급 API 호출)
+│   └── verify-install.sh        # 동작 검증 ping (MCP 도구 1건 호출)
+mcp/trip_mcp/
+├── bootstrap.py                  # startup verify (PyPI latest 비교) + 호출 실패 시 update hint
+└── exit_codes.py                 # 표준 종료 코드 enum
+src/app/api/
+└── tokens/
+    └── oauth-callback/route.ts   # OAuth 콜백 처리 (사용자 동의 후 PAT 자동 발급)
+docs/
+└── mcp-bootstrap.md              # 사용자 가이드 (협력자 안내용)
+```
+
+**Structure Decision**: install·등록은 Bash + Node helper. MCP 서버 자체 update verify는 Python. OAuth 콜백 처리는 Next.js API route(웹 도메인 인증 흐름 정합).
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| Node 로컬 HTTP listener | OAuth 1회 콜백 수령 + PAT 자동 발급에 표준 패턴(gh CLI). 단순 curl로는 콜백 수령 불가 | Bash + nc로 listener 만들기 — OS 호환성·a11y·신뢰성 약함 |
+| 사용자 동의 시 GitHub 이슈 등록 | 부트스트랩 실패 진단 자동화 — 사용자가 진단 못 함 가정 | 수동 안내만은 사용자 노터치 위반 |
+
+## Phase 0 — Research
+
+`research.md`로 합쳐 작성.
+
+### Topic 1 — install.sh 1줄 진입점 형식
+
+**Unknowns**: 협력자가 어떤 1줄 명령으로 시작할지. `curl -fsSL https://trip.idean.me/install.sh | bash`? `npx @idean3885/trip-planner-bootstrap`? `claude mcp install trip-planner`?
+
+**Tasks**:
+- curl | bash 패턴의 보안 vs 편의 균형 (gh CLI·Homebrew·oh-my-zsh 패턴 참조)
+- Claude Code의 native MCP install 명령(`claude mcp install`)이 publish된 MCP 디렉토리 지원하는지 조사
+- 사용자 안내 메시지 분기 (의존성 부족·OS 미지원 등)
+
+### Topic 2 — OAuth listener 구현 라이브러리·포트
+
+**Unknowns**: Node 표준 `http` 모듈 vs `express` vs `polka`. 사용 포트(고정 vs 랜덤). 콜백 URL whitelist.
+
+**Tasks**:
+- gh CLI(go) · GitHub CLI Action(Node) · Heroku CLI 패턴 비교
+- localhost:포트 callback 등록 (Google OAuth client config에 등록 필요)
+- 동시 install 시도 시 포트 충돌 처리
+
+### Topic 3 — PAT 로컬 저장 위치
+
+**Unknowns**: macOS Keychain vs file. 권한·접근성·동기화 영향.
+
+**Tasks**:
+- macOS Keychain 표준 (security CLI · keytar Node) 정리
+- Linux fallback (`secret-tool` · file 0600 권한)
+- AI client가 환경 변수로 PAT 읽는 경우 — keychain → env 자동 export
+
+### Topic 4 — MCP 서버 자체 update verify
+
+**Unknowns**: startup verify를 어떻게 (PyPI JSON API? GitHub Releases API? trip-planner 자체 endpoint?). 호출 실패 감지(401·405 등)를 표준 응답 코드로 어떻게.
+
+**Tasks**:
+- PyPI `https://pypi.org/pypi/trip-planner-mcp/json` 호출 비용·latency
+- MCP 프로토콜에 version mismatch 표준 응답 있는지 (없음 — 자체 컨벤션 필요)
+- AI client가 응답 코드를 자연어로 변환할 진입점
+
+### Topic 5 — 진단 메시지 + 이슈 자동 등록 권한 모델
+
+**Unknowns**: 사용자 동의 시 이슈 등록 시 어느 GitHub 계정으로 등록할지. 사용자 본인 토큰 vs trip-planner 봇 계정 vs anonymous(public 레포).
+
+**Tasks**:
+- trip-planner 레포 public 전환 여부 확인 (Constitution Constraints: "public 전환 예정")
+- 봇 계정 운영 비용 vs 사용자 토큰 권한
+- 개인정보 마스킹(이메일·PAT prefix·머신 hostname) 룰
+
+**Output**: `specs/030-mcp-auto-bootstrap/research.md`
+
+## Phase 1 — Design & Contracts
+
+### data-model.md
+
+본 spec은 DB 스키마 변경이 거의 없습니다. 기존 `Token` 모델(`/api/tokens` POST) 재사용. 이슈 등록 시 사용자 동의 plain consent 기록(메타데이터 수준)만 필요.
+
+| 엔티티 | 변경 |
+|--------|------|
+| `Token` | 변경 없음 — OAuth 콜백에서 자동 발급 시 같은 모델 사용 |
+| `BootstrapSession` (선택) | install/update 실행 단위 로깅용. DB가 아닌 로컬 파일에 둘 수도 (Phase 0 research에서 결정) |
+
+### contracts/
+
+* `install-cli.md` — 1줄 진입점·환경 변수·종료 코드(0/1/2/3)·stdout/stderr 출력 형식
+* `oauth-listener.md` — 로컬 HTTP listener의 콜백 URL·포트·timeout·콜백 응답 형식
+* `mcp-version-handshake.md` — MCP 서버 startup verify 응답·도구 호출 실패 응답에 version 메타
+
+### quickstart.md
+
+협력자가 새 macOS에서 1줄 install로 시작해 trip-planner MCP 동작에 도달하는 시나리오 + update·재인증 시나리오 + Evidence(자동·수동) 명시.
+
+### Agent context update
+
+`.specify/scripts/bash/update-agent-context.sh claude` 실행.
+
+## Phase 2 — Tasks (out of scope)
+
+`/speckit.tasks` 또는 직접 작성으로 메타태그 4종 부착된 tasks.md 생성. 본 plan은 Coverage Targets bullet 별 [why]·[multi-step] 매핑 기반 제공.
+
+## Dependencies & Risks
+
+* spec 029(여행 모델)의 MCP `create_trip`/`update_trip` breaking이 spec 030의 자동 update 흐름으로 사용자에게 안내돼야 함. v3.0.0 동시 출시 정합 핵심
+* OAuth 콜백 listener의 포트 충돌·콜백 URL whitelist는 Google OAuth client config 변경 필요(인프라 영향)
+* trip-planner 레포 public 전환 시 이슈 자동 등록의 privacy 처리(개인정보 마스킹) risk
+* macOS Keychain 외 OS에서 PAT 저장 fallback의 보안 risk — file 0600 권한·읽기 권한 명시
+
+## Notes
+
+* 1줄 curl 패턴은 메모 [feedback_capsule]("비개발자 캡슐화·1줄 설치·JSON 편집 불가") 정합
+* Claude Code MCP 등록은 메모 [feedback_mcp_registration](`claude mcp add -s user`) 정합
+* 본 spec의 release 시점은 v3.0.0 한 번. expand-and-contract 분해는 spec 029가 담당

--- a/specs/030-mcp-auto-bootstrap/quickstart.md
+++ b/specs/030-mcp-auto-bootstrap/quickstart.md
@@ -1,0 +1,97 @@
+# Quickstart — Spec 030 (MCP 자동 부트스트랩)
+
+## 시나리오 1 — 신규 협력자 설치 (US1)
+
+1. 새 macOS 머신에서 Claude Code 실행
+2. 자연어로 요청: "trip-planner MCP 설치해줘"
+3. AI가 install 진입점 실행: `curl -fsSL https://trip.idean.me/install | sh`
+4. install 스크립트 진행:
+   - 의존성 확인 (Python·uv·Node)
+   - trip-planner-mcp 다운로드
+   - OAuth listener 띄움 + 브라우저 자동 열림
+5. 사용자가 브라우저에서 Google 로그인 → 동의
+6. listener가 콜백 수령 → PAT 자동 발급 + keychain 저장
+7. Claude Code에 `claude mcp add -s user trip-planner ...` 자동 실행
+8. 동작 검증 ping (`list_trips` 호출)
+9. 완료 메시지: "trip-planner MCP가 준비됐어요"
+
+**기대 결과**: SC-001 평균 3분 이내. 사용자 손대는 추가 단계 = 브라우저 1회 클릭 (SC-002).
+
+## 시나리오 2 — 자연어 업데이트 (US2)
+
+1. 협력자가 trip-planner-mcp v2.x 설치 상태에서 v3.0.0 release 후
+2. 자연어 요청: "trip-planner MCP 업데이트해줘" 또는 자동 trigger
+3. AI가 PyPI latest 버전 확인 → v3.0.0 발견
+4. 업데이트 실행 + 변경 사항 요약 안내:
+   - "v3.0.0부터 create_trip의 startDate/endDate가 사라졌습니다. 대신 create_day로 일정을 추가해주세요"
+5. 재인증 필요 시 OAuth 흐름 재진입
+6. 동작 검증 ping
+
+## 시나리오 3 — PAT 만료 자동 복구 (US3)
+
+1. 사용자가 PAT을 웹에서 폐기 (또는 만료)
+2. AI가 trip-planner 도구 호출 → 401 응답
+3. AI: "PAT이 만료됐어요. 재발급할까요?" 안내
+4. 사용자 동의 → OAuth 흐름 재진입
+5. 새 PAT keychain 갱신 → 도구 호출 재시도
+
+## 시나리오 4 — 부트스트랩 실패 폴백 (FR-012)
+
+1. install 진행 중 네트워크 timeout
+2. 1회 자동 재시도
+3. 재시도 실패 → 진단 메시지 출력:
+   ```
+   설치 실패: PyPI 다운로드 timeout
+   다음을 시도해주세요:
+     1. 인터넷 연결 확인
+     2. 다시 시도: curl -fsSL https://trip.idean.me/install | sh
+     3. 진단 정보를 첨부한 GitHub 이슈를 자동 등록할까요? (y/n)
+   ```
+4. 사용자 `y` → `gh issue create`로 사용자 본인 권한 등록 (개인정보 마스킹)
+
+## 시나리오 5 — install 진입점 1줄 (FR-001)
+
+```bash
+$ curl -fsSL https://trip.idean.me/install | sh
+[1/5] 의존성 확인...
+[2/5] trip-planner-mcp 다운로드...
+[3/5] 인증 — 브라우저가 열립니다...
+[4/5] Claude Code에 등록...
+[5/5] 동작 검증...
+✓ 설치 완료
+```
+
+### Evidence
+
+#### 자동 검증
+
+```bash
+# Bash 스크립트 정적 분석
+shellcheck install.sh scripts/bootstrap/verify-install.sh
+
+# Node listener 단위 테스트
+node --test scripts/bootstrap/oauth-listener.test.mjs
+
+# Python MCP startup verify
+cd mcp && uv run pytest tests/test_bootstrap_verify.py
+
+# OAuth 콜백 API route 통합 테스트
+pnpm vitest run tests/integration/oauth-callback.test.ts
+
+# 표준 종료 코드 enum 정합
+shellcheck install.sh -e SC2034
+```
+
+#### 수동 검증
+
+* 시나리오 1: 새 macOS VM에서 1줄 curl 진입 → 평균 3분 이내 완료. 사용자 단계 = 브라우저 1회 클릭
+* 시나리오 2: v2.x 설치 상태에서 자연어 업데이트 요청 → 자동 갱신
+* 시나리오 3: PAT 폐기 후 도구 호출 → AI가 401 감지 + 재발급 안내
+* 시나리오 4: 네트워크 차단 환경(`sudo ifconfig en0 down`)에서 install → 진단 메시지·재시도·이슈 등록 옵션 노출
+* 시나리오 5: stdout에 단계별 진행. stderr는 진단 로그(PAT 평문 없음 확인)
+
+## 회귀 방지
+
+* OAuth 콜백 listener의 포트 충돌 시 다음 사용 가능 포트로 재시도
+* PyPI rate limit 시 verify 실패는 silent (정상 동작 유지)
+* keychain 저장 실패 시 file fallback(`~/.config/trip-planner/credentials`, 0600)으로 graceful degrade

--- a/specs/030-mcp-auto-bootstrap/research.md
+++ b/specs/030-mcp-auto-bootstrap/research.md
@@ -1,0 +1,90 @@
+# Research — Spec 030 (MCP 자동 부트스트랩)
+
+Phase 0 산출.
+
+## Topic 1 — install.sh 1줄 진입점 형식
+
+**Decision**: `curl -fsSL https://trip.idean.me/install | sh` 패턴. 트립플래너 도메인에서 직접 install 스크립트 서빙. Claude Code의 `claude mcp install` 명령은 별도 보조 진입점으로만 지원(Claude Code MCP 디렉토리 등록은 추후 별도 spec).
+
+**Rationale**:
+- `curl | sh`는 gh CLI·Homebrew·oh-my-zsh 등 검증된 패턴. 협력자 친숙도 높음
+- trip.idean.me 도메인이 사용자 신뢰 영역 — 외부 CDN 의존 없음
+- Claude Code의 native `claude mcp install`은 trip-planner를 MCP 디렉토리에 등재해야 동작 — 별도 작업으로 미루기
+
+**Alternatives considered**:
+- `npx @idean3885/trip-planner-bootstrap` — Node 의존성 요구. 비개발자 협력자에 부담
+- 단순 `pip install trip-planner-mcp` + 수동 등록 — 사용자 노터치 위반
+
+**Implications**:
+- `install.sh`가 trip-planner Vercel 정적 라우트로 서빙 (`/install` 또는 `/install.sh`)
+- 사용자 안내 메시지: OS 미지원·의존성 부족 시 명시 출력
+
+## Topic 2 — OAuth listener 구현 라이브러리·포트
+
+**Decision**: Node 표준 `http` 모듈로 직접 구현. 외부 lib 없음. 포트는 사용 가능한 랜덤 포트(localhost:0 → kernel 할당). 콜백 URL은 `http://localhost:<port>/oauth/callback` 동적.
+
+**Rationale**:
+- Node 표준 lib만 사용 — 신규 의존성 0 (Constitution II 정합)
+- 랜덤 포트는 동시 install 시 충돌 회피 + Google OAuth는 localhost: prefix만 검증
+- listener는 콜백 1회 수령 후 즉시 종료 (메모리·security minimize)
+
+**Alternatives considered**:
+- express/polka 사용 — 외부 의존성 추가 부담. 표준 lib로 충분
+- 고정 포트(예: 8765) — 동시 install 시 충돌·포트 점유 충돌
+
+**Implications**:
+- Google OAuth client config에 `http://localhost` redirect URI 추가(prefix 매칭이라 모든 포트 허용)
+- listener timeout 60초 (사용자가 브라우저 인증 마칠 시간)
+
+## Topic 3 — PAT 로컬 저장 위치
+
+**Decision**: macOS Keychain(`security` CLI) 우선. Linux는 `secret-tool`(libsecret), fallback `~/.config/trip-planner/credentials` (mode 0600). Windows는 본 spec 범위 밖.
+
+**Rationale**:
+- macOS Keychain은 OS 표준 + 사용자 본인 권한으로만 접근. 평문 노출 0
+- `~/.claude/toolkits/dooray/`의 키체인 사용 패턴 정합 (사내 toolkit 참조)
+- Linux fallback file은 0600(소유자 r/w만)으로 권한 제한
+
+**Alternatives considered**:
+- 평문 env 변수 → shell history·process 목록 노출 risk
+- 1Password CLI 통합 → 비개발자 의존성 추가
+
+**Implications**:
+- `keytar` 같은 Node 라이브러리 후보지만 native binary 의존성. `security` CLI 직접 호출이 단순
+- AI client가 PAT 읽을 때 키체인 → 환경변수 자동 export (install 스크립트가 처리)
+
+## Topic 4 — MCP 서버 자체 update verify
+
+**Decision**: MCP 서버가 startup 시 PyPI JSON API(`https://pypi.org/pypi/trip-planner-mcp/json`) 1회 호출로 latest 버전 비교. 도구 호출 실패는 trip-planner API의 응답 헤더 `X-Trip-Planner-Min-MCP-Version`로 감지. AI client가 두 신호 모두 자연어로 변환.
+
+**Rationale**:
+- PyPI JSON API는 무료·공개·rate limit 충분
+- startup 시 1회면 비용 무시 가능 (보통 분 단위 lifecycle)
+- API 응답 헤더는 client·server 양방향 합의 가능한 표준 자리
+
+**Alternatives considered**:
+- GitHub Releases API — PyPI에 이미 publish하므로 PyPI가 직접
+- 매 호출마다 verify — 비용·latency 증가. spec 본문 Q2 답(혼합 — 매번은 안 함)과 정합
+
+**Implications**:
+- MCP `bootstrap.py`가 startup 시 PyPI 호출 + 결과를 stderr에 안내 메시지
+- trip-planner API response middleware에 `X-Trip-Planner-Min-MCP-Version` 헤더 추가
+- AI client는 응답에 mismatch가 있으면 자연어 안내 (예: "trip-planner MCP를 업데이트해주세요")
+
+## Topic 5 — 진단 메시지 + 이슈 자동 등록 권한 모델
+
+**Decision**: 사용자 본인의 GitHub 토큰을 사용해 등록. trip-planner 레포가 public 전환된 후 적용. 사용자 토큰은 install 시점에 OAuth로 같이 받지 않고, 이슈 등록 동의 시점에 별도로 받음(`gh auth login` 또는 기존 `gh` CLI 활용). 또는 sentence to copy/paste 안내.
+
+**Rationale**:
+- 봇 계정 운영은 1인 개발 환경에 무리한 인프라
+- 사용자 본인 토큰 사용 시 spam 책임 분산
+- 협력자가 GitHub 계정 없는 케이스가 드물지만 가능 — 폴백은 진단 메시지 copy/paste 안내
+
+**Alternatives considered**:
+- trip-planner 봇 계정 + PAT 보관 → 운영 부담·rate limit·spam 책임
+- anonymous 등록 → GitHub 정책상 불가
+
+**Implications**:
+- 진단 메시지 + 이슈 본문 자동 생성 (개인정보 마스킹: 이메일·PAT prefix·hostname 제외)
+- `gh issue create` 명령으로 사용자 본인 권한 등록
+- 사용자 GitHub 토큰 미설정 시 진단 메시지만 출력 + copy/paste 안내

--- a/specs/030-mcp-auto-bootstrap/spec.md
+++ b/specs/030-mcp-auto-bootstrap/spec.md
@@ -1,0 +1,158 @@
+# Feature Specification: MCP 자동 부트스트랩 — 노터치 설치·인증·업데이트
+
+**Feature Branch**: `030-mcp-auto-bootstrap`
+**Created**: 2026-05-28
+**Status**: Draft
+**Input**: User description: "MCP 자동 부트스트랩 — 협력자가 AI client에 자연어 요청만으로 사용자 노터치 설치·업데이트. 마일스톤 v3.0.0에서 spec 029(여행 모델 + 캘린더 뷰)와 동시 출시."
+
+## Clarifications
+
+### Session 2026-05-28
+
+- Q: AI client 인증 흐름 → A: 브라우저 OAuth 1회 (gh CLI 패턴 — install 스크립트가 로컬 HTTP listener 띄워 redirect 수령 + PAT 자동 발급). 사용자 브라우저 1회 클릭 외 손대지 않음
+- Q: 자동 업데이트 트리거 → A: 혼합 — MCP 서버 startup 1회 verify + 도구 호출 실패 시 version mismatch 감지 + 사용자 명시 요청도 동일 흐름. 매 호출마다 verify는 안 함
+- Q: 부트스트랩 실패 시 폴백 → A: 혼합 — 1회 자동 재시도(일시 장애 회복) + 실패 시 진단 메시지(어디서 막혔는지·다음 행동) + 사용자 동의 시 이슈 자동 등록
+- Q: 지원 AI client 범위 → A: 현행 default 유지 — Claude Code 우선·Cursor·Desktop best-effort·일반 MCP-호환 client는 표준 등록 명령만 지원
+
+### 결정 1 — AI client 인증 흐름 ✅
+
+install 스크립트가 OAuth 1회 흐름을 수행합니다. 로컬 HTTP listener를 띄워 콜백을 받고 자동으로 PAT을 발급·저장합니다. 사용자는 브라우저 1회 동의 외 손대지 않습니다. CI/CD·자동화 환경 대응은 본 spec 범위 밖(필요 시 후속 spec에서 PAT fallback 추가).
+
+### 결정 2 — 자동 업데이트 트리거 ✅
+
+다음 세 시점에서 trigger됩니다:
+
+* MCP 서버 startup 시 1회 verify (자식 프로세스 spawn 직후)
+* 도구 호출 응답이 version mismatch 또는 4xx auth 실패 시
+* 사용자가 자연어로 "업데이트해줘" 요청 시
+
+세 시점 모두 같은 update 흐름을 진입합니다. 매 도구 호출마다 verify는 하지 않습니다(비용·latency 회피).
+
+### 결정 3 — 부트스트랩 실패 시 폴백 ✅
+
+부트스트랩 실패는 다음 순서로 처리합니다:
+
+1. **1회 자동 재시도** — 일시 장애(network·timeout) 회복
+2. **재시도 실패 시 진단 메시지** — 어디서 막혔는지 + 다음 행동을 사용자 친화 문구로 출력. SC-005 정합(맥락 없는 에러 코드 0건)
+3. **사용자 동의 시 이슈 자동 등록** — 진단 로그(개인 식별 정보 마스킹)를 모아 GitHub 이슈 자동 생성. 사용자 명시 동의 없이는 등록하지 않음
+
+## Metatag Conventions *(normative, inherited from PR #204)*
+
+본 피처의 tasks.md·plan.md는 네 종 메타태그를 따릅니다:
+
+- `[artifact: <path>|<path>::<symbol>]` — 산출 파일 식별자
+- `[why: <short-tag>]` — 추적 그룹 키
+- `[multi-step: N]` — plan bullet의 다단 매핑 태스크 수
+- `[migration-type: schema-only | data-migration]` — 마이그레이션 산출물 구분(본 피처는 DB 스키마 변경 없음 예상, 인증 토큰 모델 변경 시에만 사용)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - 협력자 노터치 설치 (Priority: P1)
+
+협력자가 자기 AI client(예: Claude Code)에 "trip-planner MCP 설치해줘"라고 자연어로 요청합니다. AI가 install 명령 자동 실행 → 사용자 브라우저 1회 인증(OAuth 또는 PAT 발급 페이지) → AI가 발급된 인증 정보 자동 등록 → MCP 등록 → 동작 검증 ping → 결과 안내. 사용자는 브라우저 1회 클릭 외 손대지 않습니다.
+
+**Why this priority**: 현재 협력자가 MCP 설치 단계에서 막혀 도구를 못 쓰고 있는 핵심 문제를 직접 해소합니다. v3.0.0 도구 가치의 전제 조건입니다.
+
+**Independent Test**: 새 macOS 사용자가 Claude Code에 자연어 요청 한 번으로 trip-planner MCP가 동작하는 상태에 도달하는지(`mcp__trip__list_trips` 등이 응답하는지) 확인합니다.
+
+**Acceptance Scenarios**:
+
+1. **Given** 협력자가 trip-planner 계정만 있고 MCP는 미설치 상태, **When** Claude Code에 "trip-planner MCP 설치해줘" 요청, **Then** AI가 install 실행 + 브라우저 1회 인증 안내 + 인증 후 MCP 등록 + 동작 검증을 자동 완료하고 협력자에게 완료 메시지를 출력합니다.
+2. **Given** 협력자가 install 단계에서 브라우저 인증을 마침, **When** AI가 후속 단계 진행, **Then** 사용자에게 추가 입력을 요구하지 않고 등록·검증까지 완료됩니다.
+3. **Given** 인증이 실패하거나 사용자가 브라우저를 닫음, **When** AI가 그것을 감지, **Then** 결정 3의 폴백 흐름(1회 자동 재시도 → 진단 메시지 → 동의 시 이슈 등록)이 실행됩니다.
+
+---
+
+### User Story 2 - 자연어 업데이트 (Priority: P2)
+
+협력자가 "trip-planner MCP 업데이트해줘"라고 요청하면 AI가 최신 버전 자동 감지 + 업데이트 + 재인증(필요 시) + 동작 검증을 사용자 노터치로 완료합니다.
+
+**Why this priority**: 설치 후에도 v3.0.0 같은 MAJOR breaking 직후 협력자가 자동으로 따라올 수 있어야 도구가 유지됩니다. P1 설치가 없으면 의미가 없으므로 P2.
+
+**Independent Test**: 이전 버전이 설치된 상태에서 협력자가 업데이트 요청 한 번으로 최신 버전으로 갱신되고 인증·등록 상태가 유지되는지 확인합니다.
+
+**Acceptance Scenarios**:
+
+1. **Given** 협력자가 trip-planner-mcp v2.x를 사용 중, **When** v3.0.0 release 후 "trip-planner MCP 업데이트해줘" 요청, **Then** AI가 v3.0.0으로 자동 갱신하고 호환 안 되는 호출(예: `create_trip`의 startDate)을 사용자에게 안내합니다.
+2. **Given** 업데이트 후 PAT 재인증이 필요한 경우, **When** AI가 감지, **Then** 사용자에게 브라우저 1회 인증을 요청하고 새 PAT을 자동 적용합니다.
+
+---
+
+### User Story 3 - 자동 진단·복구 (Priority: P3)
+
+PAT 만료·권한 회수·인증 실패 같은 사후 장애를 AI가 자동 감지해 협력자에게 알리고 복구 흐름(재발급 / 재등록)으로 진입합니다.
+
+**Why this priority**: 일상 운영 중 발생하는 장애를 사용자가 진단·해결할 능력이 없다고 가정. AI가 항상 옆에 있다는 전제에서 진단·복구도 노터치여야 합니다. P1·P2 없이는 의미가 작아 P3.
+
+**Independent Test**: PAT을 의도적으로 폐기한 상태에서 협력자가 MCP 도구를 호출하면 AI가 401 감지 → 자동 재발급 흐름 진입을 확인합니다.
+
+**Acceptance Scenarios**:
+
+1. **Given** 협력자의 PAT이 만료된 상태, **When** AI가 trip-planner MCP 도구 호출, **Then** 401 응답을 감지하고 "PAT이 만료되었어요. 재발급할까요?" 같은 안내 후 사용자 동의 시 자동 재발급 흐름 진입.
+
+---
+
+### Edge Cases
+
+* 협력자가 trip-planner 웹 계정이 아직 없는 경우 — install 흐름이 OAuth 회원가입(Google)을 먼저 안내한 후 후속 단계 진행.
+* 협력자 환경이 Python·uv 미설치 상태 — install 스크립트가 자체 진단 + 의존성 안내(또는 호환 가능한 단일 바이너리 배포).
+* 협력자가 회사 PC라 방화벽으로 trip.idean.me 접근 제한 — 진단 메시지 + 화이트리스트 안내.
+* 다중 AI client(Claude Code + Cursor 동시 사용) — 같은 PAT 공유 가능, 또는 client별 별도 PAT 발급(현행 다중 토큰 정책 정합).
+* 협력자가 자기 머신이 아닌 공용 PC에서 설치 시도 — PAT 공유 위험. 설치 스크립트가 "공용 PC 감지 시 경고" 휴리스틱 없이도 사용자에게 1회 알림.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### 설치 (User Story 1)
+
+* **FR-001**: 협력자가 AI client에 자연어로 설치 요청 시 AI가 단일 명령(예: 1줄 curl 또는 `npm`·`uv` 한 줄)으로 install 흐름을 시작할 수 있는 진입점이 공개돼 있어야 합니다.
+* **FR-002**: install 스크립트는 PAT 자동 발급 흐름(웹 인증 1회 → 토큰 자동 수령 → 로컬 저장)을 포함해야 합니다.
+* **FR-003**: install 스크립트는 MCP 클라이언트 등록(`claude mcp add` 같은 명령)을 자동 수행해야 합니다.
+* **FR-004**: install 완료 직후 동작 검증 ping(예: 도구 1건 호출)을 수행하고 성공·실패를 협력자에게 출력해야 합니다.
+* **FR-005**: 사용자 인증 흐름은 브라우저 OAuth 1회입니다. install 스크립트가 로컬 HTTP listener를 띄워 콜백을 받고, 사용자가 브라우저에서 1회 동의를 마치면 PAT을 자동 발급해 로컬에 저장합니다(`gh auth login` 패턴). CI/CD 환경 대응은 본 spec 범위 밖.
+
+#### 업데이트 (User Story 2)
+
+* **FR-006**: 협력자가 AI client에 자연어로 업데이트 요청 시 AI가 최신 버전을 감지하고 자동 갱신을 수행할 수 있어야 합니다.
+* **FR-007**: 업데이트 trigger는 세 시점입니다 — (1) MCP 서버 startup 시 1회 verify, (2) 도구 호출 응답이 version mismatch 또는 4xx auth 실패 시, (3) 사용자 자연어 명시 요청 시. 세 trigger 모두 같은 update 흐름을 진입합니다. 매 호출마다 verify는 하지 않습니다.
+* **FR-008**: MAJOR breaking 변경(예: v3.0.0의 `create_trip` 시그니처 변경)이 있을 때 업데이트 흐름은 사용자에게 변경 사항 요약을 안내합니다.
+* **FR-009**: 업데이트 후 동작 검증 ping을 수행합니다.
+
+#### 진단·복구 (User Story 3)
+
+* **FR-010**: PAT 만료·권한 회수·인증 실패를 AI client가 감지할 수 있도록 MCP 도구 응답에 표준 에러 코드가 명시돼야 합니다.
+* **FR-011**: 인증 실패 감지 시 AI가 자동 재발급 흐름으로 진입할 수 있는 진입점이 제공돼야 합니다.
+* **FR-012**: 부트스트랩 실패 시 폴백은 (1) 1회 자동 재시도 → (2) 재시도 실패 시 사용자 친화 진단 메시지(어디서 막혔는지·다음 행동) → (3) 사용자 명시 동의 시 진단 로그(개인 식별 정보 마스킹) 모아 GitHub 이슈 자동 등록 순으로 동작합니다.
+
+#### 안전·관측
+
+* **FR-013**: PAT 발급·만료·재발급 이벤트가 사용자 본인의 설정 화면(`/settings`)에서 조회 가능해야 합니다(현행 `Token` 모델 재사용).
+* **FR-014**: 부트스트랩 명령은 stdout에 사용자 친화 메시지를 출력하고, stderr에 진단용 상세 로그를 출력합니다. 어느 한쪽에도 PAT·비밀번호 평문이 노출되지 않습니다.
+* **FR-015**: install 명령은 일관된 종료 코드를 사용하여 AI client가 성공/실패를 명확하게 판단할 수 있어야 합니다(0=성공, 1=일반 실패, 2=인증 필요, 3=의존성 부족 등).
+
+### Key Entities
+
+* **Personal Access Token(PAT)** — 협력자별·디바이스별 인증 토큰. 발급·만료·폐기 이벤트가 있습니다.
+* **MCP 등록 항목** — AI client에 등록된 trip-planner MCP 서버 명세(명령, env, 자격). 자동 부트스트랩이 관리합니다.
+* **부트스트랩 세션** — install/update 실행 한 단위. 진단·로깅용으로 추적되며 사용자 본인이 조회 가능.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+* **SC-001**: 새 협력자가 자기 AI client에 자연어 요청 한 번으로 trip-planner MCP 동작 상태에 도달하는 데 평균 3분 이내. (브라우저 인증 1회 포함)
+* **SC-002**: 사용자가 install·update 도중 손대는 추가 단계(키 입력·파일 편집 등) 수 = 0. (브라우저 1회 클릭은 제외)
+* **SC-003**: PAT 만료 사후 장애 발생 시 협력자가 자연어 1회 요청으로 복구 가능한 비율 ≥ 95%.
+* **SC-004**: v3.0.0 release 후 1주 안에 활성 협력자 100%가 자동 업데이트로 신 버전 전환 완료.
+* **SC-005**: 부트스트랩 실패 시 사용자에게 노출되는 메시지가 "다음에 무엇을 하라"는 행동 지시를 100% 포함합니다(맥락 없는 에러 코드 0건).
+
+## Assumptions
+
+* **마일스톤 v3.0.0 묶음** — spec 029(여행 모델 + 캘린더 뷰) + spec 030(본 부트스트랩) 두 spec이 v3.0.0 MAJOR 범프에 동시 출시됩니다.
+* 지원 AI client default는 Claude Code 우선, Claude Desktop·Cursor 검증 best-effort, 일반 MCP-호환 client는 표준 등록 명령만 지원합니다. clarify 단계에서 재확인 가능.
+* trip-planner 웹 OAuth 흐름(Auth.js · Google)은 변경하지 않습니다. PAT 발급 페이지는 현행 `/settings` 흐름 재사용.
+* 협력자 환경은 macOS 우선, Linux best-effort, Windows ad-hoc(향후 별도 spec). curl·shell 한 줄 진입 가능 환경 가정.
+* install·update 명령의 배포 채널은 PyPI(`trip-planner-mcp`) + GitHub Releases(install.sh)로 정해진 현행 흐름 재사용.
+* 메모 [feedback_capsule] "비개발자 캡슐화 = 1줄 curl 설치, JSON 편집 불가" 정합.
+* 메모 [feedback_mcp_registration] "Claude Code MCP 등록은 `claude mcp add -s user`" 정합.

--- a/specs/030-mcp-auto-bootstrap/tasks.md
+++ b/specs/030-mcp-auto-bootstrap/tasks.md
@@ -1,0 +1,46 @@
+# Tasks — Spec 030 (MCP 자동 부트스트랩)
+
+Phase 2 산출. plan Coverage Targets bullet의 `[why]` 태그를 모든 태스크에 부착해 자동 검증과 연결합니다.
+
+v3.0.0 release(spec 029 contract와 동시)에 모두 implement됩니다.
+
+## install·등록·검증 흐름
+
+- [ ] T001 install.sh 1줄 진입점 — OS·의존성 진단·다운로드·OAuth listener trigger 단계 분기 [artifact: install.sh] [why: install-entry]
+- [ ] T002 trip.idean.me 정적 라우트 `/install` 서빙 — Vercel rewrite 또는 public 폴더 [artifact: vercel.json|public/install.sh] [why: install-entry]
+- [ ] T003 Node OAuth listener — localhost:0 바인딩 + 콜백 수령 + PAT 발급 API 호출 + keychain 저장 [artifact: scripts/bootstrap/oauth-listener.mjs] [why: oauth-listener]
+- [ ] T004 OAuth listener 단위 테스트 — 콜백 1회 수령·state mismatch·timeout 케이스 [artifact: scripts/bootstrap/oauth-listener.test.mjs] [why: oauth-listener]
+- [ ] T005 OAuth 콜백 API route — `/oauth/authorize` GET + `/oauth/callback` redirect 처리 [artifact: src/app/api/tokens/oauth-callback/route.ts] [why: oauth-listener]
+- [ ] T006 PAT 자동 발급 — `/api/tokens` POST 흐름 재사용 + device name 자동 설정 [artifact: src/app/api/tokens/route.ts] [why: oauth-listener]
+- [ ] T007 MCP client 등록 명령 — Claude Code(`claude mcp add -s user`) + Cursor·Desktop fallback [artifact: install.sh] [why: mcp-register]
+- [ ] T008 동작 검증 ping — `list_trips` MCP 도구 1건 호출 + 응답 검증 [artifact: scripts/bootstrap/verify-install.sh] [why: install-verify]
+
+## 자동 update 흐름
+
+- [ ] T010 MCP startup verify — PyPI JSON API 호출 + latest 비교 + stderr 안내 [artifact: mcp/trip_mcp/bootstrap.py] [why: auto-update-trigger]
+- [ ] T011 API response 헤더 추가 — `X-Trip-Planner-Min-MCP-Version` middleware [artifact: src/middleware.ts] [why: auto-update-trigger]
+- [ ] T012 MCP client 응답 헤더 감지 + `_meta.upgrade_required` 첨부 [artifact: mcp/trip_mcp/client.py] [why: auto-update-trigger]
+- [ ] T013 MAJOR breaking 응답 안내 — 4xx + 사용자 안내 메시지 [artifact: src/app/api/v2/trips/route.ts] [why: breaking-notice]
+- [ ] T014 자연어 update 진입점 — install.sh 재실행과 같은 흐름 진입 [artifact: install.sh] [why: auto-update-trigger]
+
+## 진단·복구
+
+- [ ] T020 PAT 만료 감지 + 자동 재발급 진입점 — 401 응답 시 OAuth listener 재실행 [artifact: scripts/bootstrap/reauth.sh] [why: pat-recovery]
+- [ ] T021 재인증 흐름 단위 테스트 — 401 mock + OAuth listener re-trigger [artifact: tests/integration/reauth.test.ts] [why: pat-recovery]
+
+## 폴백·진단
+
+- [ ] T030 1회 자동 재시도 + 진단 메시지 생성 [artifact: install.sh] [why: bootstrap-fallback]
+- [ ] T031 진단 메시지 형식 — "어디서 막혔는지·다음 행동" 한국어 [artifact: install.sh] [why: bootstrap-fallback]
+- [ ] T032 사용자 동의 시 GitHub 이슈 자동 등록 — gh CLI + 개인정보 마스킹 [artifact: scripts/bootstrap/report-issue.sh] [why: bootstrap-fallback]
+
+## 안전·관측
+
+- [ ] T040 표준 종료 코드 정의 — 0=성공/1=일반/2=인증/3=의존성/4=OS/5=권한 [artifact: install.sh|mcp/trip_mcp/exit_codes.py] [why: standard-exit-codes]
+- [ ] T041 PAT 평문 비노출 검증 — stdout·stderr·로그에 평문 출력 없음 [artifact: install.sh|scripts/bootstrap/*] [why: secret-redaction]
+- [ ] T042 keychain·파일 저장 wrapper — macOS Keychain 우선, Linux secret-tool fallback, file 0600 [artifact: scripts/bootstrap/credentials.sh] [why: secret-redaction]
+
+## 문서·릴리즈
+
+- [ ] T050 docs/mcp-bootstrap.md — 협력자 사용자 가이드 [artifact: docs/mcp-bootstrap.md] [why: install-entry]
+- [ ] T051 quickstart Evidence 명령 실행 [artifact: specs/030-mcp-auto-bootstrap/quickstart.md] [why: install-entry]


### PR DESCRIPTION
## 작업 내용

spec 030(MCP 자동 부트스트랩 — 협력자가 AI client에 자연어 요청만으로 사용자 노터치 install/update)의 spec/plan/research/data-model/contracts/quickstart/tasks/checklists 일괄 추가.

## 핵심 결정 (clarify session 2026-05-28)

- 인증: 브라우저 OAuth 1회 (gh CLI 패턴, 로컬 listener)
- update 트리거: startup verify + 호출 실패 감지 + 명시 요청 (혼합)
- 실패 폴백: 1회 자동 재시도 + 진단 메시지 + 동의 시 GitHub 이슈 등록
- 지원 client: Claude Code 우선, Cursor/Desktop best-effort

## 마일스톤 v3.0.0 묶음

spec 029(여행 모델 + 캘린더 뷰)와 동시 출시. spec 029의 MCP breaking이 spec 030의 자동 update 흐름으로 사용자에게 안내됨.

## 자가 검증

| 항목 | 결과 | 비고 |
|------|------|------|
| 빌드 | ⬜ 해당없음 | spec 산출물만, 코드 변경 없음 |
| 테스트 | ⬜ 해당없음 | 동일 |
| 문서 동기화 | ✅ 완료 | specs/030-mcp-auto-bootstrap/ |

## 라벨

- `chore-no-news`: spec 산출물 자체는 user-facing 변경 없음 — release 노트 단편 면제