### PR TITLE
fix(test): spec 031 grid 변경 회귀 테스트 정합 (#608)

### DIFF
--- a/tests/app/trips-id/layout-classes.test.ts
+++ b/tests/app/trips-id/layout-classes.test.ts
@@ -1,9 +1,15 @@
 /**
- * spec 026 묶음 B — trip 상세 페이지의 데스크탑 다단 분기 클래스 정적 검증.
+ * spec 026 묶음 B + spec 031 — trip 상세 페이지의 데스크탑 다단 분기 클래스
+ * 정적 검증.
  *
  * 컴포넌트는 server async + Prisma 의존이라 mount 테스트 비용이 크다.
  * 대신 소스 파일을 직접 읽어 분기 클래스가 살아있는지 정적으로 보장.
  * 이 테스트가 깨지면 누군가 데스크탑 분기를 회귀시킨 것.
+ *
+ * spec 031 변경: 본문 grid 가 `minmax(0,2fr)_minmax(280px,1fr)` 비대칭에서
+ * 좌·우 50:50 `lg:grid-cols-2` 로 단순화됨 (이슈 #608). 모바일은 본문 안
+ * SidePanel 위치(lg:hidden) 유지, 데스크탑 SidePanel 은 우측 셀에서
+ * (hidden lg:block) 노출. 두 위치 패턴은 spec 026 묶음 B 그대로 승계.
  */
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
@@ -18,9 +24,12 @@ const pageSrc = readFileSync(PAGE_PATH, "utf8");
 const sidePanelSrc = readFileSync(SIDE_PANEL_PATH, "utf8");
 const layoutSrc = readFileSync(LAYOUT_PATH, "utf8");
 
-describe("trip 상세 데스크탑 다단 분기 (spec 026/B)", () => {
-  it("페이지 wrapper에 lg: 그리드 분기 클래스가 존재한다", () => {
-    expect(pageSrc).toMatch(/lg:grid-cols-\[minmax\(0,2fr\)_minmax\(280px,1fr\)\]/);
+describe("trip 상세 데스크탑 다단 분기 (spec 026/B + spec 031)", () => {
+  it("페이지 wrapper에 lg: 그리드 분기 클래스가 존재한다 — spec 031 좌·우 50:50", () => {
+    // spec 031 (#608) — `minmax(0,2fr)_minmax(280px,1fr)` 비대칭 → 좌·우 균등
+    // `lg:grid-cols-2` 로 단순화. 회귀 방지: 두 컬럼 분기 자체가 사라지면
+    // fail. 정확한 분기 토큰은 plan 단계에서 결정되므로 둘 중 하나라도 일치.
+    expect(pageSrc).toMatch(/lg:grid-cols-2|lg:grid-cols-\[minmax\(0,2fr\)/);
   });
 
   it("페이지가 SidePanel 컴포넌트를 사용한다", () => {

--- a/tests/app/trips/list-grid.test.ts
+++ b/tests/app/trips/list-grid.test.ts
@@ -1,5 +1,9 @@
 /**
- * spec 026 묶음 C — /trips 목록 데스크탑 카드 그리드 분기 정적 검증.
+ * spec 026 묶음 C + spec 031 — /trips 목록 데스크탑 그리드 분기 정적 검증.
+ *
+ * spec 031 변경 (#608): 카드 목록 단독 1/2/3 컬럼 분기에서 좌·우 2 컬럼
+ * (좌측 통합 캘린더 + 우측 카드 목록) 으로 단순화. 우측 카드 목록은 단일
+ * 컬럼으로 세로 나열. xl:grid-cols-3 분기는 제거됨.
  */
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
@@ -8,10 +12,9 @@ import { resolve } from "node:path";
 const REPO_ROOT = resolve(__dirname, "../../..");
 const PAGE = readFileSync(resolve(REPO_ROOT, "src/app/trips/page.tsx"), "utf8");
 
-describe("trip 목록 데스크탑 카드 그리드 (spec 026/C)", () => {
-  it("그리드 wrapper에 lg:grid-cols-2 와 xl:grid-cols-3 분기가 존재한다", () => {
+describe("trip 목록 데스크탑 그리드 (spec 026/C + spec 031)", () => {
+  it("본문 wrapper에 lg:grid-cols-2 분기가 존재한다 — spec 031 좌(캘린더)/우(목록) 2분할", () => {
     expect(PAGE).toContain("lg:grid-cols-2");
-    expect(PAGE).toContain("xl:grid-cols-3");
   });
 
   it("모바일(<lg) 분기는 단일 컬럼 — sm/md prefix로 grid-cols 지정 없음", () => {
@@ -20,5 +23,9 @@ describe("trip 목록 데스크탑 카드 그리드 (spec 026/C)", () => {
 
   it("gap에 spacing 토큰을 사용한다 (gap-grid-tight·gap-grid-comfy)", () => {
     expect(PAGE).toMatch(/gap-grid-(tight|comfy)/);
+  });
+
+  it("좌측 통합 캘린더 컴포넌트가 마운트된다 — spec 031 #608", () => {
+    expect(PAGE).toContain("TripsCalendar");
   });
 });


### PR DESCRIPTION
## Summary

PR #609 (spec 031) 의 grid 클래스 변경이 spec 026 회귀 테스트 두 개의 기존 expectation 과 충돌해 develop push CI 에서 실패. 사양 변경에 맞춰 회귀 테스트 expectation 을 업데이트합니다.

## 변경

* `tests/app/trips-id/layout-classes.test.ts` — `lg:grid-cols-2` 또는 기존 `minmax(...)` 분기 중 어느 쪽이든 통과하도록 정규식 완화. 분기 자체가 사라지면 fail 유지.
* `tests/app/trips/list-grid.test.ts` — `xl:grid-cols-3` 매칭 제거 (spec 031 좌·우 50:50 단순화 의도 반영). 좌측 `TripsCalendar` 마운트 검증 추가.

## 원인

spec 031 자가 검증에서 `npx tsc --noEmit` + 변경 파일 ESLint 만 돌리고 `npm test` 전체를 누락. PR-level CI `test` job 이 IN_PROGRESS 상태로 auto-merge 진행 → 회귀가 develop 유입.

## 후속 작업 (별도)

1. CLAUDE.md 자가 검증 절차에 `npm test` 의무화.
2. branch protection 의 required check 에 `test` job 승격 (현재 informational).

## 자가 검증

| 항목 | 결과 |
|------|------|
| `npx vitest run tests/app/trips-id/layout-classes.test.ts tests/app/trips/list-grid.test.ts` | ✅ 10/10 |
| `npx vitest run` (전체) | ✅ 46 파일 / 366 테스트 |
| 코드 / API / DB 변경 | ⬜ 없음 (테스트 expectation 만) |