### PR TITLE
chore: .gitignore 에 .devex/ + .claude/worktrees/ 패턴 추가 (#617)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,12 @@ test-results/
 
 # OMC state
 .omc/
+
+# devex 사용량/플로우 추적 상태 (로컬)
+.devex/
+
+# Claude worktrees (linked worktree, 로컬 전용)
+.claude/worktrees/
 node_modules/
 .next/
 next-env.d.ts


### PR DESCRIPTION
## Summary

로컬 정리 흔적이 `git status` 에 항상 untracked 로 노출되어 다른 변경의 가독성을 떨어뜨려, 로컬 전용 두 디렉토리를 `.gitignore` 에 추가.

- `.devex/` — devex 사용량/플로우 추적 상태
- `.claude/worktrees/` — Claude Code linked worktree

## 변경

* `.gitignore` 두 줄 추가.
* 코드/DB/문서 변경 없음.

## 자가 검증

| 항목 | 결과 |
|------|------|
| 영향 범위 | repo 추적에서 두 로컬 디렉토리 제외만 |
| 회귀 가능성 | 0 (Build/test/lint 무관) |
| 단편 | 면제 — `chore-no-news` (사용자 가시 영향 0) |

Closes #617.