### PR TITLE
chore(ci): Towncrier 게이트 release/*·dependabot fragment 면제

### DIFF
--- a/.github/workflows/towncrier-fragment-check.yml
+++ b/.github/workflows/towncrier-fragment-check.yml
@@ -15,10 +15,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: chore-no-news 라벨 확인
+      - name: 면제 확인 (chore-no-news 라벨 / release 브랜치 / dependabot)
         id: label
+        env:
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          if echo '${{ toJSON(github.event.pull_request.labels.*.name) }}' | grep -q '"chore-no-news"'; then
+          # release/* 브랜치 PR, dependabot/* PR 은 fragment 면제 (towncrier build 소비 / 봇 자동 PR)
+          if echo "$LABELS" | grep -q '"chore-no-news"' \
+             || [[ "$HEAD_REF" == release/* ]] \
+             || [[ "$HEAD_REF" == dependabot/* ]]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## 배경

`Towncrier Fragment Check` 가 `release/*` 브랜치 PR 과 `dependabot/*` PR 에서 news fragment 부재로 `exit 1` → GitHub Actions 실패 알림 노이즈가 반복 발생했다.

- `release/*` PR: 누적 fragment 를 towncrier build 로 소비하는 단계라 새 fragment 를 추가하지 않는다.
- `dependabot/*` PR: 봇이 fragment 를 만들지 않는다.

## 변경

면제 판정 스텝(`id: label`)에 `head_ref` 패턴 조건을 추가한다.

- `head_ref == release/*`
- `head_ref == dependabot/*`

dependabot 은 `actor` 대신 `head_ref` 로 판정 — `synchronize` 이벤트에서 actor 가 달라져도 놓치지 않는다. 사용자 제어 값(`head_ref`)은 스크립트 인젝션 방지를 위해 `env` 로 전달한다.

해당 시 `skip=true` 로 후속 검증을 건너뛰고 job 은 성공 종료한다. job 자체를 skip 하지 않으므로 required check 는 유지되고, 일반 feature PR 의 fragment 강제도 그대로다.

## 영향

- `release/*` · `dependabot/*` PR: Towncrier 게이트 통과(성공) → 실패 알림 사라짐
- 그 외 PR: 동작 변화 없음

## 검증

- `python3 -c "import yaml; yaml.safe_load(...)"` 통과
- 이 PR 은 `.github/workflows/` 만 변경 → towncrier 면제 경로 + `chore-no-news` 라벨로 자기 자신 게이트도 통과, `speckit-gate` 는 `specs/**` 미변경이라 트리거 안 됨

Closes #781

🤖 Generated with [Claude Code](https://claude.com/claude-code)